### PR TITLE
Always allow to apply an RFID tag twice when the playlist is finished

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -778,6 +778,12 @@ void AudioPlayer_Task(void *parameter) {
 			vTaskDelay(portTICK_PERIOD_MS * 1);
 		}
 		//esp_task_wdt_reset(); // Don't forget to feed the dog!
+
+		#ifdef DONT_ACCEPT_SAME_RFID_TWICE_ENABLE
+			if (gPlayProperties.playlistFinished || gPlayProperties.playMode == NO_PLAYLIST) {
+				strncpy(gOldRfidTagId, "X", cardIdStringSize-1);     // Set old rfid-id to crap in order to allow to re-apply an rfid-tag after playback is finished
+			}
+		#endif
 	}
 	vTaskDelete(NULL);
 }


### PR DESCRIPTION
If the macro `DONT_ACCEPT_SAME_RFID_TWICE_ENABLE` is defined, the same RFID card cannot be accepted again even after the playlist was finished. This PR allows to use the same RFID card again in this case.