### PR TITLE
i18n and captive portal bugfix 

### DIFF
--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -3,6 +3,7 @@
 	<head>
 		<title data-i18n="wifi.title"></title>
 		<meta charset="utf-8">
+		<meta name="viewport" content="width=300, initial-scale=1" />
         <script src="/js/i18next.min.js"></script>
         <script src="/js/i18nextHttpBackend.min.js"></script>
         <script src="/js/loc_i18next.min.js"></script>
@@ -35,34 +36,28 @@
 				background: #3498db;
 				color: #fff;
 				cursor: pointer;
-				width: 90%;
+				width: 90% !important;
 				height: 44px;
 				border-radius: 4px;
 				margin: 10px auto;
 				font-size: 15px;
-			}
-			.rebootmsg {
-				display: none;
-			}
-			.fas{
-				padding-right: 0.25em;
 			}
 		</style>
 	</head>
 	<body>
 		<form id="settings" action="/init" class="box" method="POST">
 			<h1 data-i18n="wifi.title">WiFi-configuration</h1>
-			<label for="ssid" data-i18n="[prepend]wifi.ssid.title">:</label><br>
+			<label for="ssid" data-i18n="wifi.ssid.title">SSID</label>:<br>
 			<input type="text" id="ssid" name="ssid" placeholder="SSID" required><br>
-			<label for="pwd" data-i18n="[prepend]wifi.password.title">:</label><br>
+			<label for="pwd" data-i18n="wifi.password.title">Password</label>:<br>
 			<input type="password" id="pwd" name="pwd" autocomplete="off" required><br>
-			<label for="hostname" data-i18n="[prepend]wifi.hostname.title">:</label><br>
-			<input type="text" id="hostname" name="hostname" placeholder="espuino" required><br><br>
-			<button type="submit" id="save-button" data-i18n="submit"></button>
+			<label for="hostname" data-i18n="wifi.hostname.title">Hostname</label>:<br>
+			<input type="text" id="hostname" name="hostname" value="espuino" required><br><br>
+			<button type="submit" class="btn" id="save-button" data-i18n="submit">Submit</button>
 		</form>
 		<form action="/restart" class="box">
 			<h1 data-i18n="wifi.restartPrompt">Ready to go?</h1>
-			<button type="submit" id="restart-button" data-i18n="restart" value="Reboot"></button>
+			<button type="submit" class="btn" id="restart-button" data-i18n="restart" value="Reboot">Reboot</button>
 		</form>
         
         <script>

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -113,6 +113,10 @@ void Web_Init(void) {
 		request->send(response);
 	});
 
+	wServer.onNotFound([](AsyncWebServerRequest *request){
+		request->redirect("/");
+	});
+
 	WWWData::registerRoutes(serveProgmemFiles);
 
 	wServer.on("/init", HTTP_POST, [](AsyncWebServerRequest *request) {


### PR DESCRIPTION
Commit 02ea49f fixes the i18n for the capitve portal on older Andriod WebKit viewers (or if javascript is disabled). It also sets the width of the viewport so the access point setup page can be used on a phone with touch screen.

Commit 6526dfa enables a dynamically allocated DNS server in captive portal mode to redirect all requests to the esp32. This enables Android (and iOS) to detect the [captive portal](https://en.wikipedia.org/wiki/Captive_portal) and automatically display the setup screen. 