### PR TITLE
Adding charset="utf-8" in HTMLaccesspoint

### DIFF
--- a/src/HTMLaccesspoint_DE.h
+++ b/src/HTMLaccesspoint_DE.h
@@ -2,6 +2,7 @@ static const char accesspoint_HTML[] PROGMEM = "<!DOCTYPE html>\
 <html>\
     <head>\
         <title>WLAN-Einrichtung</title>\
+        <meta charset=\"utf-8\">\
         <style>\
             input {\
                 width: 90%%;\

--- a/src/HTMLaccesspoint_EN.h
+++ b/src/HTMLaccesspoint_EN.h
@@ -2,6 +2,7 @@ static const char accesspoint_HTML[] PROGMEM = "<!DOCTYPE html>\
 <html>\
     <head>\
         <title>WiFi-configuration</title>\
+        <meta charset=\"utf-8\">\
         <style>\
             input {\
                 width: 90%%;\


### PR DESCRIPTION
After having trouble loggin in to my WLAN I noticed that SSIDs with german umlauts are not transmitted correctly when entered during configuration. After a little research I've tried to add <meta charset=\"utf-8\"> to both HTMLaccesspoint templates (DE,EN) analog to the other HTML-files. This led to correct transmission of umlauts and several other special characters at least from Safari on MacOS and iOS.