### PR TITLE
revision: Add Git revision to logs

### DIFF
--- a/gitVersion.py
+++ b/gitVersion.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+
+"""PlatformIO script to generate a gitversion.h file and adds its path to
+   CPPPATH.
+
+Note: The PlatformIO documentation suggests to simply add the Git version as
+dynamic build flag (=define). This however leads to constant rebuilds of the
+complete project.
+"""
+
+import subprocess
+from pathlib import Path
+
+Import("env")  # pylint: disable=undefined-variable
+
+
+OUTPUT_PATH = (
+    Path(env.subst("$BUILD_DIR")) / "generated" / "gitrevision.h"
+)  # pylint: disable=undefined-variable
+
+TEMPLATE = """
+#ifndef __GIT_REVISION_H__
+    #define __GIT_REVISION_H__
+    constexpr const char gitRevision[] PROGMEM = "Git-revision: {git_revision}";
+#endif
+"""
+
+
+def git_revision():
+    """Returns Git revision or unknown."""
+    try:
+        return subprocess.check_output(
+            ["git", "describe", "--always", "--dirty"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
+
+
+def generate():
+    """Generates header file."""
+    OUTPUT_PATH.parent.mkdir(exist_ok=True, parents=True)
+    with OUTPUT_PATH.open("w") as output_file:
+        output_file.write(
+            TEMPLATE.format(git_revision=git_revision())
+        )
+
+
+generate()
+env.Append(CPPPATH=OUTPUT_PATH.parent)  # pylint: disable=undefined-variable

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,9 @@ platform = espressif32@<=3.5.0
 ;platform = https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream
 framework = arduino
 monitor_speed = 115200
-extra_scripts = pre:processHtml.py
+extra_scripts =
+    pre:gitVersion.py
+    pre:processHtml.py
 lib_deps =
 	https://github.com/schreibfaul1/ESP32-audioI2S.git
 	https://github.com/madhephaestus/ESP32Encoder.git#22992b3

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -168,6 +168,7 @@ void webserverStart(void) {
         wServer.on(
             "/info", HTTP_GET, [](AsyncWebServerRequest *request) {
                 String info = "ESPuino " + (String) softwareRevision;
+                info += "\nESPuino " + (String) gitRevision;
                 info += "\nESP-IDF version: " + String(ESP.getSdkVersion());
                 #if (LANGUAGE == DE)
                     info += "\nFreier Heap: " + String(ESP.getFreeHeap()) + " Bytes";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,7 +165,7 @@ void setup() {
     Serial.println(F(" | |___   ___) | |  __/  | |_| | | | | | | | | (_) |"));
     Serial.println(F(" |_____| |____/  |_|      \\__,_| |_| |_| |_|  \\___/ "));
     Serial.print(F(" Rfid-controlled musicplayer\n\n"));
-    Serial.printf("%s\n\n", softwareRevision);
+    Serial.printf("%s\n%s\n\n", softwareRevision, gitRevision);
     Serial.println("ESP-IDF version: " + String(ESP.getSdkVersion()));
 
     // print wake-up reason

--- a/src/revision.h
+++ b/src/revision.h
@@ -1,4 +1,5 @@
 #ifndef __REVISION_H__
     #define __REVISION_H__
+    #include "gitrevision.h"
     constexpr const char softwareRevision[] PROGMEM = "Software-revision: 20221005-1";
 #endif


### PR DESCRIPTION
This change adds a pre build script that generates a `gitrevision.h` header with the current git revision. That is then logged in the serial console and web log.

When comparing log files (for instance to hunt issues) it's useful to know exactly the git version the software has been compiled with. If local modifications have been done, '-dirty' is added to the version so that uncommitted changes can easily be identified.

I actually have / had a few problems when flashing. I couldn't get it to work over USB and also via OTA I had sometimes failures. The git revision helps to clearly see if I'm running the expected version.

We could take this one step further and move the specification of the software revision (`20221005-1`) into the `platformio.ini` and then fully generate a single `revision.h` file with with both defines.