### PR TITLE
Battery Indicator for numLedsToLight == 0

### DIFF
--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -365,6 +365,7 @@ static void Led_Task(void *parameter) {
                             FastLED.show();
                             vTaskDelay(portTICK_RATE_MS * 20);
                         }
+                        FastLED.show();
                     }
 
                     for (uint8_t i = 0; i <= 100; i++) {


### PR DESCRIPTION
Change the behaviour for nearly empty battery: instead of no change in LEDs (because FastLED.show is never called), blank once.
An alternative would be always showing at least one LED.