### PR TITLE
Stricter hostname validation

### DIFF
--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -22,6 +22,9 @@
 				width: 20px;
 				height: 20px
 			}
+			input:invalid {
+				border: red solid 3px;
+			}
 			body {
 				background: #007bff;
 				font-family: sans-serif;
@@ -83,7 +86,7 @@
 			<label for="pwd" data-i18n="wifi.password.title">Password</label>:<br>
 			<input type="password" id="pwd" name="pwd" autocomplete="off" required><br>
 			<label for="hostname" data-i18n="wifi.hostname.title">Hostname</label>:<br>
-			<input type="text" id="hostname" name="hostname" value="espuino" required><br><br>
+			<input type="text" id="hostname" name="hostname" value="espuino" pattern="^[0-9a-zA-Z][0-9a-zA-Z\-]{0,30}[0-9a-zA-Z]" required><br><br>
 
 			<input type="checkbox" id="scan_wifi_on_start" name="scan_wifi_on_start" value=false>
 			<label for="scan_wifi_on_start" data-i18n="wifi.scan.enabled">Start with best WiFi</label><br><br>

--- a/html/management.html
+++ b/html/management.html
@@ -138,6 +138,10 @@
 		.fas{
 			padding-right: 0.25em;
 		}
+
+		input:invalid {
+			border: red solid 3px;
+		}
 	</style>
 </head>
 <body>
@@ -182,7 +186,7 @@
 					<div class="form-group col-md-12">
 						<label for="hostname" data-i18n="[prepend]wifi.hostname.title">:</label>
 						<input type="text" class="form-control" id="hostname" data-i18n="[placeholder]wifi.hostname.placeholder" name="hostname"
-							value="%HOSTNAME%" pattern="^[^-\.]{2,32}" required>
+							value="%HOSTNAME%" pattern="^[0-9a-zA-Z][0-9a-zA-Z\-]{0,30}[0-9a-zA-Z]" required>
 					</div>
 					<br>
 					<div class="text-center">

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1311,7 +1311,7 @@ void handleDeleteSavedSSIDs(AsyncWebServerRequest *request) {
 }
 
 void handleGetActiveSSID(AsyncWebServerRequest *request) {
-	AsyncJsonResponse *response = new AsyncJsonResponse(true);
+	AsyncJsonResponse *response = new AsyncJsonResponse();
 	JsonObject obj = response->getRoot();
 
 	if (Wlan_IsConnected()) {


### PR DESCRIPTION
Changes the frontend validation and adds a backend validation.
The backend previously did not validate the hostname at all.

The hostname validation is primarily for mDNS. For the "pretty" hostname
much more could be allowed, but we do not make that distinction (yet).

In general, change what kind of hostnames are accepted.
For example, a hostname can have a '-' in the middle.
Also, only alphanumerical characters are allowed. Dots ('.') are still
disallowed to prevent DNS problems when using mDNS.