### PR TITLE
Port_Init() must be called to enable amplifiers even when no port extpander is present.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,9 +214,7 @@ void setup() {
         Serial.println(F("UNKNOWN"));
     }
 
-    #ifdef PORT_EXPANDER_ENABLE
-        Port_Init();
-    #endif
+    Port_Init();
     Ftp_Init();
     AudioPlayer_Init();
     Mqtt_Init();


### PR DESCRIPTION
On my board the amplifier was never enabled because neither `PORT_EXPANDER_ENABLE` nor `HEADPHONE_ADJUST_ENABLE` was defined. 