### PR TITLE
Small bugfixes

### DIFF
--- a/html/management.html
+++ b/html/management.html
@@ -7,7 +7,7 @@
 	<link rel="shortcut icon" type="image/x-icon" href="/favicon">
 	<link rel="stylesheet" href="https://espuino.de/espuino/css/bootstrap.min.css">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/themes/default/style.min.css"/>
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css"/>
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"/>
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css"/>
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/11.0.2/css/bootstrap-slider.min.css" />
 	<script src="https://espuino.de/espuino/js/jquery.min.js"></script>
@@ -678,10 +678,13 @@
 			var lastFolder = cur['id'].split('/').filter(function (el) {
 				return el.trim().length > 0;
 			}).pop();
-			if ((/\.(mp3|MP3|ogg|wav|WAV|OGG|wma|WMA|acc|ACC|flac|FLAC|m4a|M4A)$/i).test(lastFolder)) {
+			if ((/\.(mp3|ogg|wav|wma|acc|flac|m4a|opus)$/i).test(lastFolder)) {
 				data.instance.set_type(data.instance._model.data[key], 'audio');
 			} else
-			if ((/\.(png|PNG|jpg|JPG|jpeg|JPEG|bmp|BMP|gif|GIF)$/i).test(lastFolder)) {
+			if ((/\.(m3u|m3u8|asx|pls)$/i).test(lastFolder)) {
+				data.instance.set_type(data.instance._model.data[key], 'playlist');
+			} else
+			if ((/\.(png|jpg|jpeg|bmp|gif|webp)$/i).test(lastFolder)) {
 				data.instance.set_type(data.instance._model.data[key], 'image');
 				data.instance.disable_node(data.instance._model.data[key]);
 			} else {
@@ -711,7 +714,7 @@
 			$('#playMode option').removeAttr('selected').filter('[value=3]').attr('selected', true);
 		}
 
-		if (data.node.type == "audio") {
+		if ((data.node.type == "audio") || (data.node.type == "playlist")) {
 			$('.option-file').show();
 			$('.option-folder').hide();
 			$('#playMode option').removeAttr('selected').filter('[value=1]').attr('selected', true);
@@ -974,9 +977,11 @@
 
 		if(data.dir) {
 			type = "folder";
-		} else if ((/\.(mp3|MP3|ogg|wav|WAV|OGG|wma|WMA|acc|ACC|m4a|M4A|flac|FLAC)$/i).test(data.name)) {
+		} else if ((/\.(mp3|ogg|wav|wma|acc|m4a|flac|opus)$/i).test(data.name)) {
 			type = "audio";
-		} else if ((/\.(png|PNG|jpg|JPG|jpeg|JPEG|bmp|BMP|gif|GIF)$/i).test(data.name)) {
+		} else if ((/\.(m3u|m3u8|asx|pls)$/i).test(data.name)) {
+			type = "playlist";
+		} else if ((/\.(png|jpg|jpeg|bmp|gif|webp)$/i).test(data.name)) {
 			type = "image";
 		} else {
 			type = "file";
@@ -984,6 +989,7 @@
 
 		return type;
 	}
+
 
 
 	function addFileDirectory(parent, data) {
@@ -1026,6 +1032,9 @@
 						'audio': {
 							'icon': "fa fa-file-audio"
 						},
+						'playlist': {
+							'icon': "fa fa-file-alt"
+						},
 						'image': {
 							'icon': "fa fa-file-image"
 						},
@@ -1064,7 +1073,7 @@
 								if (node.data.directory) {
 									playMode = 5;
 								} else {
-									if ((/\.(m3u|M3U)$/i).test(node.data.path)) {
+									if ((/\.(m3u|m3u8|asx|pls)$/i).test(node.data.path)) {
 										playMode = 11;
 									}
 								}

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -105,11 +105,14 @@ bool fileValid(const char *_fileItem) {
 	// make file extension to lowercase (compare case insenstive)
 	char *lFileItem;
 	lFileItem = x_strdup(_fileItem);
+	if (lFileItem == NULL) {
+		return false;
+	}
 	lFileItem = strlwr(lFileItem);
 	const char ch = '/';
 	char *subst;
 	subst = strrchr(lFileItem, ch); // Don't use files that start with .
-	return (!startsWith(subst, (char *) "/.")) && (
+	bool isValid = (!startsWith(subst, (char *) "/.")) && (
 			// audio file formats
 			endsWith(lFileItem, ".mp3") || 
 			endsWith(lFileItem, ".aac") || 
@@ -123,6 +126,8 @@ bool fileValid(const char *_fileItem) {
 			endsWith(lFileItem, ".m3u8") || 
 			endsWith(lFileItem, ".pls") || 
 			endsWith(lFileItem, ".asx"));
+	free(lFileItem);
+	return isValid;
 }
 
 

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -160,7 +160,6 @@ char *SdCard_pickRandomSubdirectory(char *_directory) {
 			break;
 		}
 		if (!fileItem.isDirectory()) {
-			fileItem.close();
 			continue;
 		} else {
 			#if ESP_ARDUINO_VERSION_MAJOR >= 2
@@ -168,7 +167,6 @@ char *SdCard_pickRandomSubdirectory(char *_directory) {
 			#else
 				strncpy(buffer, (char *) fileItem.name(), 255);
 			#endif
-			fileItem.close();
 			// Log_Printf(LOGLEVEL_INFO, nameOfFileFound, buffer);
 			if ((strlen(subdirectoryList) + strlen(buffer) + 2) >= allocCount * allocSize) {
 				char *tmp = (char *) realloc(subdirectoryList, ++allocCount * allocSize);
@@ -395,7 +393,6 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 				break;
 			}
 			if (fileItem.isDirectory()) {
-				fileItem.close();
 				continue;
 			} else {
 				#if ESP_ARDUINO_VERSION_MAJOR >= 2
@@ -403,7 +400,6 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 				#else
 					strncpy(fileNameBuf, (char *) fileItem.name(), sizeof(fileNameBuf) / sizeof(fileNameBuf[0]));
 				#endif
-				fileItem.close();
 				// Don't support filenames that start with "." and only allow .mp3 and other supported audio formats
 				if (fileValid(fileNameBuf)) {
 					// Log_Printf(LOGLEVEL_INFO, "%s: %s", (char *) FPSTR(nameOfFileFound), fileNameBuf);

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -102,18 +102,27 @@ void SdCard_PrintInfo() {
 
 // Check if file-type is correct
 bool fileValid(const char *_fileItem) {
+	// make file extension to lowercase (compare case insenstive)
+	char *lFileItem;
+	lFileItem = x_strdup(_fileItem);
+	lFileItem = strlwr(lFileItem);
 	const char ch = '/';
 	char *subst;
-	subst = strrchr(_fileItem, ch); // Don't use files that start with .
-
+	subst = strrchr(lFileItem, ch); // Don't use files that start with .
 	return (!startsWith(subst, (char *) "/.")) && (
-			endsWith(_fileItem, ".mp3") || endsWith(_fileItem, ".MP3") ||
-			endsWith(_fileItem, ".aac") || endsWith(_fileItem, ".AAC") ||
-			endsWith(_fileItem, ".m3u") || endsWith(_fileItem, ".M3U") ||
-			endsWith(_fileItem, ".m4a") || endsWith(_fileItem, ".M4A") ||
-			endsWith(_fileItem, ".wav") || endsWith(_fileItem, ".WAV") ||
-			endsWith(_fileItem, ".flac") || endsWith(_fileItem, ".FLAC") ||
-			endsWith(_fileItem, ".asx") || endsWith(_fileItem, ".ASX"));
+			// audio file formats
+			endsWith(lFileItem, ".mp3") || 
+			endsWith(lFileItem, ".aac") || 
+			endsWith(lFileItem, ".m4a") || 
+			endsWith(lFileItem, ".wav") || 
+			endsWith(lFileItem, ".flac") || 
+			endsWith(lFileItem, ".ogg") || 
+			endsWith(lFileItem, ".opus") || 
+			// playlist file formats
+			endsWith(lFileItem, ".m3u") || 
+			endsWith(lFileItem, ".m3u8") || 
+			endsWith(lFileItem, ".pls") || 
+			endsWith(lFileItem, ".asx"));
 }
 
 
@@ -146,6 +155,7 @@ char *SdCard_pickRandomSubdirectory(char *_directory) {
 			break;
 		}
 		if (!fileItem.isDirectory()) {
+			fileItem.close();
 			continue;
 		} else {
 			#if ESP_ARDUINO_VERSION_MAJOR >= 2
@@ -153,7 +163,7 @@ char *SdCard_pickRandomSubdirectory(char *_directory) {
 			#else
 				strncpy(buffer, (char *) fileItem.name(), 255);
 			#endif
-
+			fileItem.close();
 			// Log_Printf(LOGLEVEL_INFO, nameOfFileFound, buffer);
 			if ((strlen(subdirectoryList) + strlen(buffer) + 2) >= allocCount * allocSize) {
 				char *tmp = (char *) realloc(subdirectoryList, ++allocCount * allocSize);
@@ -301,6 +311,11 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 			serializedPlaylist[0] = '#';
 			while (fileOrDirectory.available() > 0) {
 				buf = fileOrDirectory.read();
+				if (buf == '#') {
+					// skip M3U comment lines starting with #
+					fileOrDirectory.readStringUntil('\n');
+					continue;
+				}
 				if (fPos+1 >= allocCount * allocSize) {
 					char *tmp = (char *) realloc(serializedPlaylist, ++allocCount * allocSize);
 					Log_Println((char *) FPSTR(reallocCalled), LOGLEVEL_DEBUG);
@@ -375,6 +390,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 				break;
 			}
 			if (fileItem.isDirectory()) {
+				fileItem.close();
 				continue;
 			} else {
 				#if ESP_ARDUINO_VERSION_MAJOR >= 2
@@ -382,8 +398,8 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 				#else
 					strncpy(fileNameBuf, (char *) fileItem.name(), sizeof(fileNameBuf) / sizeof(fileNameBuf[0]));
 				#endif
-
-				// Don't support filenames that start with "." and only allow .mp3
+				fileItem.close();
+				// Don't support filenames that start with "." and only allow .mp3 and other supported audio formats
 				if (fileValid(fileNameBuf)) {
 					// Log_Printf(LOGLEVEL_INFO, "%s: %s", (char *) FPSTR(nameOfFileFound), fileNameBuf);
 					if ((strlen(serializedPlaylist) + strlen(fileNameBuf) + 2) >= allocCount * allocSize) {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1067,6 +1067,10 @@ void explorerHandleDeleteRequest(AsyncWebServerRequest *request) {
 		param = request->getParam("path");
 		convertFilenameToAscii(param->value(), filePath);
 		if (gFSystem.exists(filePath)) {
+			// stop playback, file to delete might be in use
+			if (!gPlayProperties.pausePlay) {
+				Cmd_Action(CMD_STOP);
+			}
 			file = gFSystem.open(filePath);
 			if (file.isDirectory()) {
 				if (explorerDeleteDirectory(file)) {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1068,9 +1068,7 @@ void explorerHandleDeleteRequest(AsyncWebServerRequest *request) {
 		convertFilenameToAscii(param->value(), filePath);
 		if (gFSystem.exists(filePath)) {
 			// stop playback, file to delete might be in use
-			if (!gPlayProperties.pausePlay) {
-				Cmd_Action(CMD_STOP);
-			}
+			Cmd_Action(CMD_STOP);
 			file = gFSystem.open(filePath);
 			if (file.isDirectory()) {
 				if (explorerDeleteDirectory(file)) {


### PR DESCRIPTION
- fix crash playing a .Mp3/.mP3 files (make file extension really case-insensitive). .mp3, MP3 was OK, .Mp3, .mP3 crashed
- fix reading enhanced M3U playlist with comment lines ("#EXTINF"), see https://forum.espuino.de/t/crash-beim-2-abspielen-einer-m3u-playlist/1921
- ~~fix mem-leak in loop openNextFile(), close to free file object~~
- add own icon for playlists in Web-ui
- JavaScript .test() is case-insensitive, remove unnecessary comparison
- add all audio formats supported by the ESP32-audioI2S library (.opus, .pls, .asx)
- Stop playing before explorer contextmenu DELETE (can crash if deleted file is playing currently)

I did not found a better icon in free font-awesome for a playlist:
![grafik](https://user-images.githubusercontent.com/11274319/232339887-b4c9798b-26d9-47bd-9593-b79af2feb402.png)

I hope codestyle/formatting is OK..