### PR TITLE
Add power-down method in shutdown/sleep procedure

### DIFF
--- a/src/RfidMfrc522.cpp
+++ b/src/RfidMfrc522.cpp
@@ -176,6 +176,7 @@
     }
 
     void Rfid_Exit(void) {
+	     mfrc522.PCD_SoftPowerDown();
     }
 
     void Rfid_WakeupCheck(void) {


### PR DESCRIPTION
I measured around **100mA** power draw in deep-sleep with my multimeter on the current branch. 
After adding the following line in the shutdown procedure/call I just measured **30mA** in deep-sleep.

My deep-sleep power draw is still quite high, but that seems to be a standard Dev-Board-Problem.

There seems to be no problem after wake-up and reading the cards.

**My ESPuino-Setup:**
- AZ-Delivery DevBoard (powered by Vin-PIN)
- SD-MMC-Module and Interface
- MAX98357A amplifier
- MFRC522 NFC-Reader