### PR TITLE
BUG: Volume initially not set correctly

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -298,7 +298,7 @@ void AudioPlayer_Task(void *parameter) {
 
     uint8_t settleCount = 0;
     audio->setPinout(I2S_BCLK, I2S_LRC, I2S_DOUT);
-    audio->setVolume(AudioPlayer_GetInitVolume());
+    audio->setVolume(AudioPlayer_CurrentVolume);
     audio->forceMono(gPlayProperties.currentPlayMono);
     if (gPlayProperties.currentPlayMono) {
         audio->setTone(3, 0, 0);


### PR DESCRIPTION
Volume is correctly read from NVS for initialVolume or previousVolume but was never correctly set when starting the AudioPlayer_Task. This fixes it.

Tested with and without USE_LAST_VOLUME_AFTER_REBOOT defined