### PR TITLE
Led Animation bugfix and improvements

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -801,6 +801,7 @@ void AudioPlayer_VolumeToQueueSender(const int32_t _newVolume, bool reAdjustRota
 	uint32_t _volume;
 	int32_t _volumeBuf = AudioPlayer_GetCurrentVolume();
 
+	Led_Indicate(LedIndicatorType::VolumeChange);
 	if (_newVolume < AudioPlayer_GetMinVolume()) {
 		Log_Println((char *) FPSTR(minLoudnessReached), LOGLEVEL_INFO);
 		return;

--- a/src/Cmd.cpp
+++ b/src/Cmd.cpp
@@ -274,9 +274,6 @@ void Cmd_Action(const uint16_t mod) {
 
 		case CMD_TELL_IP_ADDRESS: {
 			if (Wlan_IsConnected()) {
-				if (!gPlayProperties.pausePlay) {
-					AudioPlayer_TrackControlToQueueSender(PAUSEPLAY);
-				}
 				gPlayProperties.tellIpAddress = true;
 				gPlayProperties.currentSpeechActive = true;
 				gPlayProperties.lastSpeechActive = true;

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -224,18 +224,12 @@ void Led_SetButtonLedsEnabled(boolean value) {
 	}
 
 	bool CheckForPowerButtonAnimation() {
-		bool powerAnimation = false;
 		if (gShutdownButton < (sizeof(gButtons) / sizeof(gButtons[0])) - 1) { // Only show animation, if CMD_SLEEPMODE was assigned to BUTTON_n_LONG + button is pressed
-			if (!gButtons[gShutdownButton].currentState && (millis() - gButtons[gShutdownButton].firstPressedTimestamp >= 150) && gButtonInitComplete) {
-				powerAnimation = true;
-			}
-		} else {
-			gShutdownButton = (sizeof(gButtons) / sizeof(gButtons[0])) - 1; // If CMD_SLEEPMODE was not assigned to an enabled button, dummy-button is used
-			if (!gButtons[gShutdownButton].currentState) {
-				gButtons[gShutdownButton].currentState = true;
+			if (gButtons[gShutdownButton].isPressed && (millis() - gButtons[gShutdownButton].firstPressedTimestamp >= 150) && gButtonInitComplete) {
+				return true;
 			}
 		}
-		return powerAnimation;
+		return false;
 	}
 #endif
 

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -235,7 +235,6 @@ void Led_SetButtonLedsEnabled(boolean value) {
 
 #ifdef NEOPIXEL_ENABLE
 	static void Led_Task(void *parameter) {
-		static uint8_t hlastVolume = AudioPlayer_GetCurrentVolume();
 		static bool turnedOffLeds = false;
 		static uint8_t lastLedBrightness = Led_Brightness;
 		static CRGB leds[NUM_LEDS];
@@ -283,8 +282,7 @@ void Led_SetButtonLedsEnabled(boolean value) {
 				nextAnimation = LedAnimationType::VoltageWarning;
 			} else if (LED_INDICATOR_IS_SET(LedIndicatorType::Voltage)) {
 				nextAnimation = LedAnimationType::BatteryMeasurement;
-			} else if (hlastVolume != AudioPlayer_GetCurrentVolume()) {
-				hlastVolume = AudioPlayer_GetCurrentVolume();
+			} else if (LED_INDICATOR_IS_SET(LedIndicatorType::VolumeChange)) {
 				nextAnimation = LedAnimationType::Volume;
 			} else if (LED_INDICATOR_IS_SET(LedIndicatorType::Rewind)) {
 				LED_INDICATOR_CLEAR(LedIndicatorType::Rewind);
@@ -872,7 +870,6 @@ void Led_SetButtonLedsEnabled(boolean value) {
 		int32_t animationDelay = 0;
 		bool animationActive = true;
 		// static values
-		static uint8_t lastVolume = 0;
 		static uint16_t cyclesWaited = 0;
 
 		// wait for further volume changes within next 20ms for 50 cycles = 1s
@@ -907,8 +904,8 @@ void Led_SetButtonLedsEnabled(boolean value) {
 		FastLED.show();
 
 		// reset animation if volume changes
-		if (lastVolume != AudioPlayer_GetCurrentVolume() || startNewAnimation) {
-			lastVolume = AudioPlayer_GetCurrentVolume();
+		if (LED_INDICATOR_IS_SET(LedIndicatorType::VolumeChange) || startNewAnimation) {
+			LED_INDICATOR_CLEAR(LedIndicatorType::VolumeChange);
 			cyclesWaited = 0;
 		}
 
@@ -917,6 +914,7 @@ void Led_SetButtonLedsEnabled(boolean value) {
 			cyclesWaited ++;
 		} else {
 			animationActive = false;
+			cyclesWaited = 0;
 		}
 		return AnimationReturnType(animationActive, animationDelay);
 	}

--- a/src/Led.h
+++ b/src/Led.h
@@ -8,7 +8,8 @@ typedef enum class LedIndicator
 	PlaylistProgress,
 	Rewind,
 	Voltage,
-	VoltageWarning
+	VoltageWarning,
+	VolumeChange
 } LedIndicatorType;
 
 


### PR DESCRIPTION
This PR fixes the following 2 threads raised in the forum:

[Bug in Verbindung mit dem LED Ring und Multibutton](https://forum.espuino.de/t/bug-in-verbindung-mit-dem-led-ring-und-multibutton/1825)
The multi-button detection was using the change instead of the pressed state. This triggered the shutdown animation also in case of a Multi-Button press.

[Verhalten der Lautstärke-Anzeige auf dem LED-Ring](https://forum.espuino.de/t/verhalten-der-lautstaerke-anzeige-auf-dem-led-ring/1842)
Here, instead of listening to volume changes, the volume animation is triggered by `AudioPlayer_VolumeToQueueSender`. This allows to animate the volume even if min/max is already reached.