### PR TITLE
processHtml.py: Modernize and fix execution

### DIFF
--- a/processHtml.py
+++ b/processHtml.py
@@ -1,74 +1,56 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
-###
-# Use this script for creating PROGMEM header files from html files.
-# needs pip install requests
-##
-# html file base names
-import requests
-import argparse
 
-def str2bool(v):
-    if isinstance(v, bool):
-        return v
-    if v.lower() in ('yes', 'true', 't', 'y', '1'):
-        return True
-    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
-        return False
-    else:
-        raise argparse.ArgumentTypeError('Boolean value expected.')
+"""
+Use this script for creating PROGMEM header files from html files.
+"""
+from pathlib import Path
 
-HTML_FILES = ["management_DE","management_EN", "accesspoint_DE", "accesspoint_EN"]
+SRC_DIR = Path("src")
+HTML_DIR = Path("html")
+HTML_FILES = [
+    Path("management_DE.html"),
+    Path("management_EN.html"),
+    Path("accesspoint_DE.html"),
+    Path("accesspoint_EN.html"),
+]
 
-class htmlHeaderProcessor(object):
 
-    """
-    Returns a minified HTML string, uses html-minifier.com api.
-    """
-    def minifyHTML(self, filename):
-        with open('html/' + filename + '.html', 'r') as r:
-            data = r.read()
-            return requests.post('https://html-minifier.com/raw', data=dict(input=data)).text.encode('utf8')
+class HtmlHeaderProcessor:
+    """Create c code PROGMEM header files from HTML files"""
 
-    def escape_html(self, data):
-        data = data.replace('\n', '\\\n')
-        data = data.replace('\"', '\\"')
-        data = data.replace('\\d', '\\\d')
-        data = data.replace('\\.', '\\\.')
-        data = data.replace('\\^', '\\\\^')
-        data = data.replace('%;', '%%;')
+    @staticmethod
+    def _escape_html(data):
+        """Escape HTML characters for usage in C"""
+        data = data.replace("\n", "\\\n")
+        data = data.replace('"', r"\"")
+        data = data.replace(r"\d", r"\\d")
+        data = data.replace(r"\.", r"\\.")
+        data = data.replace(r"\^", r"\\^")
+        data = data.replace("%;", "%%;")
         return data
 
-    def html_to_c_header(self, filename):
-        content = ""
-        with open('html/' + filename + '.html', 'r') as r:
-            data = r.read()
-            content += self.escape_html(data)
-        return content
+    @classmethod
+    def _process_header_file(cls, html_path, header_path):
+        with html_path.open("r") as html_file:
+            content = cls._escape_html(html_file.read())
+
+        with header_path.open("w") as header_file:
+            header_file.write(
+                f"static const char {html_path.name.split('_')[0]}_HTML[] PROGMEM = \""
+            )
+            header_file.write(content)
+            header_file.write('";')
+
+    @classmethod
+    def process(cls):
+        print("GENERATING HTML HEADER FILES")
+        for html_file in HTML_FILES:
+            print(f"  {HTML_DIR / html_file}")
+            cls._process_header_file(
+                HTML_DIR / html_file, SRC_DIR / f"HTML{html_file.stem}.h"
+            )
 
 
-    def write_header_file(self, filename, content):
-        with open('src/HTML' + filename + '.h', 'w') as w:
-            varname = filename.split('_')[0]
-            w.write("static const char " + varname + "_HTML[] PROGMEM = \"")
-            w.write(content)
-            w.write("\";")
-
-    def main(self):
-        parser = argparse.ArgumentParser(description='Create c code PROGMEM header files from HTML files.')
-        parser.add_argument("--minify", type=str2bool, nargs='?',
-                            const=True, default=False,
-                            help="Minify HTML Code")
-        args = parser.parse_args()
-
-        for file in HTML_FILES:
-            if args.minify:
-
-                self.header_file_content = self.minifyHTML(file)
-                self.header_file_content = self.escape_html(self.header_file_content)
-            else:
-                self.header_file_content = self.html_to_c_header(file)
-            self.write_header_file(file, self.header_file_content)
-
-if __name__ == '__main__':
-    htmlHeaderProcessor().main()
+if __name__ in ["__main__", "SCons.Script"]:
+    HtmlHeaderProcessor().process()


### PR DESCRIPTION
The processHtml script was silently ignored because `extra_scripts` are launched through Platform IO's SCons build system and this doesn't define __file__. Just dropping the `if __name__` however also didn't work and just causes a cryptic SCons error message.

While at it, this modernizes the script and removes the broken and unused html minify logic.