### PR TITLE
improve neopixel display in Bluetooth speaker mode (BT-Sink)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ to (re-)enable/disable WiFi:
 ESPuino can be used as Bluetooth sink (A2DP sink). In this mode you can stream audio (e.g. from a
 mobile device) via Bluetooth to your ESPuino. This mode can be enabled/disabled via a RFID
 modification card or by assigning action `CMD_TOGGLE_BLUETOOTH_MODE` to a button (or multi-button).
-Applying this will restart ESPuino immediately. Activated Bluetooth is indicated by four slow
-rotating _blue_ LEDs.
+Applying this will restart ESPuino immediately. Activated Bluetooth is indicated by four 
+slow rotating _blue-violet_ LEDs. After the Bluetooth device is paired the LEDs turn to blue.
 
 ### ESPuino as A2DP source (stream from ESPuino)
 

--- a/src/Bluetooth.cpp
+++ b/src/Bluetooth.cpp
@@ -37,6 +37,12 @@
 	// for esp_a2d_connection_state_t see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/bluetooth/esp_a2dp.html#_CPPv426esp_a2d_connection_state_t
 	void connection_state_changed(esp_a2d_connection_state_t state, void *ptr) {
 		Log_Printf(LOGLEVEL_INFO, "Bluetooth %s => connection state: %s", getType(), ((BluetoothA2DPCommon *)ptr)->to_str(state));
+		if (System_GetOperationMode() == OPMODE_BLUETOOTH_SINK) {
+			// for Neopixel (indicator LEDs) use the webstream mode
+			gPlayProperties.isWebstream = false;
+			gPlayProperties.pausePlay = false;
+			gPlayProperties.playlistFinished = true;
+		}
 	}
 #endif
 
@@ -45,6 +51,13 @@
 	// for esp_a2d_audio_state_t see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/bluetooth/esp_a2dp.html#_CPPv421esp_a2d_audio_state_t
 	void audio_state_changed(esp_a2d_audio_state_t state, void *ptr) {
 		Log_Printf(LOGLEVEL_INFO, "Bluetooth %s => audio state: %s", getType(), ((BluetoothA2DPCommon *)ptr)->to_str(state));
+		if (System_GetOperationMode() == OPMODE_BLUETOOTH_SINK) {
+			// set play/pause status
+			gPlayProperties.pausePlay = (state != ESP_A2D_AUDIO_STATE_STARTED);
+			// for Neopixel (indicator LEDs) use the webstream mode
+			gPlayProperties.playlistFinished = false;
+			gPlayProperties.isWebstream = true;
+		}	
 	}
 #endif
 
