### PR TITLE
add web GUI option to start FTP server

### DIFF
--- a/html/management_DE.html
+++ b/html/management_DE.html
@@ -382,6 +382,16 @@
                 </div>
             </form>
         </div>
+        <div class="container" id="ftpStart">
+            <legend>FTP Server starten</legend>
+            <div>
+                Aktiviert den FTP Server bis zum Neustart des Geräts. (FTP muss aktiviert sein)
+            </div>
+            <div class="text-center">
+                <button type="button" class="btn btn-primary" onclick="ftpStart()">Server starten</button>
+            </div>
+        </div>
+    </div>
     </div>
 
     <div class="tab-pane fade" id="nav-general" role="tabpanel" aria-labelledby="nav-general-tab">
@@ -1124,6 +1134,16 @@
             "ftp": {
                 ftpUser: document.getElementById('ftpUser').value,
                 ftpPwd: document.getElementById('ftpPwd').value
+            }
+        };
+        var myJSON = JSON.stringify(myObj);
+        socket.send(myJSON);
+    }
+
+    function ftpStart() {
+        var myObj = {
+            "ftpStatus": {
+                start: 1
             }
         };
         var myJSON = JSON.stringify(myObj);

--- a/html/management_DE.html
+++ b/html/management_DE.html
@@ -385,7 +385,7 @@
         <div class="container" id="ftpStart">
             <legend>FTP Server starten</legend>
             <div>
-                Aktiviert den FTP Server bis zum Neustart des Geräts. (FTP muss aktiviert sein)
+                Startet den FTP Server bis zum Neustart des Geräts. (FTP_ENABLE muss gesetzt sein)
             </div>
             <div class="text-center">
                 <button type="button" class="btn btn-primary" onclick="ftpStart()">Server starten</button>

--- a/html/management_EN.html
+++ b/html/management_EN.html
@@ -147,7 +147,6 @@
             <a class="nav-item nav-link active" id="nav-rfid-tab" data-toggle="tab" href="#nav-rfid" role="tab" aria-controls="nav-rfid" aria-selected="true"><i class="fas fa-dot-circle"></i> RFID</a>
             <a class="nav-item nav-link" id="nav-wifi-tab" data-toggle="tab" href="#nav-wifi" role="tab" aria-controls="nav-wifi" aria-selected="false"><i class="fas fa-wifi"></i><span class=".d-sm-none .d-md-block"> WiFi</span></a>
             %SHOW_MQTT_TAB%
-            <!-- <a class="nav-item nav-link" id="nav-ftp-tab" data-toggle="tab" href="#nav-ftp" role="tab" aria-controls="nav-ftp" aria-selected="false"><i class="fas fa-sliders-h"></i> FTP</a> -->
             %SHOW_FTP_TAB%
             <a class="nav-item nav-link" id="nav-general-tab" data-toggle="tab" href="#nav-general" role="tab" aria-controls="nav-general" aria-selected="false"><i class="fas fa-sliders-h"></i> General</a>
             <a class="nav-item nav-link" id="nav-tools-tab" data-toggle="tab" href="#nav-tools" role="tab" aria-controls="nav-tools" aria-selected="false"><i class="fas fa-wrench"></i> Tools</a>

--- a/html/management_EN.html
+++ b/html/management_EN.html
@@ -147,6 +147,7 @@
             <a class="nav-item nav-link active" id="nav-rfid-tab" data-toggle="tab" href="#nav-rfid" role="tab" aria-controls="nav-rfid" aria-selected="true"><i class="fas fa-dot-circle"></i> RFID</a>
             <a class="nav-item nav-link" id="nav-wifi-tab" data-toggle="tab" href="#nav-wifi" role="tab" aria-controls="nav-wifi" aria-selected="false"><i class="fas fa-wifi"></i><span class=".d-sm-none .d-md-block"> WiFi</span></a>
             %SHOW_MQTT_TAB%
+            <!-- <a class="nav-item nav-link" id="nav-ftp-tab" data-toggle="tab" href="#nav-ftp" role="tab" aria-controls="nav-ftp" aria-selected="false"><i class="fas fa-sliders-h"></i> FTP</a> -->
             %SHOW_FTP_TAB%
             <a class="nav-item nav-link" id="nav-general-tab" data-toggle="tab" href="#nav-general" role="tab" aria-controls="nav-general" aria-selected="false"><i class="fas fa-sliders-h"></i> General</a>
             <a class="nav-item nav-link" id="nav-tools-tab" data-toggle="tab" href="#nav-tools" role="tab" aria-controls="nav-tools" aria-selected="false"><i class="fas fa-wrench"></i> Tools</a>
@@ -365,6 +366,15 @@
                 <button type="submit" class="btn btn-primary">Submit</button>
                 </div>
             </form>
+        </div>
+        <div class="container" id="ftpStart">
+            <legend>Start FTP Server</legend>
+            <div>
+                Starts the FTP Server (if enabled) until device is restarted.
+            </div>
+            <div class="text-center">
+                <button type="button" class="btn btn-primary" onclick="ftpStart()">Start FTP Server</button>
+            </div>
         </div>
     </div>
 
@@ -1056,6 +1066,16 @@
             "ftp": {
                 ftpUser: document.getElementById('ftpUser').value,
                 ftpPwd: document.getElementById('ftpPwd').value
+            }
+        };
+        var myJSON = JSON.stringify(myObj);
+        socket.send(myJSON);
+    }
+
+    function ftpStart() {
+        var myObj = {
+            "ftpStatus": {
+                start: 1
             }
         };
         var myJSON = JSON.stringify(myObj);

--- a/html/management_EN.html
+++ b/html/management_EN.html
@@ -370,7 +370,7 @@
         <div class="container" id="ftpStart">
             <legend>Start FTP Server</legend>
             <div>
-                Starts the FTP Server (if enabled) until device is restarted.
+                Starts the FTP Server until device is restarted. (FTP_ENABLE must be set)
             </div>
             <div class="text-center">
                 <button type="button" class="btn btn-primary" onclick="ftpStart()">Start FTP Server</button>

--- a/src/HTMLmanagement_DE.h
+++ b/src/HTMLmanagement_DE.h
@@ -385,7 +385,7 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html> \
         <div class=\"container\" id=\"ftpStart\">\
             <legend>FTP Server starten</legend>\
             <div>\
-                Aktiviert den FTP Server bis zum Neustart des Geräts. (FTP muss aktiviert sein)\
+                Startet den FTP Server bis zum Neustart des Geräts. (FTP_ENABLE muss gesetzt sein)\
             </div>\
             <div class=\"text-center\">\
                 <button type=\"button\" class=\"btn btn-primary\" onclick=\"ftpStart()\">Server starten</button>\

--- a/src/HTMLmanagement_DE.h
+++ b/src/HTMLmanagement_DE.h
@@ -382,6 +382,16 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html> \
                 </div>\
             </form>\
         </div>\
+        <div class=\"container\" id=\"ftpStart\">\
+            <legend>FTP Server starten</legend>\
+            <div>\
+                Aktiviert den FTP Server bis zum Neustart des Geräts. (FTP muss aktiviert sein)\
+            </div>\
+            <div class=\"text-center\">\
+                <button type=\"button\" class=\"btn btn-primary\" onclick=\"ftpStart()\">Server starten</button>\
+            </div>\
+        </div>\
+    </div>\
     </div>\
 \
     <div class=\"tab-pane fade\" id=\"nav-general\" role=\"tabpanel\" aria-labelledby=\"nav-general-tab\">\
@@ -1124,6 +1134,16 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html> \
             \"ftp\": {\
                 ftpUser: document.getElementById('ftpUser').value,\
                 ftpPwd: document.getElementById('ftpPwd').value\
+            }\
+        };\
+        var myJSON = JSON.stringify(myObj);\
+        socket.send(myJSON);\
+    }\
+\
+    function ftpStart() {\
+        var myObj = {\
+            \"ftpStatus\": {\
+                start: 1\
             }\
         };\
         var myJSON = JSON.stringify(myObj);\

--- a/src/HTMLmanagement_EN.h
+++ b/src/HTMLmanagement_EN.h
@@ -147,6 +147,7 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html>\
             <a class=\"nav-item nav-link active\" id=\"nav-rfid-tab\" data-toggle=\"tab\" href=\"#nav-rfid\" role=\"tab\" aria-controls=\"nav-rfid\" aria-selected=\"true\"><i class=\"fas fa-dot-circle\"></i> RFID</a>\
             <a class=\"nav-item nav-link\" id=\"nav-wifi-tab\" data-toggle=\"tab\" href=\"#nav-wifi\" role=\"tab\" aria-controls=\"nav-wifi\" aria-selected=\"false\"><i class=\"fas fa-wifi\"></i><span class=\".d-sm-none .d-md-block\"> WiFi</span></a>\
             %SHOW_MQTT_TAB%\
+            <!-- <a class=\"nav-item nav-link\" id=\"nav-ftp-tab\" data-toggle=\"tab\" href=\"#nav-ftp\" role=\"tab\" aria-controls=\"nav-ftp\" aria-selected=\"false\"><i class=\"fas fa-sliders-h\"></i> FTP</a> -->\
             %SHOW_FTP_TAB%\
             <a class=\"nav-item nav-link\" id=\"nav-general-tab\" data-toggle=\"tab\" href=\"#nav-general\" role=\"tab\" aria-controls=\"nav-general\" aria-selected=\"false\"><i class=\"fas fa-sliders-h\"></i> General</a>\
             <a class=\"nav-item nav-link\" id=\"nav-tools-tab\" data-toggle=\"tab\" href=\"#nav-tools\" role=\"tab\" aria-controls=\"nav-tools\" aria-selected=\"false\"><i class=\"fas fa-wrench\"></i> Tools</a>\
@@ -365,6 +366,15 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html>\
                 <button type=\"submit\" class=\"btn btn-primary\">Submit</button>\
                 </div>\
             </form>\
+        </div>\
+        <div class=\"container\" id=\"ftpStart\">\
+            <legend>Start FTP Server</legend>\
+            <div>\
+                Starts the FTP Server (if enabled) until device is restarted.\
+            </div>\
+            <div class=\"text-center\">\
+                <button type=\"button\" class=\"btn btn-primary\" onclick=\"ftpStart()\">Start FTP Server</button>\
+            </div>\
         </div>\
     </div>\
 \
@@ -1056,6 +1066,16 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html>\
             \"ftp\": {\
                 ftpUser: document.getElementById('ftpUser').value,\
                 ftpPwd: document.getElementById('ftpPwd').value\
+            }\
+        };\
+        var myJSON = JSON.stringify(myObj);\
+        socket.send(myJSON);\
+    }\
+\
+    function ftpStart() {\
+        var myObj = {\
+            \"ftpStatus\": {\
+                start: 1\
             }\
         };\
         var myJSON = JSON.stringify(myObj);\

--- a/src/HTMLmanagement_EN.h
+++ b/src/HTMLmanagement_EN.h
@@ -370,7 +370,7 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html>\
         <div class=\"container\" id=\"ftpStart\">\
             <legend>Start FTP Server</legend>\
             <div>\
-                Starts the FTP Server (if enabled) until device is restarted.\
+                Starts the FTP Server until device is restarted. (FTP_ENABLE must be set)\
             </div>\
             <div class=\"text-center\">\
                 <button type=\"button\" class=\"btn btn-primary\" onclick=\"ftpStart()\">Start FTP Server</button>\

--- a/src/HTMLmanagement_EN.h
+++ b/src/HTMLmanagement_EN.h
@@ -147,7 +147,6 @@ static const char management_HTML[] PROGMEM = "<!DOCTYPE html>\
             <a class=\"nav-item nav-link active\" id=\"nav-rfid-tab\" data-toggle=\"tab\" href=\"#nav-rfid\" role=\"tab\" aria-controls=\"nav-rfid\" aria-selected=\"true\"><i class=\"fas fa-dot-circle\"></i> RFID</a>\
             <a class=\"nav-item nav-link\" id=\"nav-wifi-tab\" data-toggle=\"tab\" href=\"#nav-wifi\" role=\"tab\" aria-controls=\"nav-wifi\" aria-selected=\"false\"><i class=\"fas fa-wifi\"></i><span class=\".d-sm-none .d-md-block\"> WiFi</span></a>\
             %SHOW_MQTT_TAB%\
-            <!-- <a class=\"nav-item nav-link\" id=\"nav-ftp-tab\" data-toggle=\"tab\" href=\"#nav-ftp\" role=\"tab\" aria-controls=\"nav-ftp\" aria-selected=\"false\"><i class=\"fas fa-sliders-h\"></i> FTP</a> -->\
             %SHOW_FTP_TAB%\
             <a class=\"nav-item nav-link\" id=\"nav-general-tab\" data-toggle=\"tab\" href=\"#nav-general\" role=\"tab\" aria-controls=\"nav-general\" aria-selected=\"false\"><i class=\"fas fa-sliders-h\"></i> General</a>\
             <a class=\"nav-item nav-link\" id=\"nav-tools-tab\" data-toggle=\"tab\" href=\"#nav-tools\" role=\"tab\" aria-controls=\"nav-tools\" aria-selected=\"false\"><i class=\"fas fa-wrench\"></i> Tools</a>\

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -462,6 +462,11 @@ bool processJsonRequest(char *_serialJson) {
               String(_ftpPwd).equals(gPrefsSettings.getString("ftppassword", "-1")))) {
             return false;
         }
