### PR TITLE
audioplayer: Generalize handling of title

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Feel free to use your own smarthome-environments (instead of openHAB). The MQTT-
 | topicRfidState          | 12 digits       | ID of current RFID-tag (if not a modification-card)                            |
 | topicTrackState         | String          | Sends current track number, total number of tracks and full path of curren track. E.g. "(2/10) /mp3/kinderlieder/Ri ra rutsch.mp3" |
 | topicTrackControlCmnd   | 1 -> 7          | `1`=stop; `2`=unused!; `3`=play/pause; `4`=next; `5`=prev; `6`=first; `7`=last |
+| topicCoverChangedState  |                 | Indicated that the cover image has potentially changed. For performance        |
+|                         |                 | reasons the application should load the image only if it's visible to the user |
 | topicLoudnessCmnd       | 0 -> 21         | Set loudness (depends on minVolume / maxVolume)                                |
 | topicLoudnessState      | 0 -> 21         | Sends loudness (depends on minVolume / maxVolume                               |
 | topicSleepTimerCmnd     | EOP             | Power off after end to playlist                                                |

--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -104,7 +104,8 @@ void AudioPlayer_Init(void) {
     // Adjust volume depending on headphone is connected and volume-adjustment is enabled
     AudioPlayer_SetupVolumeAndAmps();
 
-    // clear cover image
+    // clear title and cover image
+    gPlayProperties.title = NULL;
     gPlayProperties.coverFilePos = 0;
 
     // Don't start audio-task in BT-speaker mode!
@@ -175,21 +176,27 @@ void AudioPlayer_SetInitVolume(uint8_t value) {
     AudioPlayer_InitVolume = value;
 }
 
-// Allocates space for title of current track only once and keeps char* in order to avoid heap-fragmentation.
-char* Audio_handleTitle(bool clearTitle) {
+void Audio_setTitle(const char *format, ...)
+{
+    // Allocates space for title of current track only once and keeps char* in order to avoid heap-fragmentation.
     static char* _title = NULL;
-    
     if (_title == NULL) {
         _title = (char *) x_malloc(sizeof(char) * 255);
-    }
-
-    if (clearTitle) {
-        if (_title != NULL) {
-            strcpy(_title, "");
-        }
+        gPlayProperties.title = _title;
     }
     
-    return _title;
+    char buf[256];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buf, sizeof(buf)/sizeof(buf[0]), format, args);
+    va_end(args);
+    convertAsciiToUtf8(buf, gPlayProperties.title);
+
+    // notify web ui and mqtt
+    Web_SendWebsocketData(0, 30);
+    #ifdef MQTT_ENABLE
+        publishMqtt((char *) FPSTR(topicTrackState), gPlayProperties.title, false);
+    #endif
 }
 
 // Set maxVolume depending on headphone-adjustment is enabled and headphone is/is not connected
@@ -397,9 +404,7 @@ void AudioPlayer_Task(void *parameter) {
                     gPlayProperties.pausePlay = true;
                     gPlayProperties.playlistFinished = true;
                     gPlayProperties.playMode = NO_PLAYLIST;
-                    // delete title
-                    Audio_handleTitle(true);
-                    Web_SendWebsocketData(0, 30);
+                    Audio_setTitle((char *)FPSTR (noPlaylist));
                     AudioPlayer_ClearCover();
                     continue;
 
@@ -496,8 +501,11 @@ void AudioPlayer_Task(void *parameter) {
                         }
                         audio->stopSong();
                         Led_Indicate(LedIndicatorType::Rewind);
-                        // delete title
-                        Audio_handleTitle(true);
+                        if (gPlayProperties.numberOfTracks > 1) {
+                            Audio_setTitle("(%u/%u): %s", gPlayProperties.currentTrackNumber+1,  gPlayProperties.numberOfTracks, *(gPlayProperties.playlist + gPlayProperties.currentTrackNumber));
+                        } else {
+                            Audio_setTitle("%s", *(gPlayProperties.playlist + gPlayProperties.currentTrackNumber));
+                        };
                         AudioPlayer_ClearCover();
                         audioReturnCode = audio->connecttoFS(gFSystem, *(gPlayProperties.playlist + gPlayProperties.currentTrackNumber));
                         // consider track as finished, when audio lib call was not successful
@@ -578,17 +586,9 @@ void AudioPlayer_Task(void *parameter) {
                         // Set back to first track
                         AudioPlayer_NvsRfidWriteWrapper(gPlayProperties.playRfidTag, *(gPlayProperties.playlist + 0), 0, gPlayProperties.playMode, 0, gPlayProperties.numberOfTracks);
                     }
-                    #ifdef MQTT_ENABLE
-                        #if (LANGUAGE == DE)
-                            publishMqtt((char *) FPSTR(topicTrackState), "<Ende>", false);
-                        #else
-                            publishMqtt((char *) FPSTR(topicTrackState), "<End>", false);
-                        #endif
-                    #endif
                     gPlayProperties.playlistFinished = true;
                     gPlayProperties.playMode = NO_PLAYLIST;
-                    Audio_handleTitle(true);
-                    Web_SendWebsocketData(0, 30);
+                    Audio_setTitle((char *)FPSTR (noPlaylist));
                     AudioPlayer_ClearCover();
                     #ifdef MQTT_ENABLE
                         publishMqtt((char *) FPSTR(topicPlaymodeState), gPlayProperties.playMode, false);
@@ -623,11 +623,9 @@ void AudioPlayer_Task(void *parameter) {
             audioReturnCode = false;
 
             if (gPlayProperties.playMode == WEBSTREAM || (gPlayProperties.playMode == LOCAL_M3U && gPlayProperties.isWebstream)) { // Webstream
-                // delete title
-                Audio_handleTitle(true);
+                Audio_setTitle("Webstream");
                 audioReturnCode = audio->connecttohost(*(gPlayProperties.playlist + gPlayProperties.currentTrackNumber));
                 gPlayProperties.playlistFinished = false;
-                Web_SendWebsocketData(0, 30);
                 // AudioPlayer_ClearCover() publishes an MQTT message. This must happen after audio->connecttohost() otherwise a broken MQTT package
                 // gets sent out and the MQTT connection is reset. This seems to be a race condition in one of the libs.
                 AudioPlayer_ClearCover();
@@ -639,8 +637,11 @@ void AudioPlayer_Task(void *parameter) {
                     gPlayProperties.trackFinished = true;
                     continue;
                 } else {
-                    // delete title
-                    Audio_handleTitle(true);
+                    if (gPlayProperties.numberOfTracks > 1) {
+                        Audio_setTitle("(%u/%u): %s", gPlayProperties.currentTrackNumber+1,  gPlayProperties.numberOfTracks, *(gPlayProperties.playlist + gPlayProperties.currentTrackNumber));
+                    } else {
+                        Audio_setTitle("%s", *(gPlayProperties.playlist + gPlayProperties.currentTrackNumber));
+                    };
                     AudioPlayer_ClearCover();
                     audioReturnCode = audio->connecttoFS(gFSystem, *(gPlayProperties.playlist + gPlayProperties.currentTrackNumber));
                     // consider track as finished, when audio lib call was not successful
@@ -1162,15 +1163,11 @@ void audio_id3data(const char *info) { //id3 metadata
     Log_Println(Log_Buffer, LOGLEVEL_INFO);
     // get title
     if (startsWith((char *)info, "Title:")) {
-        // copy title
-        if (!gPlayProperties.title) {
-            gPlayProperties.title = Audio_handleTitle(false);
-        }
-        if (gPlayProperties.title != NULL) {
-            strncpy(gPlayProperties.title, info + 6, 255);
-            // notify web ui
-            Web_SendWebsocketData(0, 30);
-        }
+        if (gPlayProperties.numberOfTracks > 1) {
+            Audio_setTitle("(%u/%u): %s", gPlayProperties.currentTrackNumber+1,  gPlayProperties.numberOfTracks, info + 6);
+        } else {
+            Audio_setTitle("%s", info + 6);
+        };
     }
 }
 
@@ -1183,35 +1180,14 @@ void audio_eof_mp3(const char *info) { //end of file
 void audio_showstation(const char *info) {
     snprintf(Log_Buffer, Log_BufferLength, "station     : %s", info);
     Log_Println(Log_Buffer, LOGLEVEL_NOTICE);
-    char buf[255];
-    snprintf(buf, sizeof(buf) / sizeof(buf[0]), "Webradio: %s", info);
-    #ifdef MQTT_ENABLE
-        publishMqtt((char *) FPSTR(topicTrackState), buf, false);
-    #endif
-    // copy title
-    if (!gPlayProperties.title) {
-        gPlayProperties.title = Audio_handleTitle(false);
-    }
-    if (gPlayProperties.title != NULL) {
-        strncpy(gPlayProperties.title, info + 6, 255);
-        // notify web ui
-        Web_SendWebsocketData(0, 30);
-    }
+    Audio_setTitle("Webradio: %s", info);
 }
 
 void audio_showstreamtitle(const char *info) {
     snprintf(Log_Buffer, Log_BufferLength, "streamtitle : %s", info);
     Log_Println(Log_Buffer, LOGLEVEL_INFO);
-    if (startsWith((char *)info, "Title:")) {
-        // copy title
-        if (!gPlayProperties.title) {
-            gPlayProperties.title = Audio_handleTitle(false);
-        }
-        if (gPlayProperties.title != NULL) {
-            strncpy(gPlayProperties.title, info + 6, 255);
-            // notify web ui
-            Web_SendWebsocketData(0, 30);
-        }
+    if (strcmp(info, "")) {
+        Audio_setTitle("%s (%s)", gPlayProperties.title, info);
     }
 }
 

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -50,4 +50,4 @@ uint8_t AudioPlayer_GetInitVolume(void);
 void AudioPlayer_SetInitVolume(uint8_t value);
 void AudioPlayer_SetupVolumeAndAmps(void);
 bool Audio_Detect_Mode_HP(bool _state);
-char* Audio_handleTitle(bool clearTitle);
+void Audio_setTitle(const char *format, ...);

--- a/src/Mqtt.cpp
+++ b/src/Mqtt.cpp
@@ -258,7 +258,7 @@ bool Mqtt_Reconnect() {
 
                 // Publish current state
                 publishMqtt((char *) FPSTR(topicState), "Online", false);
-                publishMqtt((char *) FPSTR(topicTrackState), "---", false);
+                publishMqtt((char *) FPSTR(topicTrackState), gPlayProperties.title, false);
                 publishMqtt((char *) FPSTR(topicCoverChangedState), "", false);
                 publishMqtt((char *) FPSTR(topicLoudnessState), AudioPlayer_GetCurrentVolume(), false);
                 publishMqtt((char *) FPSTR(topicSleepTimerState), System_GetSleepTimerTimeStamp(), false);

--- a/src/Mqtt.cpp
+++ b/src/Mqtt.cpp
@@ -259,6 +259,7 @@ bool Mqtt_Reconnect() {
                 // Publish current state
                 publishMqtt((char *) FPSTR(topicState), "Online", false);
                 publishMqtt((char *) FPSTR(topicTrackState), "---", false);
+                publishMqtt((char *) FPSTR(topicCoverChangedState), "", false);
                 publishMqtt((char *) FPSTR(topicLoudnessState), AudioPlayer_GetCurrentVolume(), false);
                 publishMqtt((char *) FPSTR(topicSleepTimerState), System_GetSleepTimerTimeStamp(), false);
                 publishMqtt((char *) FPSTR(topicLockControlsState), System_AreControlsLocked(), false);

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -610,26 +610,7 @@ void Web_SendWebsocketData(uint32_t client, uint8_t code) {
         entry["currentTrackNumber"] = gPlayProperties.currentTrackNumber + 1;
         entry["numberOfTracks"] = gPlayProperties.numberOfTracks;
         entry["volume"] = AudioPlayer_GetCurrentVolume();
-        if (gPlayProperties.title != NULL && strcmp(gPlayProperties.title, "") != 0) {
-            // show current audio title from id3 metadata
-            if (gPlayProperties.numberOfTracks > 1) {
-                snprintf(Log_Buffer, Log_BufferLength, "(%u / %u): %s", gPlayProperties.currentTrackNumber+1,  gPlayProperties.numberOfTracks, gPlayProperties.title);
-            } else {
-                snprintf(Log_Buffer, Log_BufferLength, "%s", gPlayProperties.title);
-            };
-            char utf8Buffer[200];
-            convertAsciiToUtf8(Log_Buffer, utf8Buffer);
-            entry["name"] = utf8Buffer;
-        } else if (gPlayProperties.playMode == NO_PLAYLIST) {
-            // no active playlist
-            entry["name"] = (char *)FPSTR (noPlaylist);
-        } else {
-            // show current playlist item
-            snprintf(Log_Buffer, Log_BufferLength, "(%u / %u): %s", gPlayProperties.currentTrackNumber+1,  gPlayProperties.numberOfTracks, *(gPlayProperties.playlist + gPlayProperties.currentTrackNumber));
-            char utf8Buffer[200];
-            convertAsciiToUtf8(Log_Buffer, utf8Buffer);
-            entry["name"] = utf8Buffer;
-        }
+        entry["name"] = gPlayProperties.title;
     } else if (code == 40) {
         object["coverimg"] = "coverimg";
     } else if (code == 50) {

--- a/src/settings-override.h.sample
+++ b/src/settings-override.h.sample
@@ -234,6 +234,7 @@
         constexpr const char topicRfidState[] PROGMEM = "State/ESPuino/Rfid";
         constexpr const char topicTrackState[] PROGMEM = "State/ESPuino/Track";
         constexpr const char topicTrackControlCmnd[] PROGMEM = "Cmnd/ESPuino/TrackControl";
+        constexpr const char topicCoverChangedState[] PROGMEM = "State/ESPuino/CoverChanged";
         constexpr const char topicLoudnessCmnd[] PROGMEM = "Cmnd/ESPuino/Loudness";
         constexpr const char topicLoudnessState[] PROGMEM = "State/ESPuino/Loudness";
         constexpr const char topicSleepTimerCmnd[] PROGMEM = "Cmnd/ESPuino/SleepTimer";

--- a/src/settings.h
+++ b/src/settings.h
@@ -238,6 +238,7 @@
         constexpr const char topicRfidState[] PROGMEM = "State/ESPuino/Rfid";
         constexpr const char topicTrackState[] PROGMEM = "State/ESPuino/Track";
         constexpr const char topicTrackControlCmnd[] PROGMEM = "Cmnd/ESPuino/TrackControl";
+        constexpr const char topicCoverChangedState[] PROGMEM = "State/ESPuino/CoverChanged";
         constexpr const char topicLoudnessCmnd[] PROGMEM = "Cmnd/ESPuino/Loudness";
         constexpr const char topicLoudnessState[] PROGMEM = "State/ESPuino/Loudness";
         constexpr const char topicSleepTimerCmnd[] PROGMEM = "Cmnd/ESPuino/SleepTimer";


### PR DESCRIPTION
This change generalizes the generation of the title that is shown in the Web UI and published over MQTT with the following goal in mind:

- Save CPU cycles and memory since the formatting is just done once.
- The exact same format is used for the Web UI and MQTT.
- The initial title sent over MQTT is now correct and no longer "---".
- Make the code easier to understand and maintain.

I've included the mqtt coverChangedState commit from #160, to save some rebasing hazzle -> Therefore please see the individual commits for a proper diff.