### PR TITLE
Button.cpp: Fix headphone detection while controls are locked

### DIFF
--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -128,14 +128,14 @@ void Button_Init() {
 // If timer-semaphore is set, read buttons (unless controls are locked)
 void Button_Cyclic() {
 	if (xSemaphoreTake(Button_TimerSemaphore, 0) == pdTRUE) {
-		if (System_AreControlsLocked()) {
-			return;
-		}
-
 		unsigned long currentTimestamp = millis();
 		#ifdef PORT_EXPANDER_ENABLE
 			Port_Cyclic();
 		#endif
+
+		if (System_AreControlsLocked()) {
+			return;
+		}
 
 		// Buttons can be mixed between GPIO and port-expander.
 		// But at the same time only one of them can be for example NEXT_BUTTON


### PR DESCRIPTION
When controls are locked Button_Cyclic() is aborted and Port_Cyclic() never gets called. This means we don't get the correct status of the HP_DETECT signal.

To fix this abort Button_Cyclic() after Port_Cyclic() is called, so we can still detect if the headphones are connected.