+    } else if (doc.containsKey("ftpStatus")) {
+        uint8_t _ftpStart = doc["ftpStatus"]["start"].as<uint8_t>();
+        if (_ftpStart == 1) { // ifdef FTP_ENABLE is checked in Ftp_EnableServer()
+            Ftp_EnableServer();
+        }
     } else if (doc.containsKey("mqtt")) {
         uint8_t _mqttEnable = doc["mqtt"]["mqttEnable"].as<uint8_t>();
         const char *_mqttServer = object["mqtt"]["mqttServer"];


### PR DESCRIPTION
fixes #134
<img width="1194" alt="image" src="https://user-images.githubusercontent.com/7142618/148223588-5f870fba-7492-4aa7-9d8c-71800f916b14.png">

verified locally by clicking the button, checking the logs and opening FTP session :)

Only output in logs seems to be the heap report

```text
Aktuelle Batteriespannung: 3.90 V
no cover image for SD-card audio
Freier Heap-Speicher vor FTP-Instanzierung: 142884
Freier Heap-Speicher nach FTP-Instanzierung: 125508
RSSI: -68 dBm
```

Could not verify on LANGUAGE=EN because build fails (even without these changes)

```text
src/LogMessages_EN.cpp:189:40: error: expected initializer before 'PROGMEN'
     const char unableToTellIpAddress[] PROGMEN = "IP-address can't be announced as there's no WiFi-connection available.";
```