### PR TITLE
Bugfix/heap handling

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -44,8 +44,8 @@ static void AudioPlayer_Task(void *parameter);
 static void AudioPlayer_HeadphoneVolumeManager(void);
 static char **AudioPlayer_ReturnPlaylistFromWebstream(const char *_webUrl);
 static int AudioPlayer_ArrSortHelper(const void *a, const void *b);
-static void AudioPlayer_SortPlaylist(const char **arr, int n);
-static void AudioPlayer_SortPlaylist(char *str[], const uint32_t count);
+static void AudioPlayer_SortPlaylist(char **arr, int n);
+static void AudioPlayer_RandomizePlaylist(char **str, const uint32_t count);
 static size_t AudioPlayer_NvsRfidWriteWrapper(const char *_rfidCardId, const char *_track, const uint32_t _playPosition, const uint8_t _playMode, const uint16_t _trackLastPlayed, const uint16_t _numberOfTracks);
 static void AudioPlayer_ClearCover(void);
 
@@ -934,7 +934,7 @@ void AudioPlayer_TrackQueueDispatcher(const char *_itemToPlay, const uint32_t _l
 			gPlayProperties.numberOfTracks = 1; // Limit number to 1 even there are more entries in the playlist
 			Led_ResetToNightBrightness();
 			Log_Println((char *) FPSTR(modeSingleTrackRandom), LOGLEVEL_NOTICE);
-			AudioPlayer_SortPlaylist(musicFiles, strtoul(*(musicFiles - 1), NULL, 10));
+			AudioPlayer_RandomizePlaylist(musicFiles, gPlayProperties.numberOfTracks);
 			xQueueSend(gTrackQueue, &(musicFiles), 0);
 			break;
 		}
