### PR TITLE
PN5180: better card recognition for ISO-14443 cards

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,7 @@ lib_deps =
 	https://github.com/kkloesener/MFRC522_I2C.git#121a27e
 	https://github.com/miguelbalboa/rfid.git#ba72b92
 	https://github.com/tuniii/LogRingBuffer.git#89d7d3e
-	https://github.com/tueddy/PN5180-Library.git#2d9ae3d
+	https://github.com/tueddy/PN5180-Library.git#f99e615
 platform_packages =
 
 	platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#1.0.6

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -59,6 +59,8 @@ static void Button_DoButtonActions(void);
 void Button_Init() {
     #if (WAKEUP_BUTTON <= 39)
         esp_sleep_enable_ext0_wakeup((gpio_num_t)WAKEUP_BUTTON, 0);
+        esp_sleep_enable_ext0_wakeup((gpio_num_t)ROTARYENCODER_CLK, 0);
+        esp_sleep_enable_ext0_wakeup((gpio_num_t)ROTARYENCODER_DT, 0);
     #endif
 
     #ifdef NEOPIXEL_ENABLE // Try to find button that is used for shutdown via longpress-action (only necessary for Neopixel)

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -59,8 +59,6 @@ static void Button_DoButtonActions(void);
 void Button_Init() {
     #if (WAKEUP_BUTTON <= 39)
         esp_sleep_enable_ext0_wakeup((gpio_num_t)WAKEUP_BUTTON, 0);
-        esp_sleep_enable_ext0_wakeup((gpio_num_t)ROTARYENCODER_CLK, 0);
-        esp_sleep_enable_ext0_wakeup((gpio_num_t)ROTARYENCODER_DT, 0);
     #endif
 
     #ifdef NEOPIXEL_ENABLE // Try to find button that is used for shutdown via longpress-action (only necessary for Neopixel)

--- a/src/RfidPn5180.cpp
+++ b/src/RfidPn5180.cpp
@@ -20,14 +20,13 @@
 #define RFID_PN5180_STATE_INIT 0u
 
 #define RFID_PN5180_NFC14443_STATE_RESET 1u
-#define RFID_PN5180_NFC14443_STATE_SETUPRF 2u
-#define RFID_PN5180_NFC14443_STATE_READCARD 3u
+#define RFID_PN5180_NFC14443_STATE_READCARD 2u
 #define RFID_PN5180_NFC14443_STATE_ACTIVE 99u
 
-#define RFID_PN5180_NFC15693_STATE_RESET 4u
-#define RFID_PN5180_NFC15693_STATE_SETUPRF 5u
-#define RFID_PN5180_NFC15693_STATE_DISABLEPRIVACYMODE 6u
-#define RFID_PN5180_NFC15693_STATE_GETINVENTORY 7u
+#define RFID_PN5180_NFC15693_STATE_RESET 3u
+#define RFID_PN5180_NFC15693_STATE_SETUPRF 4u
+#define RFID_PN5180_NFC15693_STATE_DISABLEPRIVACYMODE 5u
+#define RFID_PN5180_NFC15693_STATE_GETINVENTORY 6u
 #define RFID_PN5180_NFC15693_STATE_ACTIVE 100u
 
 extern unsigned long Rfid_LastRfidCheckTimestamp;
@@ -138,10 +137,9 @@ extern unsigned long Rfid_LastRfidCheckTimestamp;
                 nfc14443.reset();
                 //snprintf(Log_Buffer, Log_BufferLength, "%u", uxTaskGetStackHighWaterMark(NULL));
                 //Log_Println(Log_Buffer, LOGLEVEL_DEBUG);
-            } else if (RFID_PN5180_NFC14443_STATE_SETUPRF == stateMachine) {
-                nfc14443.setupRF();
             } else if (RFID_PN5180_NFC14443_STATE_READCARD == stateMachine) {
-                if (nfc14443.readCardSerial(uid) >= 4u) {
+             
+                if (nfc14443.readCardSerial(uid) >= 4) {
                     cardReceived = true;
                     stateMachine = RFID_PN5180_NFC14443_STATE_ACTIVE;
                     lastTimeDetected14443 = millis();
@@ -152,7 +150,7 @@ extern unsigned long Rfid_LastRfidCheckTimestamp;
                     // Reset to dummy-value if no card is there
                     // Necessary to differentiate between "card is still applied" and "card is re-applied again after removal"
                     // lastTimeDetected14443 is used to prevent "new card detection with old card" with single events where no card was detected
-                    if (!lastTimeDetected14443 || (millis() - lastTimeDetected14443 >= 400)) {
+                    if (!lastTimeDetected14443 || (millis() - lastTimeDetected14443 >= 800)) {
                         lastTimeDetected14443 = 0;
                         #ifdef PAUSE_WHEN_RFID_REMOVED
                             cardAppliedCurrentRun = false;

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1178,8 +1178,8 @@ static void handleCoverImageRequest(AsyncWebServerRequest *request) {
             break;  
     }
 
-    int imageSize = gPlayProperties.coverFileSize - coverFile.position();
-
+    int imageSize = gPlayProperties.coverFileSize;
+	
     AsyncWebServerResponse *response = request->beginResponse(
         mimeType,
         imageSize,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,10 +193,7 @@ void setup() {
     Serial.println(F(" |_____| |____/  |_|      \\__,_| |_| |_| |_|  \\___/ "));
     Serial.print(F(" Rfid-controlled musicplayer\n\n"));
     Serial.printf("%s\n\n", softwareRevision);
-    Serial.print(F("ESP-IDF-version (major): "));
-    Serial.println(ESP_IDF_VERSION_MAJOR);
-    Serial.print(F("ESP-IDF-version (minor): "));
-    Serial.println(ESP_IDF_VERSION_MINOR);
+    Serial.println("ESP-IDF version: " + String(esp_get_idf_version()));
 
     // print wake-up reason
     printWakeUpReason();


### PR DESCRIPTION
- remove state RFID_PN5180_NFC14443_STATE_SETUPRF: This is already handled in PN5180 library
- wake-up from deep-sleep also with rotating the encoder (not only push the encoder button)
- fix a bug for serving the cover image (wrong imagesize)
- shorter show ESP-IDF version in console-log