### PR TITLE
Move FastLED access to CRGBArray and CRGBSets

### DIFF
--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -824,7 +824,7 @@ void Led_SetButtonLedsEnabled(boolean value) {
 			if constexpr(NUM_INDICATOR_LEDS == 1) {
 				leds[0].setHue((uint8_t)(85 - ((double)90 / 100) * gPlayProperties.currentRelPos));
 			} else {
-				const uint32_t ledValue = map(gPlayProperties.currentRelPos, 0, 98, 0, leds.size() * DIMMABLE_STATES);
+				const uint32_t ledValue = std::clamp<uint32_t>(map(gPlayProperties.currentRelPos, 0, 98, 0, leds.size() * DIMMABLE_STATES), 0, leds.size() * DIMMABLE_STATES);
 				const uint8_t fullLeds = ledValue / DIMMABLE_STATES;
 				const uint8_t lastLed = ledValue % DIMMABLE_STATES;
 				for (uint8_t led = 0; led < fullLeds; led++) {
@@ -862,9 +862,7 @@ void Led_SetButtonLedsEnabled(boolean value) {
 		static uint16_t cyclesWaited = 0;
 
 		// wait for further volume changes within next 20ms for 50 cycles = 1s
-		const uint32_t ledValue =  map(AudioPlayer_GetCurrentVolume(), 0,
-						AudioPlayer_GetMaxVolume(), 0,
-						leds.size() * DIMMABLE_STATES);
+		const uint32_t ledValue =  std::clamp<uint32_t>(map(AudioPlayer_GetCurrentVolume(), 0, AudioPlayer_GetMaxVolume(), 0, leds.size() * DIMMABLE_STATES), 0, leds.size() * DIMMABLE_STATES);
 		const uint8_t fullLeds = ledValue / DIMMABLE_STATES;
 		const uint8_t lastLed = ledValue % DIMMABLE_STATES;
 
@@ -922,7 +920,7 @@ void Led_SetButtonLedsEnabled(boolean value) {
 
 		if constexpr(NUM_INDICATOR_LEDS >= 4) {
 			if (gPlayProperties.numberOfTracks > 1 && gPlayProperties.currentTrackNumber < gPlayProperties.numberOfTracks) {
-				const uint32_t ledValue =  map(gPlayProperties.currentTrackNumber, 0, gPlayProperties.numberOfTracks - 1, 0, NUM_INDICATOR_LEDS * DIMMABLE_STATES);
+				const uint32_t ledValue = std::clamp<uint32_t>(map(gPlayProperties.currentTrackNumber, 0, gPlayProperties.numberOfTracks - 1, 0, leds.size() * DIMMABLE_STATES), 0, leds.size() * DIMMABLE_STATES);
 				const uint8_t fullLeds = ledValue / DIMMABLE_STATES;
 				const uint8_t lastLed = ledValue % DIMMABLE_STATES;
 
@@ -1066,10 +1064,7 @@ void Led_SetButtonLedsEnabled(boolean value) {
 			animationDelay = 20*100;
 			animationActive = false;
 		} else {
-			uint8_t numLedsToLight = staticBatteryLevel * leds.size();
-			if (numLedsToLight > leds.size()) {    // Can happen e.g. if no battery is connected
-				numLedsToLight = leds.size();
-			}
+			uint8_t numLedsToLight = std::clamp<uint8_t>(staticBatteryLevel * leds.size(), 0, leds.size());
 
 			// fill all needed LEDs
 			if (filledLedCount < numLedsToLight) {

--- a/src/Led.h
+++ b/src/Led.h
@@ -46,13 +46,14 @@ enum class LedPlaylistProgressStates
 struct AnimationReturnType {
     bool animationActive;
     int32_t animationDelay;
+	bool animationRefresh;
 
 	void clear(){
 		animationActive = false;
 		animationDelay = 0;
 	}
-	AnimationReturnType() :animationActive(false), animationDelay(0) {}
-	AnimationReturnType(bool active, int32_t delay) :animationActive(active), animationDelay(delay) {}
+	AnimationReturnType() : animationActive(false), animationDelay(0), animationRefresh(false) {}
+	AnimationReturnType(bool active, int32_t delay, bool refresh = false) :animationActive(active), animationDelay(delay), animationRefresh(refresh) {}
 };
 
 void Led_Init(void);

--- a/src/settings.h
+++ b/src/settings.h
@@ -202,9 +202,10 @@
 	//#################### Settings for optional Modules##############################
 	// (optinal) Neopixel
 	#ifdef NEOPIXEL_ENABLE
-		#define NUM_LEDS			24          	// number of LEDs
-		#define CHIPSET				WS2812B     	// type of Neopixel
-		#define COLOR_ORDER			GRB
+		#define NUM_INDICATOR_LEDS		24          	// number of LEDs
+		#define NUM_STATIC_LEDS			0				// not used currently
+		#define CHIPSET					WS2812B     	// type of Neopixel
+		#define COLOR_ORDER				GRB
 		#define NUM_LEDS_IDLE_DOTS		4           	// count of LEDs, which are shown when Idle
 		#define OFFSET_PAUSE_LEDS		false		// if true the pause-leds are centered in the mid of the LED-Strip
 		#define PROGRESS_HUE_START		85          	// Start and end hue of mulitple-LED progress indicator. Hue ranges from basically 0 - 255, but you can also set numbers outside this range to get the desired effect (e.g. 85-215 will go from green to purple via blue, 341-215 start and end at exactly the same color but go from green to purple via yellow and red)


### PR DESCRIPTION
Change over to CRGBArray from native arrays and add a CRGBSet for the indicator. 

This allows to update the indicator independent of other parts of the CRBG array.