### PR TITLE
Refactor web: Move dependant html-code from web.cpp to management.htm

### DIFF
--- a/html/management.html
+++ b/html/management.html
@@ -198,9 +198,9 @@
 			<a class="nav-item nav-link" id="nav-control-tab" data-toggle="tab" href="#nav-control" role="tab" aria-controls="nav-control" aria-selected="false"><i class="fas fa-gamepad"></i><span class=".d-sm-none .d-md-block" data-i18n="nav.control">Control</span></a>
 			<a class="nav-item nav-link active" id="nav-rfid-tab" data-toggle="tab" href="#nav-rfid" role="tab" aria-controls="nav-rfid" aria-selected="true"><i class="fas fa-dot-circle"></i><span data-i18n="nav.rfid">RFID</span></a>
 			<a class="nav-item nav-link" id="nav-wifi-tab" data-toggle="tab" href="#nav-wifi" role="tab" aria-controls="nav-wifi" aria-selected="false"><i class="fas fa-wifi"></i><span class=".d-sm-none .d-md-block"><span data-i18n="nav.wifi">WiFi</span></a>
-			%SHOW_MQTT_TAB%
-			%SHOW_FTP_TAB%
-			%SHOW_BLUETOOTH_TAB%
+			<a class="nav-item nav-link" id="nav-mqtt-tab" data-toggle="tab" href="#nav-mqtt" role="tab" aria-controls="nav-mqtt" aria-selected="false"><i class="fas fa-network-wired"></i><span data-i18n="nav.mqtt"></span></a>
+			<a class="nav-item nav-link" id="nav-ftp-tab" data-toggle="tab" href="#nav-ftp" role="tab" aria-controls="nav-ftp" aria-selected="false"><i class="fas fa-folder"></i><span data-i18n="nav.ftp"></span></a>
+			<a class="nav-item nav-link" id="nav-bt-tab" data-toggle="tab" href="#nav-bt" role="tab" aria-controls="nav-bt" aria-selected="false"><i class="fab fa-bluetooth"></i><span data-i18n="nav.bluetooth"></span></a>
 			<a class="nav-item nav-link" id="nav-general-tab" data-toggle="tab" href="#nav-general" role="tab" aria-controls="nav-general" aria-selected="false"><i class="fas fa-sliders-h"></i><span data-i18n="nav.general">General</span></a>
 			<a class="nav-item nav-link" id="nav-tools-tab" data-toggle="tab" href="#nav-tools" role="tab" aria-controls="nav-tools" aria-selected="false"><i class="fas fa-wrench"></i><span data-i18n="nav.tools">Tools</span></a>
 			<a class="nav-item nav-link" id="nav-forum-tab" data-toggle="tab" href="#nav-forum" role="tab" aria-controls="nav-forum" aria-selected="false"><i class="fas fa-comment"></i><span class=".d-sm-none .d-md-block"><span data-i18n="nav.forum">Forum</span></span></a>
@@ -714,6 +714,16 @@
 	var language = navigator.language || navigator.userLanguage;
 	var localize;
 
