### PR TITLE
LED volume indicator refactoring and glitch fixes

### DIFF
--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -565,6 +565,10 @@ static void Led_Task(void *parameter) {
 			case NO_PLAYLIST: // If no playlist is active (idle)
 				if (hlastVolume == AudioPlayer_GetCurrentVolume() && lastLedBrightness == Led_Brightness) {
 					for (uint8_t i = 0; i < NUM_LEDS; i++) {
+						if (hlastVolume != AudioPlayer_GetCurrentVolume()) {
+							// skip idle pattern if volume has changed
+							break;
+						}
 						if (OPMODE_BLUETOOTH_SINK == System_GetOperationMode()) {
 							idleColor = CRGB::Blue;
 						} else

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -28,6 +28,10 @@
 		#error LED_OFFSET must be between 0 and NUM_LEDS-1
 	#endif
 
+	// Time in milliseconds the volume indicator is visible
+	#define LED_VOLUME_INDICATOR_RETURN_DELAY	1000U
+	#define LED_VOLUME_INDICATOR_NUM_CYCLES		(LED_VOLUME_INDICATOR_RETURN_DELAY / 20)
+
 	extern t_button gButtons[7];    // next + prev + pplay + rotEnc + button4 + button5 + dummy-button
 	extern uint8_t gShutdownButton;
 
@@ -162,11 +166,11 @@ void Led_SetButtonLedsEnabled(boolean value) {
 
 bool Led_NeedsProgressRedraw(bool lastPlayState, bool lastLockState,
 			     bool notificationShown, bool ledBusyShown,
-			     bool volumeChangeShown) {
+			     bool requestProgressRedraw) {
 #ifdef BATTERY_MEASURE_ENABLE
 	if (gPlayProperties.pausePlay != lastPlayState ||
 	    System_AreControlsLocked() != lastLockState ||
-	    notificationShown || ledBusyShown || volumeChangeShown ||
+	    notificationShown || ledBusyShown || requestProgressRedraw ||
 	    LED_INDICATOR_IS_SET(LedIndicatorType::VoltageWarning) ||
 	    LED_INDICATOR_IS_SET(LedIndicatorType::Voltage) ||
 	    !gButtons[gShutdownButton].currentState ||
@@ -174,7 +178,7 @@ bool Led_NeedsProgressRedraw(bool lastPlayState, bool lastLockState,
 #else
 	if (gPlayProperties.pausePlay != lastPlayState ||
 	    System_AreControlsLocked() != lastLockState ||
-	    notificationShown || ledBusyShown || volumeChangeShown ||
+	    notificationShown || ledBusyShown || requestProgressRedraw ||
 	    !gButtons[gShutdownButton].currentState ||
 	    System_IsSleepRequested()) {
 #endif
@@ -192,7 +196,7 @@ static void Led_Task(void *parameter) {
 		static bool lastLockState = false;
 		static bool ledBusyShown = false;
 		static bool notificationShown = false;
-		static bool volumeChangeShown = false;
+		static bool requestProgressRedraw = false;
 		static bool showEvenError = false;
 		static bool turnedOffLeds = false;
 		static bool singleLedStatus = false;
@@ -432,34 +436,56 @@ static void Led_Task(void *parameter) {
 			}
 		#endif
 
-		// Single-LED: led indicates loudness between green (low) => red (high)
-		// Multiple-LEDs: number of LEDs indicate loudness; gradient is shown between green (low) => red (high)
+		/*
+		 * - Single-LED: led indicates loudness between green (low) => red (high)
+		 * - Multiple-LEDs: number of LEDs indicate loudness; gradient is shown between
+		 *   green (low) => red (high)
+		 */
 		if (hlastVolume != AudioPlayer_GetCurrentVolume()) { // If volume has been changed
-			uint8_t numLedsToLight = map(AudioPlayer_GetCurrentVolume(), 0, AudioPlayer_GetMaxVolume(), 0, NUM_LEDS);
-			hlastVolume = AudioPlayer_GetCurrentVolume();
-			volumeChangeShown = true;
-			FastLED.clear();
+			uint8_t timeout = LED_VOLUME_INDICATOR_NUM_CYCLES;
+			// wait for further volume changes within next 20ms for 50 cycles = 1s
+			while (timeout--) {
+				uint8_t numLedsToLight = map(AudioPlayer_GetCurrentVolume(), 0,
+							     AudioPlayer_GetMaxVolume(), 0,
+							     NUM_LEDS);
 
+				// Reset timeout when volume has changed
+				if (hlastVolume != AudioPlayer_GetCurrentVolume())
+					timeout = LED_VOLUME_INDICATOR_NUM_CYCLES;
 
-			if (NUM_LEDS == 1) {
-				leds[0].setHue((uint8_t)(85 - (90 * ((double)AudioPlayer_GetCurrentVolume() / (double)AudioPlayer_GetMaxVolumeSpeaker()))));
-			} else {
-				for (int led = 0; led < numLedsToLight; led++) { // (Inverse) color-gradient from green (85) back to (still) red (250) using unsigned-cast
-					leds[Led_Address(led)].setHue((uint8_t)((-86.0f) / (NUM_LEDS-1) * led + 85.0f));
-				}
-			}
-			FastLED.show();
+				hlastVolume = AudioPlayer_GetCurrentVolume();
+				FastLED.clear();
 
-			for (uint8_t i = 0; i <= 50; i++) {
-				if (hlastVolume != AudioPlayer_GetCurrentVolume() || LED_INDICATOR_IS_SET(LedIndicatorType::Error) || LED_INDICATOR_IS_SET(LedIndicatorType::Ok) || !gButtons[gShutdownButton].currentState || System_IsSleepRequested()) {
-					if (hlastVolume != AudioPlayer_GetCurrentVolume()) {
-						volumeChangeShown = false;
+				if (NUM_LEDS == 1) {
+					uint8_t hue = 85 - (90 *
+						((double)AudioPlayer_GetCurrentVolume() /
+						(double)AudioPlayer_GetMaxVolumeSpeaker()));
+					leds[0].setHue(hue);
+				} else {
+					/*
+					 * (Inverse) color-gradient from green (85) back to (still)
+					 * red (250) using unsigned-cast.
+					 */
+					for (int led = 0; led < numLedsToLight; led++) {
+						uint8_t hue = (-86.0f) / (NUM_LEDS-1) * led + 85.0f;
+						leds[Led_Address(led)].setHue(hue);
 					}
+				}
+
+				FastLED.show();
+
+				// abort volume change indication if necessary
+				if (LED_INDICATOR_IS_SET(LedIndicatorType::Error) ||
+				    LED_INDICATOR_IS_SET(LedIndicatorType::Ok) ||
+				    !gButtons[gShutdownButton].currentState ||
+				    System_IsSleepRequested()) {
 					break;
 				}
 
 				vTaskDelay(portTICK_RATE_MS * 20);
 			}
+
+			requestProgressRedraw = true;
 		}
 
 		// < 4 LEDs: doesn't make sense at all
@@ -632,11 +658,11 @@ static void Led_Task(void *parameter) {
 				if (!gPlayProperties.playlistFinished) {
 					if (Led_NeedsProgressRedraw(lastPlayState, lastLockState,
 								    notificationShown, ledBusyShown,
-								    volumeChangeShown)) {
+								    requestProgressRedraw)) {
 						lastPlayState = gPlayProperties.pausePlay;
 						lastLockState = System_AreControlsLocked();
 						notificationShown = false;
-						volumeChangeShown = false;
+						requestProgressRedraw = false;
 						if (ledBusyShown) {
 							ledBusyShown = false;
 							FastLED.clear();


### PR DESCRIPTION
This is a somewhat improved version of https://github.com/biologist79/ESPuino/pull/178. It solves two glitches in the LEDs as described by @Joe91:

1. When changing the volume in idle, there was a short blinking of the LEDs with the idle-colour.
2. When changing the volume in default mode the progress shines through for one frame.

In contrast to https://github.com/biologist79/ESPuino/pull/178 this PR also tries to improve the code style and the code flow. Therefore it is somewhat related to https://github.com/biologist79/ESPuino/issues/176.