### PR TITLE
Platformio.ini Refractoring and Bugfix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,12 +15,17 @@ default_envs = lolin_d32_pro_sdmmc_pe
 [env]
 board_build.flash_mode = qio
 board_build.bootloader = dio
+board_build.partitions = custom_4mb_noota.csv
 ;platform = espressif32@<=3.5.0
-platform = espressif32@<=6.1.0
+platform = espressif32@^6.1.0
 ;platform = espressif32
 ;platform = https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream
 framework = arduino
 monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+;monitor_port = /dev/cu.SLAB_USBtoUART
+;upload_port = /dev/cu.SLAB_USBtoUART
+;upload_speed = 115200
 extra_scripts =
     pre:gitVersion.py
     pre:processHtml.py
@@ -51,8 +56,6 @@ board = esp-wrover-kit
 lib_deps =
     ${env.lib_deps}
     https://github.com/kkloesener/AC101.git
-;board_build.partitions = huge_app.csv
-board_build.partitions = custom_4mb_noota.csv
 build_flags = -DHAL=2
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
@@ -61,53 +64,32 @@ build_flags = -DHAL=2
               -DCONFIG_ASYNC_TCP_USE_WDT=1
 board_upload.maximum_size = 16777216
 board_upload.flash_size = 16MB
-monitor_filters = esp32_exception_decoder
 
 [env:lolin32]
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin32.html
 board = lolin32
-;board_build.partitions = huge_app.csv
-board_build.partitions = custom_4mb_noota.csv
 build_flags = -DHAL=1
               -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
               -DCONFIG_ASYNC_TCP_USE_WDT=1
-;upload_port = /dev/cu.SLAB_USBtoUART
-;monitor_port = /dev/cu.SLAB_USBtoUART
-monitor_filters = esp32_exception_decoder
 
 [env:lolin_d32]
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin_d32.html
 board = lolin_d32
-;board_build.partitions = huge_app.csv
-board_build.partitions = custom_4mb_noota.csv
 build_flags = -DHAL=3
               -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
               -DCONFIG_ASYNC_TCP_USE_WDT=1
-;upload_port = /dev/cu.wchusbserial1410
-;monitor_port = /dev/cu.wchusbserial1410
-monitor_filters = esp32_exception_decoder
 
 [env:lolin_d32_sdmmc_pe]
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin_d32.html
 board = lolin_d32
-;board_build.partitions = huge_app.csv
-board_build.partitions = custom_4mb_noota.csv
 build_flags = -DHAL=9
               -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
               -DCONFIG_ASYNC_TCP_USE_WDT=1
-;upload_port = /dev/cu.wchusbserial1410
-;monitor_port = /dev/cu.wchusbserial1410
-monitor_filters = esp32_exception_decoder
 
 [env:lolin_d32_pro]
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin_d32_pro.html
 board = lolin_d32_pro
-;board_build.partitions = huge_app.csv
-;board_build.partitions = custom_4mb_noota.csv
 board_build.partitions = custom_16mb_ota.csv
-;upload_port = /dev/cu.wchusbserial1410
-;monitor_port = /dev/cu.wchusbserial1410
-monitor_filters = esp32_exception_decoder
 build_flags = -DHAL=4
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
@@ -121,12 +103,7 @@ board_upload.flash_size = 16MB
 [env:lolin_d32_pro_sdmmc_pe]
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin_d32_pro.html
 board = lolin_d32_pro
-;board_build.partitions = huge_app.csv
-;board_build.partitions = custom_4mb_noota.csv
 board_build.partitions = custom_16mb_ota.csv
-;upload_port = /dev/cu.wchusbserial1410
-;monitor_port = /dev/cu.wchusbserial1410
-monitor_filters = esp32_exception_decoder
 build_flags = -DHAL=7
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
@@ -141,20 +118,10 @@ board_upload.flash_size = 16MB
 [env:nodemcu-32s]
 ;https://docs.platformio.org/en/latest/boards/espressif32/nodemcu-32s.html
 board = nodemcu-32s
