### PR TITLE
(re-)allow to compile without any RFID-reader

### DIFF
--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -1087,3 +1087,16 @@ void Led_SetButtonLedsEnabled(boolean value) {
 		return AnimationReturnType(animationActive, animationDelay, refresh);
 	}
 #endif
+
+void Led_TaskPause(void) {
+	#ifdef NEOPIXEL_ENABLE
+		vTaskSuspend(Led_TaskHandle);
+		FastLED.clear(true);
+	#endif
+}
+
+void Led_TaskResume(void) {
+	#ifdef NEOPIXEL_ENABLE
+		vTaskResume(Led_TaskHandle);
+	#endif
+}

--- a/src/Led.h
+++ b/src/Led.h
@@ -64,3 +64,5 @@ void Led_ResetToInitialBrightness(void);
 void Led_ResetToNightBrightness(void);
 uint8_t Led_GetBrightness(void);
 void Led_SetBrightness(uint8_t value);
+void Led_TaskPause(void);
+void Led_TaskResume(void);

--- a/src/Rfid.h
+++ b/src/Rfid.h
@@ -18,5 +18,7 @@ extern char gCurrentRfidTagId[cardIdStringSize];
 void Rfid_Init(void);
 void Rfid_Cyclic(void);
 void Rfid_Exit(void);
+void Rfid_TaskPause(void);
+void Rfid_TaskResume(void);
 void Rfid_WakeupCheck(void);
 void Rfid_PreferenceLookupHandler(void);

--- a/src/RfidCommon.cpp
+++ b/src/RfidCommon.cpp
@@ -99,6 +99,10 @@ void Rfid_PreferenceLookupHandler(void) {
 	#endif
 }
 
+#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
+	extern TaskHandle_t rfidTaskHandle;
+#endif
+
 void Rfid_TaskPause(void) {
 	#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
 		vTaskSuspend(rfidTaskHandle);

--- a/src/RfidCommon.cpp
+++ b/src/RfidCommon.cpp
@@ -17,9 +17,14 @@ char gCurrentRfidTagId[cardIdStringSize] = ""; // No crap here as otherwise it c
 	char gOldRfidTagId[cardIdStringSize] = "X";     // Init with crap
 #endif
 
+// check if we have RFID-reader enabled
+#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
+	#define RFID_READER_ENABLED 1
+#endif
+
 // Tries to lookup RFID-tag-string in NVS and extracts parameter from it if found
 void Rfid_PreferenceLookupHandler(void) {
-	#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
+	#if defined (RFID_READER_ENABLED)
 		BaseType_t rfidStatus;
 		char rfidTagId[cardIdStringSize];
 		char _file[255];
@@ -99,17 +104,17 @@ void Rfid_PreferenceLookupHandler(void) {
 	#endif
 }
 
-#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
+#if defined (RFID_READER_ENABLED)
 	extern TaskHandle_t rfidTaskHandle;
 #endif
 
 void Rfid_TaskPause(void) {
-	#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
+	#if defined (RFID_READER_ENABLED)
 		vTaskSuspend(rfidTaskHandle);
 	#endif
 }
 void Rfid_TaskResume(void) {
-	#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
+	#if defined (RFID_READER_ENABLED)
 		vTaskResume(rfidTaskHandle);
 	#endif
 }

--- a/src/RfidCommon.cpp
+++ b/src/RfidCommon.cpp
@@ -98,3 +98,15 @@ void Rfid_PreferenceLookupHandler(void) {
 		}
 	#endif
 }
+
+void Rfid_TaskPause(void) {
+	#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
+		vTaskSuspend(rfidTaskHandle);
+	#endif
+}
+void Rfid_TaskResume(void) {
+	#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
+		vTaskResume(rfidTaskHandle);
+	#endif
+}
+

--- a/src/System.h
+++ b/src/System.h
@@ -4,8 +4,6 @@
 extern Preferences gPrefsRfid;
 extern Preferences gPrefsSettings;
 extern TaskHandle_t AudioTaskHandle;
-extern TaskHandle_t rfidTaskHandle;
-extern TaskHandle_t Led_TaskHandle;
 
 
 void System_Init(void);

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -827,11 +827,9 @@ void explorerHandleFileStorageTask(void *parameter) {
 	uploadFile = gFSystem.open((char *)parameter, "w");
 
 	// pause some tasks to get more free CPU time for the upload
-	#ifdef NEOPIXEL_ENABLE
-		vTaskSuspend(Led_TaskHandle);
-	#endif
 	vTaskSuspend(AudioTaskHandle);
-	vTaskSuspend(rfidTaskHandle);
+	Led_TaskPause(); 
+	Rfid_TaskPause();
 
 	for (;;) {
 
@@ -861,11 +859,9 @@ void explorerHandleFileStorageTask(void *parameter) {
 			if (lastUpdateTimestamp + maxUploadDelay * 1000 < millis()) {
 				Log_Println(webTxCanceled, LOGLEVEL_ERROR);
 				// resume the paused tasks
-				#ifdef NEOPIXEL_ENABLE
-					vTaskResume(Led_TaskHandle);
-				#endif
+				Led_TaskResume();
 				vTaskResume(AudioTaskHandle);
-				vTaskResume(rfidTaskHandle);
+				Rfid_TaskResume();
 				// just delete task without signaling (abort)
 				vTaskDelete(NULL);
 				return;
@@ -880,11 +876,9 @@ void explorerHandleFileStorageTask(void *parameter) {
 		#endif
 	}
 	// resume the paused tasks
-	#ifdef NEOPIXEL_ENABLE
-		vTaskResume(Led_TaskHandle);
-	#endif
+	Led_TaskResume();
 	vTaskResume(AudioTaskHandle);
-	vTaskResume(rfidTaskHandle);
+	Rfid_TaskResume();
 	// send signal to upload function to terminate
 	xQueueSend(explorerFileUploadStatusQueue, &value, 0);
 	vTaskDelete(NULL);


### PR DESCRIPTION
All non-essential tasks such as audio player, RFID and LED are paused to speed up the web upload.
Until now, a global task handle was used for this. However, this no longer compiles if no RFID-reader is selected. This could be the case for testing or special applications such as a pure web player.
This PR allows compiling even without an RFID reader and does not need global declarations. It also clear all LEDs instead of just freezing..