@@ -144,18 +157,15 @@
 
 void Bluetooth_VolumeChanged(int _newVolume) {
 	#ifdef BLUETOOTH_ENABLE
-		Log_Printf(LOGLEVEL_INFO, "Bluetooth => volume changed:  %d !", _newVolume);
+		if ((_newVolume < 0) || (_newVolume > 0x7F)) {
+			return;
+		}
+		// map bluetooth volume (0..127) to ESPuino volume (0..21) to
 		uint8_t _volume;
-		if (_newVolume < int(BLUETOOTHPLAYER_VOLUME_MIN)) {
-			return;
-		} else if (_newVolume > BLUETOOTHPLAYER_VOLUME_MAX) {
-			return;
-		} else {
-			// map bluetooth volume (0..127) to ESPuino volume (0..21) to
-			_volume = map(_newVolume, 0, 0x7F, BLUETOOTHPLAYER_VOLUME_MIN, BLUETOOTHPLAYER_VOLUME_MAX);
-			AudioPlayer_SetCurrentVolume(_volume);
-			// update rotary encoder
-			RotaryEncoder_Readjust();
+		_volume = map(_newVolume, 0, 0x7F, BLUETOOTHPLAYER_VOLUME_MIN, BLUETOOTHPLAYER_VOLUME_MAX);
+		if (AudioPlayer_GetCurrentVolume() != _volume) {
+			Log_Printf(LOGLEVEL_INFO, "Bluetooth => volume changed:  %d !", _volume);
+			AudioPlayer_VolumeToQueueSender(_volume, true);
 		}
 	#endif
 }
@@ -302,14 +312,11 @@ bool Bluetooth_Source_SendAudioData(uint32_t* sample) {
 	#endif
 }
 
-bool Bluetooth_Source_Connected() {
+bool Bluetooth_Device_Connected() {
 	#ifdef BLUETOOTH_ENABLE
 		// send audio data to ringbuffer
-		if ((System_GetOperationMode() == OPMODE_BLUETOOTH_SOURCE) && (a2dp_source) && a2dp_source->is_connected()) {
-			return true;
-		} else {
-			return false;
-		}
+		return  (((System_GetOperationMode() == OPMODE_BLUETOOTH_SINK) && (a2dp_sink) && a2dp_sink->is_connected()) ||
+				((System_GetOperationMode() == OPMODE_BLUETOOTH_SOURCE) && (a2dp_source) && a2dp_source->is_connected()));
 	#else
 		return false;
 	#endif

--- a/src/Bluetooth.cpp
+++ b/src/Bluetooth.cpp
@@ -216,9 +216,12 @@ void Bluetooth_Init(void) {
 			// start bluetooth source
 			a2dp_source->set_ssid_callback(scan_bluetooth_device_callback);
 			a2dp_source->start(get_data_channels);
-
-		    	btDeviceName = gPrefsSettings.getString("btDeviceName", nameBluetoothSourceDevice);
-			Log_Printf(LOGLEVEL_INFO, "Bluetooth source started, connect to device: '%s'", (btDeviceName == "") ? "First device found" : btDeviceName.c_str());
+			// get device name
+			btDeviceName = nameBluetoothSourceDevice;
+			if (gPrefsSettings.isKey("btDeviceName")) {
+				btDeviceName = gPrefsSettings.getString("btDeviceName", nameBluetoothSourceDevice);
+			}
+			Log_Printf(LOGLEVEL_INFO, "Bluetooth source started, connect to device: '%s'", (btDeviceName == "") ? "connect to first device found" : btDeviceName.c_str());
 			// connect events after startup
 			a2dp_source->set_on_connection_state_changed(connection_state_changed, a2dp_source);
 			a2dp_source->set_on_audio_state_changed(audio_state_changed, a2dp_source);

--- a/src/Bluetooth.h
+++ b/src/Bluetooth.h
@@ -15,4 +15,4 @@ void Bluetooth_PreviousTrack(void);
 void Bluetooth_SetVolume(const int32_t _newVolume, bool reAdjustRotary);
 
 bool Bluetooth_Source_SendAudioData(uint32_t* sample);
-bool Bluetooth_Source_Connected();
+bool Bluetooth_Device_Connected();

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -206,10 +206,8 @@ void Led_SetButtonLedsEnabled(boolean value) {
 	}
 	CRGB::HTMLColorCode Led_GetIdleColor() {
 		CRGB::HTMLColorCode idleColor = CRGB::Black;
-		if (OPMODE_BLUETOOTH_SINK == System_GetOperationMode()) {
-			idleColor = CRGB::Blue;
-		} else if (OPMODE_BLUETOOTH_SOURCE == System_GetOperationMode()) {
-			if (Bluetooth_Source_Connected()) {
+		if ((OPMODE_BLUETOOTH_SINK == System_GetOperationMode())  || (OPMODE_BLUETOOTH_SOURCE == System_GetOperationMode())) {
+			if (Bluetooth_Device_Connected()) {
 				idleColor = CRGB::Blue;
 			} else {
 				idleColor = CRGB::BlueViolet;
@@ -646,7 +644,13 @@ void Led_SetButtonLedsEnabled(boolean value) {
 		// pause-animation
 		if (gPlayProperties.pausePlay) {
 			leds = CRGB::Black;
-			CRGB::HTMLColorCode generalColor = CRGB::Orange;
+			CRGB::HTMLColorCode generalColor;
+			if (OPMODE_BLUETOOTH_SINK == System_GetOperationMode()) {
+				generalColor = CRGB::Blue;
+			} else {
+				generalColor = CRGB::Orange;
+			}
+
 			if constexpr(NUM_INDICATOR_LEDS == 1) {
 				leds[0] = generalColor;
 			} else {
@@ -674,8 +678,13 @@ void Led_SetButtonLedsEnabled(boolean value) {
 					if constexpr(NUM_INDICATOR_LEDS == 1) {
 						leds[0].setHue(webstreamColor++);
 					} else {
-						leds[Led_Address(ledPosWebstream)].setHue(webstreamColor);
-						leds[(Led_Address(ledPosWebstream) + leds.size() / 2) % leds.size()].setHue(webstreamColor++);
+						if (OPMODE_BLUETOOTH_SINK == System_GetOperationMode()) {
+							leds[Led_Address(ledPosWebstream)] = CRGB::Blue;
+							leds[(Led_Address(ledPosWebstream) + leds.size() / 2) % leds.size()] = CRGB::Blue;
+						} else {
+							leds[Led_Address(ledPosWebstream)].setHue(webstreamColor);
+							leds[(Led_Address(ledPosWebstream) + leds.size() / 2) % leds.size()].setHue(webstreamColor++);
+						}
 					}
 				}
 			refresh = true;

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -644,13 +644,10 @@ void Led_SetButtonLedsEnabled(boolean value) {
 		// pause-animation
 		if (gPlayProperties.pausePlay) {
 			leds = CRGB::Black;
-			CRGB::HTMLColorCode generalColor;
+			CRGB::HTMLColorCode generalColor = CRGB::Orange;
 			if (OPMODE_BLUETOOTH_SINK == System_GetOperationMode()) {
 				generalColor = CRGB::Blue;
-			} else {
-				generalColor = CRGB::Orange;
 			}
-
 			if constexpr(NUM_INDICATOR_LEDS == 1) {
 				leds[0] = generalColor;
 			} else {


### PR DESCRIPTION
- BT-Sink disconnected: Show blue-violet (same as in BT-source mode)
- BT-Sink connected: switch to blue
- start audio: show neopixel in webstream mode but with blue leds
- show volume change same as in other modes