### PR TITLE
web: Fix loading covers with UTF16 encoding

### DIFF
--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1332,14 +1332,16 @@ static void handleCoverImageRequest(AsyncWebServerRequest *request) {
     Serial.println(coverFileName);
 
     File coverFile = gFSystem.open(coverFileName, FILE_READ);
-    // seek to start position, skip 1 byte encoding
-    coverFile.seek(gPlayProperties.coverFilePos + 1);
+    // seek to start position
+    coverFile.seek(gPlayProperties.coverFilePos);
+    uint8_t encoding = coverFile.read();
     // mime-type (null terminated)
     char mimeType[255];
     for (uint8_t i = 0u; i < 255; i++) {
         mimeType[i] = coverFile.read();
-        if (uint8_t(mimeType[i]) == 0)
+        if (uint8_t(mimeType[i]) == 0) {
             break;
+        }
     }
     snprintf(Log_Buffer, Log_BufferLength, "serve cover image (%s): %s", (char *) mimeType, coverFileName);
     Log_Println(Log_Buffer, LOGLEVEL_NOTICE);
@@ -1348,8 +1350,13 @@ static void handleCoverImageRequest(AsyncWebServerRequest *request) {
     coverFile.read();
     // skip description (null terminated)
     for (uint8_t i = 0u; i < 255; i++) {
-        if (uint8_t(coverFile.read()) == 0)
+        if (uint8_t(coverFile.read()) == 0) {
             break;
+        }
+    }
+    // UTF-16 and UTF-16BE are terminated with an extra 0
+    if (encoding == 1 || encoding == 2) {
+        coverFile.read();
     }
 
     int imageSize = gPlayProperties.coverFileSize;


### PR DESCRIPTION
I noticed that only half of my cover images loaded and debugged the issue down to a problem with the ID3 text encoding for the image description. Even if the description is an empty string, if the text encoding is set to UTF16, an extra 0 has to be skipped when skipping over the image description.

Now all images load fine.

See: https://id3.org/id3v2.4.0-frames, chapter 4.14:

```
 <Header for 'Attached picture', ID: "APIC">
 Text encoding      $xx
 MIME type          <text string> $00
 Picture type       $xx
 Description        <text string according to encoding> $00 (00)
 Picture data       <binary data>
```

And: https://id3.org/id3v2.4.0-structure, chapter 4:

```
Frames that allow different types of text encoding contains a text encoding description byte. Possible encodings:

  $00   ISO-8859-1 [ISO-8859-1]. Terminated with $00.
  $01   UTF-16 [UTF-16] encoded Unicode [UNICODE] with BOM. All
        strings in the same frame SHALL have the same byteorder.
        Terminated with $00 00.
  $02   UTF-16BE [UTF-16] encoded Unicode [UNICODE] without BOM.
        Terminated with $00 00.
  $03   UTF-8 [UTF-8] encoded Unicode [UNICODE]. Terminated with $00.
```