+	/* hide disabled tabs */
+	if (! %SHOW_MQTT_TAB% ) {
+			$('#nav-mqtt-tab').hide();
+		};   
+	if (! %SHOW_FTP_TAB% ) {
+		$('#nav-ftp-tab').hide();
+	};   
+	if (! %SHOW_BLUETOOTH_TAB% ) {
+		$('#nav-bt-tab').hide();
+	};
 	/* show active / selected tab */
 	$('#SubTab.nav-tabs a').on('shown.bs.tab', function (e) {
 		ActiveSubTab = $(e.target).attr('id');

--- a/html/management.html
+++ b/html/management.html
@@ -126,6 +126,9 @@
 		#SubTabContent.tab-content > .active {
 			visibility: visible;
 		}
+		[data-visible="false"] {
+			display: none;
+		}
 
 		/* IOS display fix */
 		select {
@@ -198,9 +201,9 @@
 			<a class="nav-item nav-link" id="nav-control-tab" data-toggle="tab" href="#nav-control" role="tab" aria-controls="nav-control" aria-selected="false"><i class="fas fa-gamepad"></i><span class=".d-sm-none .d-md-block" data-i18n="nav.control">Control</span></a>
 			<a class="nav-item nav-link active" id="nav-rfid-tab" data-toggle="tab" href="#nav-rfid" role="tab" aria-controls="nav-rfid" aria-selected="true"><i class="fas fa-dot-circle"></i><span data-i18n="nav.rfid">RFID</span></a>
 			<a class="nav-item nav-link" id="nav-wifi-tab" data-toggle="tab" href="#nav-wifi" role="tab" aria-controls="nav-wifi" aria-selected="false"><i class="fas fa-wifi"></i><span class=".d-sm-none .d-md-block"><span data-i18n="nav.wifi">WiFi</span></a>
-			<a class="nav-item nav-link" id="nav-mqtt-tab" data-toggle="tab" href="#nav-mqtt" role="tab" aria-controls="nav-mqtt" aria-selected="false"><i class="fas fa-network-wired"></i><span data-i18n="nav.mqtt"></span></a>
-			<a class="nav-item nav-link" id="nav-ftp-tab" data-toggle="tab" href="#nav-ftp" role="tab" aria-controls="nav-ftp" aria-selected="false"><i class="fas fa-folder"></i><span data-i18n="nav.ftp"></span></a>
-			<a class="nav-item nav-link" id="nav-bt-tab" data-toggle="tab" href="#nav-bt" role="tab" aria-controls="nav-bt" aria-selected="false"><i class="fab fa-bluetooth"></i><span data-i18n="nav.bluetooth"></span></a>
+			<a class="nav-item nav-link" id="nav-mqtt-tab" data-visible="%SHOW_MQTT_TAB%" data-toggle="tab" href="#nav-mqtt" role="tab" aria-controls="nav-mqtt" aria-selected="false"><i class="fas fa-network-wired"></i><span data-i18n="nav.mqtt">MQTT</span></a>
+			<a class="nav-item nav-link" id="nav-ftp-tab" data-visible="%SHOW_FTP_TAB%" data-toggle="tab" href="#nav-ftp" role="tab" aria-controls="nav-ftp" aria-selected="false"><i class="fas fa-folder"></i><span data-i18n="nav.ftp">FTP</span></a>
+			<a class="nav-item nav-link" id="nav-bt-tab" data-visible="%SHOW_BLUETOOTH_TAB%" data-toggle="tab" href="#nav-bt" role="tab" aria-controls="nav-bt" aria-selected="false"><i class="fab fa-bluetooth"></i><span data-i18n="nav.bluetooth">Bluetooth</span></a>
 			<a class="nav-item nav-link" id="nav-general-tab" data-toggle="tab" href="#nav-general" role="tab" aria-controls="nav-general" aria-selected="false"><i class="fas fa-sliders-h"></i><span data-i18n="nav.general">General</span></a>
 			<a class="nav-item nav-link" id="nav-tools-tab" data-toggle="tab" href="#nav-tools" role="tab" aria-controls="nav-tools" aria-selected="false"><i class="fas fa-wrench"></i><span data-i18n="nav.tools">Tools</span></a>
 			<a class="nav-item nav-link" id="nav-forum-tab" data-toggle="tab" href="#nav-forum" role="tab" aria-controls="nav-forum" aria-selected="false"><i class="fas fa-comment"></i><span class=".d-sm-none .d-md-block"><span data-i18n="nav.forum">Forum</span></span></a>
@@ -714,16 +717,6 @@
 	var language = navigator.language || navigator.userLanguage;
 	var localize;
 
-	/* hide disabled tabs */
-	if (! %SHOW_MQTT_TAB% ) {
-			$('#nav-mqtt-tab').hide();
-		};   
-	if (! %SHOW_FTP_TAB% ) {
-		$('#nav-ftp-tab').hide();
-	};   
-	if (! %SHOW_BLUETOOTH_TAB% ) {
-		$('#nav-bt-tab').hide();
-	};
 	/* show active / selected tab */
 	$('#SubTab.nav-tabs a').on('shown.bs.tab', function (e) {
 		ActiveSubTab = $(e.target).attr('id');

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -37,9 +37,6 @@ typedef struct {
 	char nvsEntry[275];
 } nvs_t;
 
-const char mqttTab[] = "<a class=\"nav-item nav-link\" id=\"nav-mqtt-tab\" data-toggle=\"tab\" href=\"#nav-mqtt\" role=\"tab\" aria-controls=\"nav-mqtt\" aria-selected=\"false\"><i class=\"fas fa-network-wired\"></i><span data-i18n=\"nav.mqtt\"></span></a>";
-const char ftpTab[] = "<a class=\"nav-item nav-link\" id=\"nav-ftp-tab\" data-toggle=\"tab\" href=\"#nav-ftp\" role=\"tab\" aria-controls=\"nav-ftp\" aria-selected=\"false\"><i class=\"fas fa-folder\"></i><span data-i18n=\"nav.ftp\"></span></a>";
-const char bluetoothTab[] = "<a class=\"nav-item nav-link\" id=\"nav-bt-tab\" data-toggle=\"tab\" href=\"#nav-bt\" role=\"tab\" aria-controls=\"nav-bt\" aria-selected=\"false\"><i class=\"fab fa-bluetooth\"></i><span data-i18n=\"nav.bluetooth\"></span></a>";
 
 AsyncWebServer wServer(80);
 AsyncWebSocket ws("/ws");
@@ -507,15 +504,15 @@ String templateProcessor(const String &templ) {
 		return String(ftpPasswordLength - 1);
 	} else if (templ == "SHOW_FTP_TAB") { // Only show FTP-tab if FTP-support was compiled
 		#ifdef FTP_ENABLE
-			return ftpTab;
+			return "true";
 		#else
-			return String();
+			return "false";
 		#endif
 	} else if (templ == "SHOW_BLUETOOTH_TAB") { // Only show Bluetooth-tab if Bluetooth-support was compiled
 		#ifdef BLUETOOTH_ENABLE
-			return bluetoothTab;
+			return "true";
 		#else
-			return String();
+			return "false";
 		#endif		
 	} else if (templ == "INIT_LED_BRIGHTNESS") {
 		return String(gPrefsSettings.getUChar("iLedBrightness", 0));
@@ -563,9 +560,9 @@ String templateProcessor(const String &templ) {
 		}
 	} else if (templ == "SHOW_MQTT_TAB") { // Only show MQTT-tab if MQTT-support was compiled
 		#ifdef MQTT_ENABLE
-			return mqttTab;
+			return "true";
 		#else
-			return String();
+			return "false";
 		#endif
 	} else if (templ == "MQTT_ENABLE") {
 		if (Mqtt_IsEnabled()) {


### PR DESCRIPTION
Move the HTML code for tabs FTP, MQTT & Bluetooth from web.cpp to management.htm