-;board_build.partitions = huge_app.csv
-board_build.partitions = custom_4mb_noota.csv
-;upload_port = /dev/cu.SLAB_USBtoUART
-;monitor_port = /dev/cu.SLAB_USBtoUART
-monitor_filters = esp32_exception_decoder
 
 [env:az-delivery-devkit-v4]
 ;https://docs.platformio.org/en/latest/boards/espressif32/az-delivery-devkit-v4.html
 board = az-delivery-devkit-v4
-;board_build.partitions = huge_app.csv
-board_build.partitions = custom_4mb_noota.csv
-;upload_port = /dev/cu.SLAB_USBtoUART
-;monitor_port = /dev/cu.SLAB_USBtoUART
-monitor_filters = esp32_exception_decoder
 build_flags = -DHAL=8
               -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
               -DCONFIG_ASYNC_TCP_USE_WDT=1
@@ -163,11 +130,6 @@ build_flags = -DHAL=8
 [env:ttgo_t8]
 ;https://docs.platformio.org/en/latest/boards/espressif32/esp-wrover-kit.html
 board = esp-wrover-kit
-;board_build.partitions = huge_app.csv
-board_build.partitions = custom_4mb_noota.csv
-;upload_port = /dev/cu.SLAB_USBtoUART
-;monitor_port = /dev/cu.SLAB_USBtoUART
-monitor_filters = esp32_exception_decoder
 build_flags = -DHAL=5
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
@@ -178,11 +140,7 @@ build_flags = -DHAL=5
 [env:complete]
 ;https://docs.platformio.org/en/latest/boards/espressif32/esp-wrover-kit.html
 board = esp-wrover-kit
-;board_build.partitions = huge_app.csv
 board_build.partitions = custom_16mb_ota.csv
-;upload_port = /dev/tty.wchusbserial1410
-;monitor_port = /dev/tty.wchusbserial1410
-monitor_filters = esp32_exception_decoder
 build_flags = -DHAL=6
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
@@ -205,7 +163,6 @@ build_flags = -DHAL=99
               -DBOARD_HAS_16MB_FLASH_AND_OTA_SUPPORT ; 8MB is fine
 board_upload.maximum_size = 8388608
 board_upload.flash_size = 8MB
-monitor_filters = esp32_exception_decoder
 
 ;;; Change upload/monitor-port of your board regarding your operating-system and develboard!
 ;MAC: /dev/cu.SLAB_USBtoUART / /dev/cu.wchusbserial1420 / /dev/cu.wchusbserial1410
@@ -214,14 +171,12 @@ monitor_filters = esp32_exception_decoder
 
 [env:museluxe]
 board = esp-wrover-kit
-board_build.partitions = custom_4mb_noota.csv
 build_flags = -DHAL=10
 	          -DBOARD_HAS_PSRAM
 	          -mfix-esp32-psram-cache-issue
 	          -DLOG_BUFFER_SIZE=10240
               -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
               -DCONFIG_ASYNC_TCP_USE_WDT=1
-monitor_filters = esp32_exception_decoder
 
 
 [env:esp32-s3-devkitc-1]
@@ -238,4 +193,3 @@ build_flags = -DHAL=99
               -DLOG_BUFFER_SIZE=10240
               -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
               -DCONFIG_ASYNC_TCP_USE_WDT=1
-monitor_filters = esp32_exception_decoder

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,53 +50,52 @@ platform_packages =
     ;platformio/framework-arduinoespressif32 @ https://github.com/tuniii/arduino-esp32-v1.0.6-wt#v1.0.6-patched
     ;platformio/tool-esptoolpy @ ~1.30100
     ;framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.1-RC1
+build_flags =
+    -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
+    -DCONFIG_ASYNC_TCP_USE_WDT=1
+;    -DCORE_DEBUG_LEVEL=6
 
 [env:esp32-a1s]
 board = esp-wrover-kit
 lib_deps =
     ${env.lib_deps}
     https://github.com/kkloesener/AC101.git
-build_flags = -DHAL=2
+build_flags = ${env.build_flags}
+              -DHAL=2
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
               -DLOG_BUFFER_SIZE=10240
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
 board_upload.maximum_size = 16777216
 board_upload.flash_size = 16MB
 
 [env:lolin32]
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin32.html
 board = lolin32
-build_flags = -DHAL=1
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
+build_flags = ${env.build_flags}
+              -DHAL=1
 
 [env:lolin_d32]
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin_d32.html
 board = lolin_d32
