### PR TITLE
Fix rare issue where the RFID tag is read before queues are initialized

### DIFF
--- a/src/LogMessages_DE.cpp
+++ b/src/LogMessages_DE.cpp
@@ -51,6 +51,7 @@
     const char trackChangeWebstream[] PROGMEM = "Im Webradio-Modus kann nicht an den Anfang gesprungen werden.";
     const char endOfPlaylistReached[] PROGMEM = "Ende der Playlist erreicht.";
     const char trackStartatPos[] PROGMEM = "Titel wird abgespielt ab Position";
+    const char waitingForTaskQueues[] PROGMEM = "Task Queue für RFID existiert noch nicht, warte...";
     const char rfidScannerReady[] PROGMEM = "RFID-Tags koennen jetzt gescannt werden...";
     const char rfidTagDetected[] PROGMEM = "RFID-Karte erkannt: ";
     const char rfid15693TagDetected[] PROGMEM = "RFID-Karte (ISO-15693) erkannt: ";

--- a/src/LogMessages_EN.cpp
+++ b/src/LogMessages_EN.cpp
@@ -51,6 +51,7 @@
     const char trackChangeWebstream[] PROGMEM = "Playing from the very beginning is not possible while webradio-mode is active.";
     const char endOfPlaylistReached[] PROGMEM = "Reached end of playlist.";
     const char trackStartatPos[] PROGMEM = "Starting track at position";
+    const char waitingForTaskQueues[] PROGMEM = "Task Queue for RFID does not exist yet, waiting...";
     const char rfidScannerReady[] PROGMEM = "RFID-tags can now be applied...";
     const char rfidTagDetected[] PROGMEM = "RFID-tag detected: ";
     const char rfid15693TagDetected[] PROGMEM = "RFID-ta (ISO-15693) detected: ";

--- a/src/RfidPn5180.cpp
+++ b/src/RfidPn5180.cpp
@@ -95,6 +95,12 @@ extern unsigned long Rfid_LastRfidCheckTimestamp;
         static byte cardId[cardIdSize], lastCardId[cardIdSize];
         uint8_t uid[10];
 
+        // wait until queues are created
+        while(gRfidCardQueue == NULL){
+            Log_Println((char *) FPSTR(waitingForTaskQueues), LOGLEVEL_DEBUG);
+            vTaskDelay(50);
+        }
+
         for (;;) {
             vTaskDelay(portTICK_RATE_MS * 10u);
             #ifdef PN5180_ENABLE_LPCD

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,7 @@ void printWakeUpReason() {
 
 void setup() {
     Log_Init();
+    Queues_Init();
     #ifdef RFID_READER_TYPE_PN5180
         Rfid_Init();
     #endif
@@ -206,7 +207,6 @@ void setup() {
         Serial.println(F("UNKNOWN"));
     }
 
-    Queues_Init();
     #ifdef PORT_EXPANDER_ENABLE
         Port_Init();
     #endif


### PR DESCRIPTION
Calling Queues_Init() earlier already fixes the problem for me, but I also added a simple block that waits until the rfid queue is initialized.