### PR TITLE
Add options for NEOpixel ring

### DIFF
--- a/src/Cmd.cpp
+++ b/src/Cmd.cpp
@@ -81,18 +81,13 @@ void Cmd_Action(const uint16_t mod) {
 				#ifdef MQTT_ENABLE
 					publishMqtt((char *) FPSTR(topicSleepTimerState), "0", false);
 				#endif
-				#ifdef NEOPIXEL_ENABLE
-					Led_ResetToInitialBrightness();
-				#endif
+				Led_ResetToInitialBrightness();
 			} else {
 				Log_Println((char *) FPSTR(modificatorSleepAtEOT), LOGLEVEL_NOTICE);
 				#ifdef MQTT_ENABLE
 					publishMqtt((char *) FPSTR(topicSleepTimerState), "EOT", false);
 				#endif
-				#ifdef NEOPIXEL_ENABLE
-					Led_ResetToNightBrightness();
-					Log_Println((char *) FPSTR(ledsDimmedToNightmode), LOGLEVEL_INFO);
-				#endif
+				Led_ResetToNightBrightness();
 			}
 			gPlayProperties.sleepAfterCurrentTrack = !gPlayProperties.sleepAfterCurrentTrack;
 			gPlayProperties.sleepAfterPlaylist = false;
@@ -116,16 +111,11 @@ void Cmd_Action(const uint16_t mod) {
 				#ifdef MQTT_ENABLE
 					publishMqtt((char *) FPSTR(topicSleepTimerState), "0", false);
 				#endif
-				#ifdef NEOPIXEL_ENABLE
-					Led_ResetToInitialBrightness();
-				#endif
+				Led_ResetToInitialBrightness();
 				Log_Println((char *) FPSTR(modificatorSleepAtEOPd), LOGLEVEL_NOTICE);
 			} else {
-				#ifdef NEOPIXEL_ENABLE
-					Led_ResetToNightBrightness();
-					Log_Println((char *) FPSTR(ledsDimmedToNightmode), LOGLEVEL_INFO);
-				#endif
-					Log_Println((char *) FPSTR(modificatorSleepAtEOP), LOGLEVEL_NOTICE);
+				Led_ResetToNightBrightness();
+				Log_Println((char *) FPSTR(modificatorSleepAtEOP), LOGLEVEL_NOTICE);
 				#ifdef MQTT_ENABLE
 					publishMqtt((char *) FPSTR(topicSleepTimerState), "EOP", false);
 				#endif
@@ -158,9 +148,7 @@ void Cmd_Action(const uint16_t mod) {
 				#ifdef MQTT_ENABLE
 					publishMqtt((char *) FPSTR(topicSleepTimerState), "0", false);
 				#endif
-				#ifdef NEOPIXEL_ENABLE
-					Led_ResetToInitialBrightness();
-				#endif
+				Led_ResetToInitialBrightness();
 				Log_Println((char *) FPSTR(modificatorSleepd), LOGLEVEL_NOTICE);
 			} else {
 				if (gPlayProperties.currentTrackNumber + 5 > gPlayProperties.numberOfTracks) { // If currentTrack + 5 exceeds number of tracks in playlist, sleep after end of playlist
@@ -174,9 +162,7 @@ void Cmd_Action(const uint16_t mod) {
 						publishMqtt((char *) FPSTR(topicSleepTimerState), "EO5T", false);
 					#endif
 				}
-				#ifdef NEOPIXEL_ENABLE
-					Led_ResetToNightBrightness();
-				#endif
+				Led_ResetToNightBrightness();
 				Log_Println((char *) FPSTR(sleepTimerEO5), LOGLEVEL_NOTICE);
 			}
 
@@ -230,9 +216,7 @@ void Cmd_Action(const uint16_t mod) {
 				publishMqtt((char *) FPSTR(topicLedBrightnessState), Led_GetBrightness(), false);
 			#endif
 			Log_Println((char *) FPSTR(ledsDimmedToNightmode), LOGLEVEL_INFO);
-			#ifdef NEOPIXEL_ENABLE
-				Led_ResetToNightBrightness();
-			#endif
+			Led_ResetToNightBrightness();
 			System_IndicateOk();
 			break;
 		}

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -10,6 +10,7 @@
 #include "System.h"
 #include "Wlan.h"
 #include "Bluetooth.h"
+#include "Port.h"
 
 #ifdef NEOPIXEL_ENABLE
 	#include <FastLED.h>
@@ -104,12 +105,18 @@ void Led_ResetToInitialBrightness(void) {
 		Led_Brightness = Led_InitialBrightness;
 		Log_Println((char *) FPSTR(ledsDimmedToInitialValue), LOGLEVEL_INFO);
 	#endif
+	#ifdef BUTTONS_LED
+		Port_Write(BUTTONS_LED, HIGH, false);
+	#endif
 }
 
 void Led_ResetToNightBrightness(void) {
 	#ifdef NEOPIXEL_ENABLE
 		Led_Brightness = Led_NightBrightness;
 		Log_Println((char *) FPSTR(ledsDimmedToNightmode), LOGLEVEL_INFO);
+	#endif
+	#ifdef BUTTONS_LED
+		Port_Write(BUTTONS_LED, LOW, false);
 	#endif
 }
 
@@ -124,6 +131,9 @@ uint8_t Led_GetBrightness(void) {
 void Led_SetBrightness(uint8_t value) {
 	#ifdef NEOPIXEL_ENABLE
 		Led_Brightness = value;
+		#ifdef BUTTONS_LED
+			Port_Write(BUTTONS_LED, value <= Led_NightBrightness ? LOW : HIGH, false);
+		#endif
 	#endif
 }
 
@@ -141,6 +151,12 @@ uint8_t Led_Address(uint8_t number) {
 		#else
 			return number;
 		#endif
+	#endif
+}
+
+void Led_SetButtonLedsEnabled(boolean value) {
+	#ifdef BUTTONS_LED
+		Port_Write(BUTTONS_LED, value ? HIGH : LOW, false);
 	#endif
 }
 

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -406,7 +406,7 @@ static void Led_Task(void *parameter) {
 				leds[0].setHue((uint8_t)(85 - (90 * ((double)AudioPlayer_GetCurrentVolume() / (double)AudioPlayer_GetMaxVolumeSpeaker()))));
 			} else {
 				for (int led = 0; led < numLedsToLight; led++) { // (Inverse) color-gradient from green (85) back to (still) red (250) using unsigned-cast
-					leds[Led_Address(led)].setHue((uint8_t)(85 - ((double)90 / NUM_LEDS) * led));
+					leds[Led_Address(led)].setHue((uint8_t)((-86.0f) / (NUM_LEDS-1) * led + 85.0f));
 				}
 			}
 			FastLED.show();
@@ -623,7 +623,7 @@ static void Led_Task(void *parameter) {
 									if (System_AreControlsLocked()) {
 										leds[Led_Address(led)] = CRGB::Red;
 									} else if (!gPlayProperties.pausePlay) { // Hue-rainbow
-										leds[Led_Address(led)].setHue((uint8_t)(85 - ((double)90 / NUM_LEDS) * led));
+										leds[Led_Address(led)].setHue((uint8_t)(((float)PROGRESS_HUE_END - (float)PROGRESS_HUE_START) / (NUM_LEDS-1) * led + PROGRESS_HUE_START));
 									}
 								}
 							}

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -21,6 +21,12 @@
 	#define LED_INDICATOR_IS_SET(indicator) (((Led_Indicators) & (1u << ((uint8_t)indicator))) > 0u)
 	#define LED_INDICATOR_CLEAR(indicator) ((Led_Indicators) &= ~(1u << ((uint8_t)indicator)))
 
+	#ifndef LED_OFFSET
+		#define LED_OFFSET 0
+	#elif LED_OFFSET < 0 || LED_OFFSET >= NUM_LEDS
+		#error LED_OFFSET must be between 0 and NUM_LEDS-1
+	#endif
+
 	extern t_button gButtons[7];    // next + prev + pplay + rotEnc + button4 + button5 + dummy-button
 	extern uint8_t gShutdownButton;
 
@@ -121,12 +127,20 @@ void Led_SetBrightness(uint8_t value) {
 	#endif
 }
 
-// Switches Neopixel-addressing from clockwise to counter clockwise (and vice versa)
+// Calculates physical address for a virtual LED address. This handles reversing the rotation direction of the ring and shifting the starting LED
 uint8_t Led_Address(uint8_t number) {
 	#ifdef NEOPIXEL_REVERSE_ROTATION
-		return NUM_LEDS - 1 - number;
+		#if LED_OFFSET > 0
+			return number <=  LED_OFFSET - 1 ? LED_OFFSET - 1 - number : NUM_LEDS + LED_OFFSET - 1 - number;
+		#else
+			return NUM_LEDS - 1 - number;
+		#endif
 	#else
-		return number;
+		#if LED_OFFSET > 0
+			return number >= NUM_LEDS - LED_OFFSET ?  number + LED_OFFSET - NUM_LEDS : number + LED_OFFSET;
+		#else
+			return number;
+		#endif
 	#endif
 }
 

--- a/src/Port.cpp
+++ b/src/Port.cpp
@@ -217,6 +217,14 @@ void Port_Write(const uint8_t _channel, const bool _newState, const bool _initGp
 			}
 		#endif
 
+		#ifdef BUTTONS_LED
+			if (BUTTONS_LED >= 100 && BUTTONS_LED <= 107) {
+				OutputBitMaskInOutAsPerPort[0] &= ~(1 << Port_ChannelToBit(BUTTONS_LED));
+			} else if (BUTTONS_LED >= 108 && BUTTONS_LED <= 115) {
+				OutputBitMaskInOutAsPerPort[1] &= ~(1 << Port_ChannelToBit(BUTTONS_LED));
+			}
+		#endif
+
 		// Only change port-config if necessary (at least bitmask changed from base-default for one port)
 		if ((OutputBitMaskInOutAsPerPort[0] != portBaseValueBitMask) || (OutputBitMaskInOutAsPerPort[1] != portBaseValueBitMask)) {
 			i2cBusTwo.beginTransmission(expanderI2cAddress);
@@ -281,6 +289,14 @@ void Port_Write(const uint8_t _channel, const bool _newState, const bool _initGp
 				#else
 					OutputBitMaskInOutAsPerPort[1] &= ~(1 << Port_ChannelToBit(POWER));
 				#endif
+			}
+		#endif
+
+		#ifdef BUTTONS_LED
+			if (BUTTONS_LED >= 100 && BUTTONS_LED <= 107) {
+				OutputBitMaskInOutAsPerPort[0] &= ~(1 << Port_ChannelToBit(BUTTONS_LED));
+			} else if (BUTTONS_LED >= 108 && BUTTONS_LED <= 115) {
+				OutputBitMaskInOutAsPerPort[1] &= ~(1 << Port_ChannelToBit(BUTTONS_LED));
 			}
 		#endif
 

--- a/src/Power.cpp
+++ b/src/Power.cpp
@@ -14,10 +14,16 @@ void Power_Init(void) {
 // Switch on peripherals. Please note: meaning of POWER_ON is HIGH per default. But is LOW in case of INVERT_POWER is enabled.
 void Power_PeripheralOn(void) {
 	Port_Write(POWER, POWER_ON, false);
+	#ifdef BUTTONS_LED
+		Port_Write(BUTTONS_LED, HIGH, false);
+	#endif
 	delay(50);  // Give peripherals some time to settle down
 }
 
 // Switch off peripherals. Please note: meaning of POWER_OFF is LOW per default. But is HIGH in case of INVERT_POWER is enabled.
 void Power_PeripheralOff(void) {
 	Port_Write(POWER, POWER_OFF, false);
+	#ifdef BUTTONS_LED
+		Port_Write(BUTTONS_LED, LOW, false);
+	#endif
 }

--- a/src/settings-azdelivery_sdmmc.h
+++ b/src/settings-azdelivery_sdmmc.h
@@ -70,6 +70,8 @@
     #define BUTTON_4                        99          // Button 4: unnamed optional button
     #define BUTTON_5                        99          // Button 5: unnamed optional button
 
+    //#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
     // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
     // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
     #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings-complete.h
+++ b/src/settings-complete.h
@@ -62,6 +62,8 @@
 #define BUTTON_4                        104         // Button 4: unnamed optional button
 #define BUTTON_5                        101         // Button 5: unnamed optional button
 
+//#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
 // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
 // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
 #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings-custom.h
+++ b/src/settings-custom.h
@@ -64,6 +64,8 @@
     #define BUTTON_4                        99          // Button 4: unnamed optional button
     #define BUTTON_5                        99          // Button 5: unnamed optional button
 
+    //#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
     // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
     // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
     #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings-espa1s.h
+++ b/src/settings-espa1s.h
@@ -64,6 +64,8 @@
     #define BUTTON_4                        99          // Button 4: unnamed optional button
     #define BUTTON_5                        99          // Button 5: unnamed optional button
 
+    //#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
     // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
     // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
     #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings-lolin32.h
+++ b/src/settings-lolin32.h
@@ -71,6 +71,8 @@
 #define BUTTON_4                        99          // Button 4: unnamed optional button
 #define BUTTON_5                        99          // Button 5: unnamed optional button
 
+//#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
 // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
 // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
 #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings-lolin_d32.h
+++ b/src/settings-lolin_d32.h
@@ -71,6 +71,8 @@
     #define BUTTON_4                        99          // Button 4: unnamed optional button
     #define BUTTON_5                        99          // Button 5: unnamed optional button
 
+    //#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
     // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
     // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
     #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings-lolin_d32_pro.h
+++ b/src/settings-lolin_d32_pro.h
@@ -66,6 +66,8 @@
     #define BUTTON_4                        99          // Button 4: unnamed optional button
     #define BUTTON_5                        99          // Button 5: unnamed optional button
 
+    //#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
     // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
     // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
     #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings-lolin_d32_pro_sdmmc_pe.h
+++ b/src/settings-lolin_d32_pro_sdmmc_pe.h
@@ -70,6 +70,8 @@
     #define BUTTON_4                        104         // Button 4: connected to port-expander
     #define BUTTON_5                        105         // Button 5: connected to port-expander
 
+    //#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
     // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
     // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
     #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings-lolin_d32_sdmmc_pe.h
+++ b/src/settings-lolin_d32_sdmmc_pe.h
@@ -69,6 +69,8 @@
     #define BUTTON_4                        104         // Button 4: connected to port-expander
     #define BUTTON_5                        105         // Button 5: connected to port-expander
 
+    //#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
     // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
     // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
     #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings-ttgo_t8.h
+++ b/src/settings-ttgo_t8.h
@@ -66,6 +66,8 @@
 #define BUTTON_4                        99          // Button 4: unnamed optional button
 #define BUTTON_5                        99          // Button 5: unnamed optional button
 
+//#define BUTTONS_LED                   114         // Powers the LEDs of the buttons. Make sure the current consumed by the LEDs can be handled by the used GPIO
+
 // Channels of port-expander can be read cyclic or interrupt-driven. It's strongly recommended to use the interrupt-way!
 // Infos: https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306
 #ifdef PORT_EXPANDER_ENABLE

--- a/src/settings.h
+++ b/src/settings.h
@@ -187,6 +187,7 @@
         #define NUM_LEDS                    24          // number of LEDs
         #define CHIPSET                     WS2812B     // type of Neopixel
         #define COLOR_ORDER                 GRB
+        //#define LED_OFFSET                0           // shifts the starting LED in the original direction of the neopixel ring
     #endif
 
     #if defined(MEASURE_BATTERY_VOLTAGE) || defined(MEASURE_BATTERY_MAX17055)

--- a/src/settings.h
+++ b/src/settings.h
@@ -187,6 +187,8 @@
         #define NUM_LEDS                    24          // number of LEDs
         #define CHIPSET                     WS2812B     // type of Neopixel
         #define COLOR_ORDER                 GRB
+        #define PROGRESS_HUE_START          85          // Start and end hue of mulitple-LED progress indicator. Hue ranges from basically 0 - 255, but you can also set numbers outside this range to get the desired effect (e.g. 85-215 will go from green to purple via blue, 341-215 start and end at exactly the same color but go from green to purple via yellow and red)
+        #define PROGRESS_HUE_END            -1
         //#define LED_OFFSET                0           // shifts the starting LED in the original direction of the neopixel ring
     #endif
 


### PR DESCRIPTION
- LED_OFFSET: if defined must be in the range [0; NUM_LEDS-1]. The starting LED will be shifted by this number of pixels
I added this option because I wanted to compare the look when the ring starts at top to the ring starting at bottom without having to reassemble the box. I think this does not add much complexity and maybe someone else might need it

- PROGRESS_HUE_START and PROGRESS_HUE_END: defines the start and end hue for the multi LED progress indicator gradient. By default it starts at green and ends at red (just as it did before). However I did not like the fact that the volume is displayed the same way as the current progress. With this defines you can e.g. display the progess with a single color or use the whole rainbow.
I also slightly edited the calulcation for the volume gradient (because actually it was not going from 85 back to -5, but the actual end value depended on the number of LEDs. For 24 LEDs it was going back to -1) to make sure volume and progress gradients are exaxlty the same by default

- BUTTONS_LED: defines a GPIO that powers button (or any other kind of) LEDs. Those LEDs will be enabled by default and disabled when nightmode is set (or the brightness of Neopixels is manually set to a level below the level for nightmode)