@@ -942,7 +942,7 @@ void AudioPlayer_TrackQueueDispatcher(const char *_itemToPlay, const uint32_t _l
 		case AUDIOBOOK: { // Tracks need to be alph. sorted!
 			gPlayProperties.saveLastPlayPosition = true;
 			Log_Println((char *) FPSTR(modeSingleAudiobook), LOGLEVEL_NOTICE);
-			AudioPlayer_SortPlaylist((const char **)musicFiles, strtoul(*(musicFiles - 1), NULL, 10));
+			AudioPlayer_SortPlaylist(musicFiles, gPlayProperties.numberOfTracks);
 			xQueueSend(gTrackQueue, &(musicFiles), 0);
 			break;
 		}
@@ -951,7 +951,7 @@ void AudioPlayer_TrackQueueDispatcher(const char *_itemToPlay, const uint32_t _l
 			gPlayProperties.repeatPlaylist = true;
 			gPlayProperties.saveLastPlayPosition = true;
 			Log_Println((char *) FPSTR(modeSingleAudiobookLoop), LOGLEVEL_NOTICE);
-			AudioPlayer_SortPlaylist((const char **)musicFiles, strtoul(*(musicFiles - 1), NULL, 10));
+			AudioPlayer_SortPlaylist(musicFiles, gPlayProperties.numberOfTracks);
 			xQueueSend(gTrackQueue, &(musicFiles), 0);
 			break;
 		}
@@ -960,14 +960,14 @@ void AudioPlayer_TrackQueueDispatcher(const char *_itemToPlay, const uint32_t _l
 		case RANDOM_SUBDIRECTORY_OF_DIRECTORY: {
 			snprintf(Log_Buffer, Log_BufferLength, "%s '%s' ", (char *) FPSTR(modeAllTrackAlphSorted), filename);
 			Log_Println(Log_Buffer, LOGLEVEL_NOTICE);
-			AudioPlayer_SortPlaylist((const char **)musicFiles, strtoul(*(musicFiles - 1), NULL, 10));
+			AudioPlayer_SortPlaylist(musicFiles, gPlayProperties.numberOfTracks);
 			xQueueSend(gTrackQueue, &(musicFiles), 0);
 			break;
 		}
 
 		case ALL_TRACKS_OF_DIR_RANDOM: {
 			Log_Println((char *) FPSTR(modeAllTrackRandom), LOGLEVEL_NOTICE);
-			AudioPlayer_SortPlaylist(musicFiles, strtoul(*(musicFiles - 1), NULL, 10));
+			AudioPlayer_RandomizePlaylist(musicFiles, gPlayProperties.numberOfTracks);
 			xQueueSend(gTrackQueue, &(musicFiles), 0);
 			break;
 		}
@@ -975,7 +975,7 @@ void AudioPlayer_TrackQueueDispatcher(const char *_itemToPlay, const uint32_t _l
 		case ALL_TRACKS_OF_DIR_SORTED_LOOP: {
 			gPlayProperties.repeatPlaylist = true;
 			Log_Println((char *) FPSTR(modeAllTrackAlphSortedLoop), LOGLEVEL_NOTICE);
-			AudioPlayer_SortPlaylist((const char **)musicFiles, strtoul(*(musicFiles - 1), NULL, 10));
+			AudioPlayer_SortPlaylist(musicFiles, gPlayProperties.numberOfTracks);
 			xQueueSend(gTrackQueue, &(musicFiles), 0);
 			break;
 		}
@@ -983,7 +983,7 @@ void AudioPlayer_TrackQueueDispatcher(const char *_itemToPlay, const uint32_t _l
 		case ALL_TRACKS_OF_DIR_RANDOM_LOOP: {
 			gPlayProperties.repeatPlaylist = true;
 			Log_Println((char *) FPSTR(modeAllTrackRandomLoop), LOGLEVEL_NOTICE);
-			AudioPlayer_SortPlaylist(musicFiles, strtoul(*(musicFiles - 1), NULL, 10));
+			AudioPlayer_RandomizePlaylist(musicFiles, gPlayProperties.numberOfTracks);
 			xQueueSend(gTrackQueue, &(musicFiles), 0);
 			break;
 		}
@@ -1074,7 +1074,7 @@ void AudioPlayer_TrackControlToQueueSender(const uint8_t trackCommand) {
 }
 
 // Knuth-Fisher-Yates-algorithm to randomize playlist
-void AudioPlayer_SortPlaylist(char *str[], const uint32_t count) {
+void AudioPlayer_RandomizePlaylist(char **str, const uint32_t count) {
 	if (!count) {
 		return;
 	}
@@ -1098,7 +1098,7 @@ static int AudioPlayer_ArrSortHelper(const void *a, const void *b) {
 }
 
 // Sort playlist alphabetically
-void AudioPlayer_SortPlaylist(const char **arr, int n) {
+void AudioPlayer_SortPlaylist(char **arr, int n) {
 	qsort(arr, n, sizeof(const char *), AudioPlayer_ArrSortHelper);
 }
 

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -3,7 +3,7 @@
 typedef struct { // Bit field
 	uint8_t playMode:                   4;      // playMode
 	char **playlist;                            // playlist
-	char *title;                                // current title
+	char title[255];                            // current title
 	bool repeatCurrentTrack:            1;      // If current track should be looped
 	bool repeatPlaylist:                1;      // If whole playlist should be looped
 	uint16_t currentTrackNumber:        9;      // Current tracknumber

--- a/src/Common.h
+++ b/src/Common.h
@@ -140,10 +140,11 @@ inline void convertAsciiToUtf8(String asciiString, char *utf8String) {
 
 // Release previously allocated memory
 inline void freeMultiCharArray(char **arr, const uint32_t cnt) {
-	for (uint32_t i = 0; i <= cnt; i++) {
+	for (uint32_t i = 0; i < cnt; i++) {
 		/*snprintf(Log_Buffer, Log_BufferLength, "%s: %s", (char *) FPSTR(freePtr), *(arr+i));
 		Log_Println(Log_Buffer, LOGLEVEL_DEBUG);*/
 		free(*(arr + i));
 	}
+	free(arr);
 	*arr = NULL;
 }

--- a/src/Mqtt.cpp
+++ b/src/Mqtt.cpp
@@ -315,6 +315,7 @@ void Mqtt_ClientCallback(const char *topic, const byte *payload, uint32_t length
 				Log_Println((char *) FPSTR(modificatorNotallowedWhenIdle), LOGLEVEL_INFO);
 				publishMqtt((char *) FPSTR(topicSleepState), 0, false);
 				System_IndicateError();
+				free(receivedString);
 				return;
 			}
 			if (strcmp(receivedString, "EOP") == 0) {
@@ -324,6 +325,7 @@ void Mqtt_ClientCallback(const char *topic, const byte *payload, uint32_t length
 				Led_ResetToNightBrightness();
 				publishMqtt((char *) FPSTR(topicLedBrightnessState), Led_GetBrightness(), false);
 				System_IndicateOk();
+				free(receivedString);
 				return;
 			} else if (strcmp(receivedString, "EOT") == 0) {
 				gPlayProperties.sleepAfterCurrentTrack = true;
@@ -332,6 +334,7 @@ void Mqtt_ClientCallback(const char *topic, const byte *payload, uint32_t length
 				Led_ResetToNightBrightness();
 				publishMqtt((char *) FPSTR(topicLedBrightnessState), Led_GetBrightness(), false);
 				System_IndicateOk();
+				free(receivedString);
 				return;
 			} else if (strcmp(receivedString, "EO5T") == 0) {
 				if ((gPlayProperties.numberOfTracks - 1) >= (gPlayProperties.currentTrackNumber + 5)) {
@@ -344,6 +347,7 @@ void Mqtt_ClientCallback(const char *topic, const byte *payload, uint32_t length
 				Led_ResetToNightBrightness();
 				publishMqtt((char *) FPSTR(topicLedBrightnessState), Led_GetBrightness(), false);
 				System_IndicateOk();
+				free(receivedString);
 				return;
 			} else if (strcmp(receivedString, "0") == 0) {  // Disable sleep after it was active previously
 				if (System_IsSleepTimerEnabled()) {
@@ -355,12 +359,12 @@ void Mqtt_ClientCallback(const char *topic, const byte *payload, uint32_t length
 					gPlayProperties.sleepAfterPlaylist = false;
 					gPlayProperties.sleepAfterCurrentTrack = false;
 					gPlayProperties.playUntilTrackNumber = 0;
-					return;
 				} else {
 					Log_Println((char *) FPSTR(sleepTimerAlreadyStopped), LOGLEVEL_INFO);
 					System_IndicateError();
-					return;
 				}
+				free(receivedString);
+				return;
 			}
 			System_SetSleepTimer((uint8_t)strtoul(receivedString, NULL, 10));
 			snprintf(Log_Buffer, Log_BufferLength, "%s: %u Minute(n)", (char *) FPSTR(sleepTimerSetTo), System_GetSleepTimer());

--- a/src/Mqtt.cpp
+++ b/src/Mqtt.cpp
@@ -290,9 +290,8 @@ void Mqtt_ClientCallback(const char *topic, const byte *payload, uint32_t length
 	#ifdef MQTT_ENABLE
 		char *receivedString = (char*)x_calloc(length + 1u, sizeof(char));
 		memcpy(receivedString, (char *) payload, length);
-		char *mqttTopic = x_strdup(topic);
 
-		snprintf(Log_Buffer, Log_BufferLength, "%s: [Topic: %s] [Command: %s]", (char *) FPSTR(mqttMsgReceived), mqttTopic, receivedString);
+		snprintf(Log_Buffer, Log_BufferLength, "%s: [Topic: %s] [Command: %s]", (char *) FPSTR(mqttMsgReceived), topic, receivedString);
 		Log_Println(Log_Buffer, LOGLEVEL_INFO);
 
 		// Go to sleep?
@@ -303,8 +302,7 @@ void Mqtt_ClientCallback(const char *topic, const byte *payload, uint32_t length
 		}
 		// New track to play? Take RFID-ID as input
 		else if (strcmp_P(topic, topicRfidCmnd) == 0) {
-			char *_rfidId = x_strdup(receivedString);
-			xQueueSend(gRfidCardQueue, _rfidId, 0);
+			xQueueSend(gRfidCardQueue, receivedString, 0);
 		}
 		// Loudness to change?
 		else if (strcmp_P(topic, topicLoudnessCmnd) == 0) {
@@ -460,6 +458,5 @@ void Mqtt_ClientCallback(const char *topic, const byte *payload, uint32_t length
 		}
 
 		free(receivedString);
-		free(mqttTopic);
 	#endif
 }

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -298,7 +298,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 			if (serializedPlaylist == NULL) {
 				Log_Println((char *) FPSTR(unableToAllocateMemForLinearPlaylist), LOGLEVEL_ERROR);
 				System_IndicateError();
-				return files;
+				return nullptr;
 			}
 			char buf;
 			char lastBuf = '#';
@@ -314,7 +314,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 						Log_Println((char *) FPSTR(unableToAllocateMemForLinearPlaylist), LOGLEVEL_ERROR);
 						System_IndicateError();
 						free(serializedPlaylist);
-						return files;
+						return nullptr;
 					}
 					serializedPlaylist = tmp;
 				}
@@ -333,7 +333,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 				serializedPlaylist[fPos-1] = '\0';
 			}
 		} else {
-			return files;
+			return nullptr;
 		}
 	}
 
@@ -343,10 +343,10 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 		// File-mode
 		if (!fileOrDirectory.isDirectory()) {
 			files = (char **) x_malloc(sizeof(char *) * 2);
-			if (files == NULL) {
+			if (files == nullptr) {
 				Log_Println((char *) FPSTR(unableToAllocateMemForPlaylist), LOGLEVEL_ERROR);
 				System_IndicateError();
-				return NULL;
+				return nullptr;
 			}
 			Log_Println((char *) FPSTR(fileModeDetected), LOGLEVEL_INFO);
 			#if ESP_ARDUINO_VERSION_MAJOR >= 2
@@ -360,7 +360,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 			}
 			files[0] = x_strdup("1"); // Number of files is always 1 in file-mode
 
-			return ++files;
+			return &(files[1]);
 		}
 
 		// Directory-mode (linear-playlist)
@@ -397,11 +397,11 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 					if ((strlen(serializedPlaylist) + strlen(fileNameBuf) + 2) >= allocCount * allocSize) {
 						char *tmp = (char *) realloc(serializedPlaylist, ++allocCount * allocSize);
 						Log_Println((char *) FPSTR(reallocCalled), LOGLEVEL_DEBUG);
-						if (tmp == NULL) {
+						if (tmp == nullptr) {
 							Log_Println((char *) FPSTR(unableToAllocateMemForLinearPlaylist), LOGLEVEL_ERROR);
 							System_IndicateError();
 							free(serializedPlaylist);
-							return files;
+							return nullptr;
 						}
 						serializedPlaylist = tmp;
 					}
@@ -434,10 +434,8 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 	if (files == NULL) {
 		Log_Println((char *) FPSTR(unableToAllocateMemForPlaylist), LOGLEVEL_ERROR);
 		System_IndicateError();
-		if(serializedPlaylist) {
 			free(serializedPlaylist);
-		}
-		return NULL;
+		return nullptr;
 	}
 
 	// Extract elements out of serialized playlist and copy to playlist
@@ -453,15 +451,15 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 
 	files[0] = (char *) x_malloc(sizeof(char) * 5);
 
-	if (files[0] == NULL) {
+	if (files[0] == nullptr) {
 		Log_Println((char *) FPSTR(unableToAllocateMemForPlaylist), LOGLEVEL_ERROR);
 		System_IndicateError();
 		freeMultiCharArray(files, cnt + 1);
-		return NULL;
+		return nullptr;
 	}
 	sprintf(files[0], "%u", cnt);
 	snprintf(Log_Buffer, Log_BufferLength, "%s: %d", (char *) FPSTR(numberOfValidFiles), cnt);
 	Log_Println(Log_Buffer, LOGLEVEL_NOTICE);
 
-	return files++; // return ptr+1 (starting at 1st payload-item); ptr+0 contains number of items
+	return &(files[1]); // return ptr+1 (starting at 1st payload-item); ptr+0 contains number of items
 }

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -282,8 +282,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 
 	if (files != NULL) { // If **ptr already exists, de-allocate its memory
 		Log_Println((char *) FPSTR(releaseMemoryOfOldPlaylist), LOGLEVEL_DEBUG);
-		--files;
-		freeMultiCharArray(files, strtoul(*files, NULL, 10));
+		freeMultiCharArray(files, strtoul(*files, NULL, 10) + 1);
 		snprintf(Log_Buffer, Log_BufferLength, "%s: %u", (char *) FPSTR(freeMemoryAfterFree), ESP.getFreeHeap());
 		Log_Println(Log_Buffer, LOGLEVEL_DEBUG);
 	}
@@ -457,12 +456,12 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 	if (files[0] == NULL) {
 		Log_Println((char *) FPSTR(unableToAllocateMemForPlaylist), LOGLEVEL_ERROR);
 		System_IndicateError();
-		freeMultiCharArray(files, cnt);
+		freeMultiCharArray(files, cnt + 1);
 		return NULL;
 	}
 	sprintf(files[0], "%u", cnt);
 	snprintf(Log_Buffer, Log_BufferLength, "%s: %d", (char *) FPSTR(numberOfValidFiles), cnt);
 	Log_Println(Log_Buffer, LOGLEVEL_NOTICE);
 
-	return ++files; // return ptr+1 (starting at 1st payload-item); ptr+0 contains number of items
+	return files++; // return ptr+1 (starting at 1st payload-item); ptr+0 contains number of items
 }

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -262,7 +262,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 					if(serializedPlaylist == NULL) {
 						Log_Println((char *) FPSTR(unableToAllocateMemForLinearPlaylist), LOGLEVEL_ERROR);
 						System_IndicateError();
-						return files;
+						return nullptr;
 					}
 
 					char buf;
@@ -282,7 +282,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 
 	if (files != NULL) { // If **ptr already exists, de-allocate its memory
 		Log_Println((char *) FPSTR(releaseMemoryOfOldPlaylist), LOGLEVEL_DEBUG);
-		freeMultiCharArray(files, strtoul(*files, NULL, 10) + 1);
+		freeMultiCharArray(files, strtoul(files[0], NULL, 10) + 1);
 		snprintf(Log_Buffer, Log_BufferLength, "%s: %u", (char *) FPSTR(freeMemoryAfterFree), ESP.getFreeHeap());
 		Log_Println(Log_Buffer, LOGLEVEL_DEBUG);
 	}
@@ -355,7 +355,6 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 				strncpy(fileNameBuf, (char *) fileOrDirectory.name(), sizeof(fileNameBuf) / sizeof(fileNameBuf[0]));
 			#endif
 			if (fileValid(fileNameBuf)) {
-				files = (char **) x_malloc(sizeof(char *) * 2);
 				files[1] = x_strdup(fileNameBuf);
 			}
 			files[0] = x_strdup("1"); // Number of files is always 1 in file-mode
@@ -429,12 +428,11 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 	}
 
 	// Alloc only necessary number of playlist-pointers
-	files = (char **) x_malloc(sizeof(char *) * cnt + 1);
-
-	if (files == NULL) {
+	files = (char **) x_malloc(sizeof(char *) * (cnt + 1));
+	if (files == nullptr) {
 		Log_Println((char *) FPSTR(unableToAllocateMemForPlaylist), LOGLEVEL_ERROR);
 		System_IndicateError();
-			free(serializedPlaylist);
+		free(serializedPlaylist);
 		return nullptr;
 	}
 
@@ -457,7 +455,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 		freeMultiCharArray(files, cnt + 1);
 		return nullptr;
 	}
-	sprintf(files[0], "%u", cnt);
+	snprintf(files[0], 5,  "%u", cnt);
 	snprintf(Log_Buffer, Log_BufferLength, "%s: %d", (char *) FPSTR(numberOfValidFiles), cnt);
 	Log_Println(Log_Buffer, LOGLEVEL_NOTICE);
 

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -221,11 +221,18 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 	bool enablePlaylistCaching = false;
 	bool enablePlaylistFromM3u = false;
 
+	if (files != NULL) { // If **ptr already exists, de-allocate its memory
+		Log_Println((char *) FPSTR(releaseMemoryOfOldPlaylist), LOGLEVEL_DEBUG);
+		freeMultiCharArray(files, strtoul(files[0], NULL, 10) + 1);
+		snprintf(Log_Buffer, Log_BufferLength, "%s: %u", (char *) FPSTR(freeMemoryAfterFree), ESP.getFreeHeap());
+		Log_Println(Log_Buffer, LOGLEVEL_DEBUG);
+	}
+
 	// Look if file/folder requested really exists. If not => break.
 	File fileOrDirectory = gFSystem.open(fileName);
 	if (!fileOrDirectory) {
 		Log_Println((char *) FPSTR(dirOrFileDoesNotExist), LOGLEVEL_ERROR);
-		return NULL;
+		return nullptr;
 	}
 
 	// Create linear playlist of caching-file
@@ -279,13 +286,6 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 
 	snprintf(Log_Buffer, Log_BufferLength, "%s: %u", (char *) FPSTR(freeMemory), ESP.getFreeHeap());
 	Log_Println(Log_Buffer, LOGLEVEL_DEBUG);
-
-	if (files != NULL) { // If **ptr already exists, de-allocate its memory
-		Log_Println((char *) FPSTR(releaseMemoryOfOldPlaylist), LOGLEVEL_DEBUG);
-		freeMultiCharArray(files, strtoul(files[0], NULL, 10) + 1);
-		snprintf(Log_Buffer, Log_BufferLength, "%s: %u", (char *) FPSTR(freeMemoryAfterFree), ESP.getFreeHeap());
-		Log_Println(Log_Buffer, LOGLEVEL_DEBUG);
-	}
 
 	// Parse m3u-playlist and create linear-playlist out of it
 	if (_playMode == LOCAL_M3U) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,8 +98,7 @@ bool testSPIRAM(void) {
 			if (!lastRfidPlayed.compareTo("-1")) {
 				Log_Println((char *) FPSTR(unableToRestoreLastRfidFromNVS), LOGLEVEL_INFO);
 			} else {
-				char *lastRfid = x_strdup(lastRfidPlayed.c_str());
-				xQueueSend(gRfidCardQueue, lastRfid, 0);
+				xQueueSend(gRfidCardQueue, lastRfidPlayed.c_str(), 0);
 				snprintf(Log_Buffer, Log_BufferLength, "%s: %s", (char *) FPSTR(restoredLastRfidFromNVS), lastRfidPlayed.c_str());
 				Log_Println(Log_Buffer, LOGLEVEL_INFO);
 			}


### PR DESCRIPTION
This fixes #202. It also changes the usage of the heap (reduces the number of malloc's to reduce heap fragmentation) and fixes some possible memory leaks due to missing free statements. I also moved some static buffers (eg buffers which are created once and then reused) into the global memory. 

These commits aim to make ESPuino memor management more robust in case of errors (like if a malloc/realloc failes, we should not make things worse my not freeing the memory we requested up until then), 

I'm still expirience ~50 bytes of memory leak / track (meaning that after each track played, the avaliable heap is reduced by this amount), but I could not track them down. 
