### PR TITLE
bugfixes/better handling of coverimage

### DIFF
--- a/html/management_DE.html
+++ b/html/management_DE.html
@@ -824,7 +824,7 @@
 
 		if(data.dir) {
 			type = "folder";
-		} else if ((/\.(mp3|MP3|ogg|wav|WAV|OGG|wma|WMA|acc|ACC|flac|FLAC)$/i).test(data.name)) {
+		} else if ((/\.(mp3|MP3|ogg|wav|WAV|OGG|wma|WMA|acc|ACC|m4a|M4A|flac|FLAC)$/i).test(data.name)) {
 			type = "audio";
 		} else {
 			type = "file";
@@ -904,7 +904,14 @@
 						items.play = {
 							label: "Abspielen",
 							action: function(x) {
-								var playMode = node.data.directory?"5":"1";
+								var playMode = 1;
+                                if (node.data.directory) {
+                                    playMode = 5; 
+                                } else {
+                                    if ((/\.(m3u|M3U)$/i).test(node.data.path)) {
+                                        playMode = 11;
+                                    }
+                                }                                
 								postData("/exploreraudio?path=" + node.data.path + "&playmode=" + playMode);
 							}
 						};

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -25,6 +25,9 @@ typedef struct { // Bit field
     bool tellIpAddress:                 1;      // If true current IP-address is spoken
     bool currentSpeechActive:           1;      // If speech-play is active
     bool lastSpeechActive:              1;      // If speech-play was active
+    char *coverFileName;                        // current coverfile
+    size_t coverFilePos;                        // current cover file position
+    size_t coverFileSize;                       // current cover file size
 } playProps;
 
 extern playProps gPlayProperties;

--- a/src/HTMLmanagement_DE.h
+++ b/src/HTMLmanagement_DE.h
@@ -824,7 +824,7 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html> \
 \
 		if(data.dir) {\
 			type = \"folder\";\
-		} else if ((/\\.(mp3|MP3|ogg|wav|WAV|OGG|wma|WMA|acc|ACC|flac|FLAC)$/i).test(data.name)) {\
+		} else if ((/\\.(mp3|MP3|ogg|wav|WAV|OGG|wma|WMA|acc|ACC|m4a|M4A|flac|FLAC)$/i).test(data.name)) {\
 			type = \"audio\";\
 		} else {\
 			type = \"file\";\
@@ -904,7 +904,14 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html> \
 						items.play = {\
 							label: \"Abspielen\",\
 							action: function(x) {\
-								var playMode = node.data.directory?\"5\":\"1\";\
+								var playMode = 1;\
+                                if (node.data.directory) {\
+                                    playMode = 5; \
+                                } else {\
+                                    if ((/\\.(m3u|M3U)$/i).test(node.data.path)) {\
+                                        playMode = 11;\
+                                    }\
+                                }                                \
 								postData(\"/exploreraudio?path=\" + node.data.path + \"&playmode=\" + playMode);\
 							}\
 						};\


### PR DESCRIPTION
- fix delays in start playing: do not save image /.cover on SD card, instead just remember file, position and size for later use.
- do not consume too much time in serving coverimage (audio stuttering)
- properly show icon for webstreams
- handle m4a files/webstream in webui context menu (file explorer)