### PR TITLE
Add support for control LEDs to be connected to the NeoPixel

### DIFF
--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -44,8 +44,9 @@
 	static uint8_t Led_NightBrightness = LED_INITIAL_NIGHT_BRIGHTNESS;
 	constexpr uint8_t Led_IdleDotDistance = NUM_INDICATOR_LEDS / NUM_LEDS_IDLE_DOTS;
 
-	static CRGBArray<NUM_INDICATOR_LEDS + NUM_STATIC_LEDS> leds;
+	static CRGBArray<NUM_INDICATOR_LEDS + NUM_CONTROL_LEDS> leds;
 	static CRGBSet indicator(leds(0, NUM_INDICATOR_LEDS - 1));
+	static CRGBSet controlLeds(leds(NUM_INDICATOR_LEDS, NUM_INDICATOR_LEDS + NUM_CONTROL_LEDS - 1));
 
 	TaskHandle_t Led_TaskHandle;
 	static void Led_Task(void *parameter);
@@ -182,6 +183,15 @@ void Led_SetBrightness(uint8_t value) {
 	}
 #endif
 
+#ifdef NEOPIXEL_ENABLE
+	void Led_DrawControls() {
+		static CRGB::HTMLColorCode controlLedColors[NUM_CONTROL_LEDS] = CONTROL_LEDS_COLORS;
+		for (uint8_t controlLed = 0; controlLed < NUM_CONTROL_LEDS; controlLed++) {
+			controlLeds[controlLed] = controlLedColors[controlLed];
+		}
+	}
+#endif
+
 void Led_SetButtonLedsEnabled(boolean value) {
 	#ifdef BUTTONS_LED
 		Port_Write(BUTTONS_LED, value ? HIGH : LOW, false);
@@ -260,6 +270,8 @@ void Led_SetButtonLedsEnabled(boolean value) {
 				vTaskDelay(portTICK_RATE_MS * 10);
 				continue;
 			}
+
+			Led_DrawControls();
 
 			uint32_t taskDelay = 20;
 			bool startNewAnimation = false;

--- a/src/settings.h
+++ b/src/settings.h
@@ -209,8 +209,9 @@
 	//#################### Settings for optional Modules##############################
 	// (optinal) Neopixel
 	#ifdef NEOPIXEL_ENABLE
-		#define NUM_INDICATOR_LEDS		24          	// number of LEDs
-		#define NUM_STATIC_LEDS			0				// not used currently
+		#define NUM_INDICATOR_LEDS		24          	// number of Neopixel LEDs (formerly NUM_LEDS)
+		#define NUM_CONTROL_LEDS		0		// optional control leds (https://forum.espuino.de/t/statische-ws2812-leds/1703)
+                #define CONTROL_LEDS_COLORS		{}		// Colors for the control LEDs. Make sure it lists at least NUM_CONTROL_LEDS colors, e.g. for three control LEDs define: CONTROL_LEDS_COLORS {CRGB::Yellow, CRGB::Blue, 0xFFFFFF} (predefined colors: http://fastled.io/docs/3.1/struct_c_r_g_b.html)
 		#define CHIPSET					WS2812B     	// type of Neopixel
 		#define COLOR_ORDER				GRB
 		#define NUM_LEDS_IDLE_DOTS		4           	// count of LEDs, which are shown when Idle


### PR DESCRIPTION
This commit allows to add additional WS2812 LEDs to be connected at the end of the NeoPixel ring.

This may be useful to lighten up other artwork, buttons, texts etc on the ESPuino. This feature is somewhat redundant to the already BUTTON_LEDS feature but it allows to use WS2812 LEDs that can be dimmed with the overall brightness of the neopixel leds, and with that also follow the night mode brightness instead of just going 100% or off like the BUTTON_LEDS feature which only turns on/off a GPIO. Also colors of the static LEDs can be configured through settings.h by defining them in the CONTROL_LEDS_COLORS array.