### PR TITLE
mqtt: Fix title for webradio

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -1122,10 +1122,12 @@ void audio_eof_mp3(const char *info) { //end of file
 void audio_showstation(const char *info) {
     snprintf(Log_Buffer, Log_BufferLength, "station     : %s", info);
     Log_Println(Log_Buffer, LOGLEVEL_NOTICE);
-    if (gPlayProperties.numberOfTracks > 1) {
-        Audio_setTitle("(%u/%u): Webradio: %s", gPlayProperties.currentTrackNumber+1,  gPlayProperties.numberOfTracks, info);
-    } else {
-        Audio_setTitle("Webradio: %s", info);
+    if (strcmp(info, "")) {
+        if (gPlayProperties.numberOfTracks > 1) {
+            Audio_setTitle("(%u/%u): %s", gPlayProperties.currentTrackNumber+1,  gPlayProperties.numberOfTracks, info);
+        } else {
+            Audio_setTitle("%s", info);
+        }
     }
 }
 
@@ -1133,7 +1135,11 @@ void audio_showstreamtitle(const char *info) {
     snprintf(Log_Buffer, Log_BufferLength, "streamtitle : %s", info);
     Log_Println(Log_Buffer, LOGLEVEL_INFO);
     if (strcmp(info, "")) {
-        Audio_setTitle("%s (%s)", gPlayProperties.title, info);
+        if (gPlayProperties.numberOfTracks > 1) {
+            Audio_setTitle("(%u/%u): %s", gPlayProperties.currentTrackNumber+1,  gPlayProperties.numberOfTracks, info);
+        } else {
+            Audio_setTitle("%s", info);
+        }
     }
 }
 


### PR DESCRIPTION
Starting with commit 751f182 the webradio stream title gets appended to the station title. This introduced a bug and now all further stream titles are simply appended.

Fix the problem by simply replacing the title with the stream title updates. That way the station name is no longer visible after a while, but that behavior is aligned with titles on the SD card, where we also don't differentiate between the track title / artist / album / ...