-build_flags = -DHAL=3
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
+build_flags = ${env.build_flags}
+              -DHAL=3
 
 [env:lolin_d32_sdmmc_pe]
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin_d32.html
 board = lolin_d32
-build_flags = -DHAL=9
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
+build_flags = ${env.build_flags}
+              -DHAL=9
 
 [env:lolin_d32_pro]
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin_d32_pro.html
 board = lolin_d32_pro
 board_build.partitions = custom_16mb_ota.csv
-build_flags = -DHAL=4
+build_flags = ${env.build_flags}
+              -DHAL=4
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
               -DLOG_BUFFER_SIZE=10240
               -DBOARD_HAS_16MB_FLASH_AND_OTA_SUPPORT
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
 board_upload.maximum_size = 16777216
 board_upload.flash_size = 16MB
 
@@ -104,14 +103,12 @@ board_upload.flash_size = 16MB
 ;https://docs.platformio.org/en/latest/boards/espressif32/lolin_d32_pro.html
 board = lolin_d32_pro
 board_build.partitions = custom_16mb_ota.csv
-build_flags = -DHAL=7
+build_flags = ${env.build_flags}
+              -DHAL=7
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
               -DLOG_BUFFER_SIZE=10240
               -DBOARD_HAS_16MB_FLASH_AND_OTA_SUPPORT
-              ;-DCORE_DEBUG_LEVEL=5
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
 board_upload.maximum_size = 16777216
 board_upload.flash_size = 16MB
 
@@ -122,32 +119,29 @@ board = nodemcu-32s
 [env:az-delivery-devkit-v4]
 ;https://docs.platformio.org/en/latest/boards/espressif32/az-delivery-devkit-v4.html
 board = az-delivery-devkit-v4
-build_flags = -DHAL=8
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
+build_flags = ${env.build_flags}
+              -DHAL=8
 
 
 [env:ttgo_t8]
 ;https://docs.platformio.org/en/latest/boards/espressif32/esp-wrover-kit.html
 board = esp-wrover-kit
-build_flags = -DHAL=5
+build_flags = ${env.build_flags}
+              -DHAL=5
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
               -DLOG_BUFFER_SIZE=10240
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
 
 [env:complete]
 ;https://docs.platformio.org/en/latest/boards/espressif32/esp-wrover-kit.html
 board = esp-wrover-kit
 board_build.partitions = custom_16mb_ota.csv
-build_flags = -DHAL=6
+build_flags = ${env.build_flags}
+              -DHAL=6
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
               -DLOG_BUFFER_SIZE=10240
               -DBOARD_HAS_16MB_FLASH_AND_OTA_SUPPORT
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
 board_upload.maximum_size = 16777216
 board_upload.flash_size = 16MB
 
@@ -156,7 +150,8 @@ board_upload.flash_size = 16MB
 ;https://docs.platformio.org/en/latest/boards/espressif32/esp-wrover-kit.html
 board = esp-wrover-kit
 board_build.partitions = custom_8mb_ota.csv
-build_flags = -DHAL=99
+build_flags = ${env.build_flags}
+              -DHAL=99
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
               -DLOG_BUFFER_SIZE=10240
@@ -171,12 +166,11 @@ board_upload.flash_size = 8MB
 
 [env:museluxe]
 board = esp-wrover-kit
-build_flags = -DHAL=10
+build_flags = ${env.build_flags}
+              -DHAL=10
 	          -DBOARD_HAS_PSRAM
 	          -mfix-esp32-psram-cache-issue
 	          -DLOG_BUFFER_SIZE=10240
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1
 
 
 [env:esp32-s3-devkitc-1]
@@ -188,8 +182,6 @@ platform = espressif32
 board_build.mcu = esp32s3
 
 ; change MCU frequency
-board_build.f_cpu = 240000000L
-build_flags = -DHAL=99
+build_flags = ${env.build_flags}
+              -DHAL=99
               -DLOG_BUFFER_SIZE=10240
-              -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
-              -DCONFIG_ASYNC_TCP_USE_WDT=1


### PR DESCRIPTION
This commit moves the common flags (like monitor_filter and build_flags) to the global env in platformio. 
This allows the central maintanance of the build_flags and reduce the number of copy & paste errors.