### PR TITLE
Lost feature „PLAY_LAST_RFID_AFTER_REBOOT“   for webstreaming (local m3u file)

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -19,6 +19,7 @@
 #include "Web.h"
 #include "Bluetooth.h"
 #include "Cmd.h"
+#include "main.h"
 
 #define AUDIOPLAYER_VOLUME_MAX 21u
 #define AUDIOPLAYER_VOLUME_MIN 0u
@@ -618,6 +619,7 @@ void AudioPlayer_Task(void *parameter) {
 			if (gPlayProperties.playMode == WEBSTREAM || (gPlayProperties.playMode == LOCAL_M3U && gPlayProperties.isWebstream)) { // Webstream
 				audioReturnCode = audio->connecttohost(*(gPlayProperties.playlist + gPlayProperties.currentTrackNumber));
 				gPlayProperties.playlistFinished = false;
+				gTriedToConnectToHost = true;
 			} else if (gPlayProperties.playMode != WEBSTREAM && !gPlayProperties.isWebstream) {
 				// Files from SD
 				if (!gFSystem.exists(*(gPlayProperties.playlist + gPlayProperties.currentTrackNumber))) { // Check first if file/folder exists

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -9,6 +9,7 @@
 #include "System.h"
 #include "Web.h"
 #include "MemX.h"
+#include "main.h"
 
 // HELPER //
 unsigned long wifiCheckLastTimestamp = 0;
@@ -161,6 +162,13 @@ void Wlan_Cyclic(void) {
 			
 			free(_ssid);
 			free(_pwd);
+			
+			#ifdef PLAY_LAST_RFID_AFTER_REBOOT
+				if (gPlayLastRfIdWhenWiFiConnected && gTriedToConnectToHost ) {
+					gPlayLastRfIdWhenWiFiConnected=false;
+					recoverLastRfidPlayedFromNvs(true);
+				}
+			#endif
 		}
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,10 @@
 #include "revision.h"
 #include "Power.h"
 #include "HallEffectSensor.h"
+#include "main.h"
 
+bool gPlayLastRfIdWhenWiFiConnected = false;
+bool gTriedToConnectToHost = false;
 
 // avoid PSRAM check while wake-up from deepsleep
 bool testSPIRAM(void) {
@@ -87,8 +90,8 @@ bool testSPIRAM(void) {
 	}
 
 	// Get last RFID-tag applied from NVS
-	void recoverLastRfidPlayedFromNvs(void) {
-		if (recoverLastRfid) {
+	void recoverLastRfidPlayedFromNvs(bool force) {
+		if (recoverLastRfid || force) {
 			if (System_GetOperationMode() == OPMODE_BLUETOOTH_SINK) { // Don't recover if BT-mode is desired
 				recoverLastRfid = false;
 				return;
@@ -99,6 +102,7 @@ bool testSPIRAM(void) {
 				Log_Println((char *) FPSTR(unableToRestoreLastRfidFromNVS), LOGLEVEL_INFO);
 			} else {
 				xQueueSend(gRfidCardQueue, lastRfidPlayed.c_str(), 0);
+				gPlayLastRfIdWhenWiFiConnected = !force;
 				snprintf(Log_Buffer, Log_BufferLength, "%s: %s", (char *) FPSTR(restoredLastRfidFromNVS), lastRfidPlayed.c_str());
 				Log_Println(Log_Buffer, LOGLEVEL_INFO);
 			}

--- a/src/main.h
+++ b/src/main.h
@@ -1,0 +1,9 @@
+#pragma once
+
+extern bool gPlayLastRfIdWhenWiFiConnected;
+extern bool gTriedToConnectToHost;
+
+#ifdef PLAY_LAST_RFID_AFTER_REBOOT
+  extern void recoverLastRfidPlayedFromNvs(bool force = false);
+#endif
+


### PR DESCRIPTION
Brings this feature back.