### PR TITLE
Web-UI: Replace the template processor

### DIFF
--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -156,6 +156,8 @@
                     "140":"Bluetooth-Lautsprecher aktivieren/deaktivieren",
                     "141":"Bluetooth-Kopfhörer aktivieren/deaktivieren",
                     "150":"Aktiviere FTP",
+                    "151":"IP-Adresse ansagen",
+                    "152":"Uhrzeit ansagen",
                     "0":"Lösche Zuordnung",
                     "170":"Play/Pause",
                     "171":"Vorheriger Titel",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -156,6 +156,8 @@
                     "140":"Toggle Bluetooth Speaker",
                     "141":"Toggle Bluetooth Headphones",
                     "150":"Enable FTP",
+                    "151":"Announce IP-Address",
+                    "152":"Announce current time",
                     "0":"Remove assignment",
                     "170":"Toggle Play/Pause",
                     "171":"Previous track",

--- a/html/management.html
+++ b/html/management.html
@@ -579,7 +579,7 @@
 					<label for="maxVolumeSpeaker" data-i18n="[prepend]general.volume.speakerMax">:</label>
 						<div class="text-center">
 					 <i class="fas fa-volume-down fa-2x .icon-pos"></i>   <input data-provide="slider" type="number" data-slider-min="1" data-slider-max="21" min="1" max="21" class="form-control" id="maxVolumeSpeaker" name="maxVolumeSpeaker"
-						data-slider-value="1"  value="1" required>  <i class="fas fa-volume-up fa-2x .icon-pos"></i>
+					 	required>  <i class="fas fa-volume-up fa-2x .icon-pos"></i>
 						</div>
 						<br>
 					<label for="maxVolumeHeadphone" data-i18n="[prepend]general.volume.headphoneMax">:</label>
@@ -590,7 +590,7 @@
 				</fieldset>
 				</div>
 				<br>
-				<div class="form-group col-md-12">
+				<div class="form-group col-md-12" id="neopixelConfig" data-visible="false">
 					<fieldset >
 						<legend class="w-auto" data-i18n="general.neopixel.title"></legend>
 					<label for="initBrightness" data-i18n="[prepend]general.neopixel.restart">:</label>
@@ -618,7 +618,7 @@
 				</div>
 				<br>
 
-				<div class="form-group col-md-12">
+				<div class="form-group col-md-12" id="batteryConfig" data-visible="false">
 					<fieldset>
 						<legend data-i18n="general.battery.title"></legend>
 					<div data-i18n="general.battery.desc"></div>
@@ -653,8 +653,8 @@
 				</div>
 <br>
 				<div class="text-center">
-				<button type="reset" class="btn btn-secondary" data-i18n="reset"></button>&nbsp
-				<button type="submit" class="btn btn-primary" data-i18n="submit"></button>
+					<button type="reset" class="btn btn-secondary" data-i18n="reset" onclick="resetSettings()"></button>&nbsp
+					<button type="submit" class="btn btn-primary" data-i18n="submit"></button>
 				</div>
 			</form>
 		</div>
@@ -1453,22 +1453,54 @@
 	}
 
 	async function fillSettings(settings) {
-		document.getElementById("hostname").value = settings.hostname;
-		document.getElementById("rfidIdMusic").value = settings.rfidTagId;
+		if (!settings) { 
+			return false 
+		}
 		// general
 		let genSettings = settings.general;
-		$('#initialVolume').bootstrapSlider('setValue', genSettings.iVol);
-		$('#maxVolumeSpeaker').bootstrapSlider('setValue', genSettings.mVolSpeaker);
-		volumeSlider.setValue(settings.volume);
-		$('#maxVolumeHeadphone').bootstrapSlider('setValue', genSettings.mVolHeadphone);
-		$('#initBrightness').bootstrapSlider('setValue', genSettings.iBright);
-		$('#nightBrightness').bootstrapSlider('setValue', genSettings.nBright);
-		$('#inactivityTime').bootstrapSlider('setValue', genSettings.iTime);
-		$('#warningLowVoltage').bootstrapSlider('setValue', genSettings.vWarning);
-		$('#voltageIndicatorLow').bootstrapSlider('setValue', genSettings.vIndLow);
-		$('#voltageIndicatorHigh').bootstrapSlider('setValue', genSettings.vIndHi);
-		$('#voltageCheckInterval').bootstrapSlider('setValue', genSettings.vInt);
-
+		if (genSettings) {
+			$('#initialVolume').bootstrapSlider('setValue', genSettings.iVol);
+			$('#maxVolumeSpeaker').bootstrapSlider('setValue', genSettings.mVolSpeaker);
+			$('#maxVolumeHeadphone').bootstrapSlider('setValue', genSettings.mVolHeadphone);
+			$('#inactivityTime').bootstrapSlider('setValue', genSettings.iTime);
+		}
+		// current values
+		let currSettings = settings.current;
+		if (currSettings) {
+			document.getElementById("hostname").value = currSettings.hostname;
+			document.getElementById("rfidIdMusic").value = currSettings.rfidTagId;
+			volumeSlider.setValue(currSettings.volume);
+		}
+		// default (factory) settings 
+		let defSettings = settings.defaults;
+		if (defSettings) {
+			$('#initialVolume').bootstrapSlider('setValue', defSettings.iVol);
+			$('#maxVolumeSpeaker').bootstrapSlider('setValue', defSettings.mVolSpeaker);
+			$('#maxVolumeHeadphone').bootstrapSlider('setValue', defSettings.mVolHeadphone);
+			$('#inactivityTime').bootstrapSlider('setValue', defSettings.iTime);
+			$('#initBrightness').bootstrapSlider('setValue', defSettings.iBright);
+			$('#nightBrightness').bootstrapSlider('setValue', defSettings.nBright);
+			$('#warningLowVoltage').bootstrapSlider('setValue', defSettings.vWarning);
+			$('#voltageIndicatorLow').bootstrapSlider('setValue', defSettings.vIndLow);
+			$('#voltageIndicatorHigh').bootstrapSlider('setValue', defSettings.vIndHi);
+			$('#voltageCheckInterval').bootstrapSlider('setValue', defSettings.vInt);
+		}
+		// neopixel
+		let neopixelSettings = settings.neopixel;
+		if (neopixelSettings) {
+			document.getElementById('neopixelConfig').setAttribute('data-visible', true);
+			$('#initBrightness').bootstrapSlider('setValue', neopixelSettings.iBright);
+			$('#nightBrightness').bootstrapSlider('setValue', neopixelSettings.nBright);
+		}
+		// battery
+		let batSettings = settings.battery;
+		if (batSettings) {
+			document.getElementById('batteryConfig').setAttribute('data-visible', true);
+			$('#warningLowVoltage').bootstrapSlider('setValue', batSettings.vWarning);
+			$('#voltageIndicatorLow').bootstrapSlider('setValue', batSettings.vIndLow);
+			$('#voltageIndicatorHigh').bootstrapSlider('setValue', batSettings.vIndHi);
+			$('#voltageCheckInterval').bootstrapSlider('setValue', batSettings.vInt);
+		}
 		// ftp
 		let ftpSettings = settings.ftp;
 		if (ftpSettings) {
@@ -1501,6 +1533,11 @@
 			document.getElementById('btDeviceName').value = btSettings.deviceName;
 			document.getElementById('btPinCode').value = btSettings.pinCode;
 		}
+	}
+
+	async function resetSettings() {
+		let defaults = await (await fetch("/settings?section=defaults")).json();
+		fillSettings(defaults);
 	}
 
 	const wifiListSavedSSIDs = document.getElementById("wifiListSavedSSIDs");
@@ -1644,10 +1681,12 @@
 			"general": {
 				iVol: document.getElementById('initialVolume').value,
 				mVolSpeaker: document.getElementById('maxVolumeSpeaker').value,
-				mVolHeadphone: document.getElementById('maxVolumeHeadphone').value,
-				iBright: document.getElementById('initBrightness').value,
-				nBright: document.getElementById('nightBrightness').value,
+				mVolHeadphone: document.getElementById('maxVolumeHeadphone').value },
 				iTime: document.getElementById('inactivityTime').value,
+			"neopixel": {
+				iBright: document.getElementById('initBrightness').value,
+				nBright: document.getElementById('nightBrightness').value},
+			"battery": {
 				vWarning: document.getElementById('warningLowVoltage').value,
 				vIndLow: document.getElementById('voltageIndicatorLow').value,
 				vIndHi: document.getElementById('voltageIndicatorHigh').value,

--- a/html/management.html
+++ b/html/management.html
@@ -613,7 +613,7 @@
 
 						<label for="inactivityTime" data-i18n="general.sleep.incativity"></label>
 						<div class="text-center"><i class="fas fa-hourglass-start fa-2x .icon-pos"></i> <input type="number" data-provide="slider" data-slider-min="0" data-slider-max="30" min="1" max="120" class="form-control" id="inactivityTime" name="inactivityTime"
-						 data-slider-value=""  value="" required><i class="fas fa-hourglass-end fa-2x .icon-pos"></i></div>
+						 data-slider-value="" value="" required><i class="fas fa-hourglass-end fa-2x .icon-pos"></i></div>
 					</fieldset>
 				</div>
 				<br>
@@ -1459,10 +1459,10 @@
 		// general
 		let genSettings = settings.general;
 		if (genSettings) {
-			$('#initialVolume').bootstrapSlider('setValue', genSettings.iVol);
-			$('#maxVolumeSpeaker').bootstrapSlider('setValue', genSettings.mVolSpeaker);
-			$('#maxVolumeHeadphone').bootstrapSlider('setValue', genSettings.mVolHeadphone);
-			$('#inactivityTime').bootstrapSlider('setValue', genSettings.iTime);
+			$('#initialVolume').bootstrapSlider('setValue', genSettings.initVolume);
+			$('#maxVolumeSpeaker').bootstrapSlider('setValue', genSettings.maxVolumeSp);
+			$('#maxVolumeHeadphone').bootstrapSlider('setValue', genSettings.maxVolumeHp);
+			$('#inactivityTime').bootstrapSlider('setValue', genSettings.sleepInactivity);
 		}
 		// current values
 		let currSettings = settings.current;
@@ -1474,40 +1474,40 @@
 		// default (factory) settings 
 		let defSettings = settings.defaults;
 		if (defSettings) {
-			$('#initialVolume').bootstrapSlider('setValue', defSettings.iVol);
-			$('#maxVolumeSpeaker').bootstrapSlider('setValue', defSettings.mVolSpeaker);
-			$('#maxVolumeHeadphone').bootstrapSlider('setValue', defSettings.mVolHeadphone);
-			$('#inactivityTime').bootstrapSlider('setValue', defSettings.iTime);
-			$('#initBrightness').bootstrapSlider('setValue', defSettings.iBright);
-			$('#nightBrightness').bootstrapSlider('setValue', defSettings.nBright);
-			$('#warningLowVoltage').bootstrapSlider('setValue', defSettings.vWarning);
-			$('#voltageIndicatorLow').bootstrapSlider('setValue', defSettings.vIndLow);
-			$('#voltageIndicatorHigh').bootstrapSlider('setValue', defSettings.vIndHi);
-			$('#voltageCheckInterval').bootstrapSlider('setValue', defSettings.vInt);
+			$('#initialVolume').bootstrapSlider('setValue', defSettings.initVolume);
+			$('#maxVolumeSpeaker').bootstrapSlider('setValue', defSettings.maxVolumeSp);
+			$('#maxVolumeHeadphone').bootstrapSlider('setValue', defSettings.maxVolumeHp);
+			$('#inactivityTime').bootstrapSlider('setValue', defSettings.sleepInactivity);
+			$('#initBrightness').bootstrapSlider('setValue', defSettings.initBrightness);
+			$('#nightBrightness').bootstrapSlider('setValue', defSettings.nightBrightness);
+			$('#warningLowVoltage').bootstrapSlider('setValue', defSettings.warnLowVoltage);
+			$('#voltageIndicatorLow').bootstrapSlider('setValue', defSettings.indicatorLow);
+			$('#voltageIndicatorHigh').bootstrapSlider('setValue', defSettings.indicatorHi);
+			$('#voltageCheckInterval').bootstrapSlider('setValue', defSettings.voltageCheckInterval);
 		}
 		// neopixel
 		let neopixelSettings = settings.neopixel;
 		if (neopixelSettings) {
 			document.getElementById('neopixelConfig').setAttribute('data-visible', true);
-			$('#initBrightness').bootstrapSlider('setValue', neopixelSettings.iBright);
-			$('#nightBrightness').bootstrapSlider('setValue', neopixelSettings.nBright);
+			$('#initBrightness').bootstrapSlider('setValue', neopixelSettings.initBrightness);
+			$('#nightBrightness').bootstrapSlider('setValue', neopixelSettings.nightBrightness);
 		}
 		// battery
 		let batSettings = settings.battery;
 		if (batSettings) {
 			document.getElementById('batteryConfig').setAttribute('data-visible', true);
-			$('#warningLowVoltage').bootstrapSlider('setValue', batSettings.vWarning);
-			$('#voltageIndicatorLow').bootstrapSlider('setValue', batSettings.vIndLow);
-			$('#voltageIndicatorHigh').bootstrapSlider('setValue', batSettings.vIndHi);
-			$('#voltageCheckInterval').bootstrapSlider('setValue', batSettings.vInt);
+			$('#warningLowVoltage').bootstrapSlider('setValue', batSettings.warnLowVoltage);
+			$('#voltageIndicatorLow').bootstrapSlider('setValue', batSettings.indicatorLow);
+			$('#voltageIndicatorHigh').bootstrapSlider('setValue', batSettings.indicatorHi);
+			$('#voltageCheckInterval').bootstrapSlider('setValue', batSettings.voltageCheckInterval);
 		}
 		// ftp
 		let ftpSettings = settings.ftp;
 		if (ftpSettings) {
 			document.getElementById('nav-ftp-tab').setAttribute('data-visible', true);
-			document.getElementById("ftpUser").value = ftpSettings.ftpUser;
+			document.getElementById("ftpUser").value = ftpSettings.username;
 			document.getElementById("ftpUser").setAttribute('maxlength', ftpSettings.maxUserLength);
-			document.getElementById("ftpPwd").value = ftpSettings.ftpPwd;
+			document.getElementById("ftpPwd").value = ftpSettings.password;
 			document.getElementById("ftpPwd").setAttribute('maxlength', ftpSettings.maxPwdLength);
 		}
 		// mqtt
@@ -1515,16 +1515,16 @@
 		if (mqttSettings) {
 			// todo: get the bootstrap sliders to work:
 			document.getElementById('nav-mqtt-tab').setAttribute('data-visible', true);
-			document.getElementById('mqttEnable').checked = mqttSettings.mqttEnable;
-			document.getElementById('mqttClientId').value = mqttSettings.mqttClientId;
+			document.getElementById('mqttEnable').checked = mqttSettings.enable;
+			document.getElementById('mqttClientId').value = mqttSettings.clientID;
 			document.getElementById('mqttClientId').setAttribute('maxlength', mqttSettings.mqttClientIdLength);
-			document.getElementById('mqttServer').value = mqttSettings.mqttServer;
+			document.getElementById('mqttServer').value = mqttSettings.server;
 			document.getElementById('mqttServer').setAttribute('maxlength', mqttSettings.mqttServerLength);
-			document.getElementById('mqttUser').value = mqttSettings.mqttUser;
+			document.getElementById('mqttUser').value = mqttSettings.username;
 			document.getElementById('mqttUser').setAttribute('maxlength', mqttSettings.maxUserLength);
-			document.getElementById('mqttPwd').value = mqttSettings.mqttPwd;
+			document.getElementById('mqttPwd').value = mqttSettings.password;
 			document.getElementById('mqttPwd').setAttribute('maxlength', mqttSettings.maxPwdLength);
-			document.getElementById('mqttPort').value = mqttSettings.mqttPort;
+			document.getElementById('mqttPort').value = mqttSettings.port;
 		}
 		// bluetooth
 		let btSettings = settings.bluetooth;
@@ -1679,18 +1679,18 @@
 		lastIdclicked = clickedId;
 		var myObj = {
 			"general": {
-				iVol: document.getElementById('initialVolume').value,
-				mVolSpeaker: document.getElementById('maxVolumeSpeaker').value,
-				mVolHeadphone: document.getElementById('maxVolumeHeadphone').value, 
-				iTime: document.getElementById('inactivityTime').value},
+				initVolume: document.getElementById('initialVolume').value,
+				maxVolumeSp: document.getElementById('maxVolumeSpeaker').value,
+				maxVolumeHp: document.getElementById('maxVolumeHeadphone').value, 
+				sleepInactivity: document.getElementById('inactivityTime').value},
 			"neopixel": {
-				iBright: document.getElementById('initBrightness').value,
-				nBright: document.getElementById('nightBrightness').value},
+				initBrightness: document.getElementById('initBrightness').value,
+				nightBrightness: document.getElementById('nightBrightness').value},
 			"battery": {
-				vWarning: document.getElementById('warningLowVoltage').value,
-				vIndLow: document.getElementById('voltageIndicatorLow').value,
-				vIndHi: document.getElementById('voltageIndicatorHigh').value,
-				vInt: document.getElementById('voltageCheckInterval').value
+				warnLowVoltage: document.getElementById('warningLowVoltage').value,
+				indicatorLow: document.getElementById('voltageIndicatorLow').value,
+				indicatorHi: document.getElementById('voltageIndicatorHigh').value,
+				voltageCheckInterval: document.getElementById('voltageCheckInterval').value
 			}
 		};
 		var myJSON = JSON.stringify(myObj);
@@ -1701,8 +1701,8 @@
 		lastIdclicked = clickedId;
 		var myObj = {
 			"ftp": {
-				ftpUser: document.getElementById('ftpUser').value,
-				ftpPwd: document.getElementById('ftpPwd').value
+				username: document.getElementById('ftpUser').value,
+				password: document.getElementById('ftpPwd').value
 			}
 		};
 		var myJSON = JSON.stringify(myObj);
@@ -1729,12 +1729,12 @@
 		}
 		var myObj = {
 			"mqtt": {
-				mqttEnable: val,
-				mqttClientId: document.getElementById('mqttClientId').value,
-				mqttServer: document.getElementById('mqttServer').value,
-				mqttUser: document.getElementById('mqttUser').value,
-				mqttPwd: document.getElementById('mqttPwd').value,
-				mqttPort: document.getElementById('mqttPort').value
+				enable: val,
+				clientID: document.getElementById('mqttClientId').value,
+				server: document.getElementById('mqttServer').value,
+				username: document.getElementById('mqttUser').value,
+				password: document.getElementById('mqttPwd').value,
+				port: document.getElementById('mqttPort').value
 			}
 		};
 		var myJSON = JSON.stringify(myObj);

--- a/html/management.html
+++ b/html/management.html
@@ -1467,7 +1467,6 @@
 		// current values
 		let currSettings = settings.current;
 		if (currSettings) {
-			document.getElementById("hostname").value = currSettings.hostname;
 			document.getElementById("rfidIdMusic").value = currSettings.rfidTagId;
 			volumeSlider.setValue(currSettings.volume);
 		}
@@ -1484,6 +1483,12 @@
 			$('#voltageIndicatorLow').bootstrapSlider('setValue', defSettings.indicatorLow);
 			$('#voltageIndicatorHigh').bootstrapSlider('setValue', defSettings.indicatorHi);
 			$('#voltageCheckInterval').bootstrapSlider('setValue', defSettings.voltageCheckInterval);
+		}
+		// wifi
+		let wifiSettings = settings.wifi;
+		if (wifiSettings) {
+			document.getElementById("hostname").value = wifiSettings.hostname;
+			document.getElementById("scan_wifi_on_start").checked = wifiSettings.scanOnStart;
 		}
 		// neopixel
 		let neopixelSettings = settings.neopixel;
@@ -1586,24 +1591,9 @@
 		}	
 	}
 
-	async function updateWifiFields() {
-		let hostnameElem = document.getElementById("hostname");
-		let scanWifiElem = document.getElementById("scan_wifi_on_start");
-
-		let config = await (await fetch("/wificonfig")).json();
-
-		if (config.hostname && config.hostname !== "") {
-			hostnameElem.value = config.hostname;
-			hostnameElem.defaultValue = config.hostname;
-		} 
-		scanWifiElem.checked = config.scanwifionstart;
-	}
-
 	function onWifiTabOpened() {
-		console.log("wifi tab opened!")
+		console.log("wifi tab opened!");
 		rebuildSSIDList();
-		
-		updateWifiFields();
 	}
 
 	async function deleteSSID(ssid) {

--- a/html/management.html
+++ b/html/management.html
@@ -201,9 +201,9 @@
 			<a class="nav-item nav-link" id="nav-control-tab" data-toggle="tab" href="#nav-control" role="tab" aria-controls="nav-control" aria-selected="false"><i class="fas fa-gamepad"></i><span class=".d-sm-none .d-md-block" data-i18n="nav.control">Control</span></a>
 			<a class="nav-item nav-link active" id="nav-rfid-tab" data-toggle="tab" href="#nav-rfid" role="tab" aria-controls="nav-rfid" aria-selected="true"><i class="fas fa-dot-circle"></i><span data-i18n="nav.rfid">RFID</span></a>
 			<a class="nav-item nav-link" id="nav-wifi-tab" data-toggle="tab" href="#nav-wifi" role="tab" aria-controls="nav-wifi" aria-selected="false"><i class="fas fa-wifi"></i><span class=".d-sm-none .d-md-block"><span data-i18n="nav.wifi">WiFi</span></a>
-			<a class="nav-item nav-link" id="nav-mqtt-tab" data-visible="%SHOW_MQTT_TAB%" data-toggle="tab" href="#nav-mqtt" role="tab" aria-controls="nav-mqtt" aria-selected="false"><i class="fas fa-network-wired"></i><span data-i18n="nav.mqtt">MQTT</span></a>
-			<a class="nav-item nav-link" id="nav-ftp-tab" data-visible="%SHOW_FTP_TAB%" data-toggle="tab" href="#nav-ftp" role="tab" aria-controls="nav-ftp" aria-selected="false"><i class="fas fa-folder"></i><span data-i18n="nav.ftp">FTP</span></a>
-			<a class="nav-item nav-link" id="nav-bt-tab" data-visible="%SHOW_BLUETOOTH_TAB%" data-toggle="tab" href="#nav-bt" role="tab" aria-controls="nav-bt" aria-selected="false"><i class="fab fa-bluetooth"></i><span data-i18n="nav.bluetooth">Bluetooth</span></a>
+			<a class="nav-item nav-link" id="nav-mqtt-tab" data-visible="false" data-toggle="tab" href="#nav-mqtt" role="tab" aria-controls="nav-mqtt" aria-selected="false"><i class="fas fa-network-wired"></i><span data-i18n="nav.mqtt">MQTT</span></a>
+			<a class="nav-item nav-link" id="nav-ftp-tab" data-visible="false" data-toggle="tab" href="#nav-ftp" role="tab" aria-controls="nav-ftp" aria-selected="false"><i class="fas fa-folder"></i><span data-i18n="nav.ftp">FTP</span></a>
+			<a class="nav-item nav-link" id="nav-bt-tab" data-visible="false" data-toggle="tab" href="#nav-bt" role="tab" aria-controls="nav-bt" aria-selected="false"><i class="fab fa-bluetooth"></i><span data-i18n="nav.bluetooth">Bluetooth</span></a>
 			<a class="nav-item nav-link" id="nav-general-tab" data-toggle="tab" href="#nav-general" role="tab" aria-controls="nav-general" aria-selected="false"><i class="fas fa-sliders-h"></i><span data-i18n="nav.general">General</span></a>
 			<a class="nav-item nav-link" id="nav-tools-tab" data-toggle="tab" href="#nav-tools" role="tab" aria-controls="nav-tools" aria-selected="false"><i class="fas fa-wrench"></i><span data-i18n="nav.tools">Tools</span></a>
 			<a class="nav-item nav-link" id="nav-forum-tab" data-toggle="tab" href="#nav-forum" role="tab" aria-controls="nav-forum" aria-selected="false"><i class="fas fa-comment"></i><span class=".d-sm-none .d-md-block"><span data-i18n="nav.forum">Forum</span></span></a>
@@ -219,7 +219,7 @@
 					<div class="form-group col-md-12">
 						<label for="hostname" data-i18n="[prepend]wifi.hostname.title">:</label>
 						<input type="text" class="form-control" id="hostname" data-i18n="[placeholder]wifi.hostname.placeholder" name="hostname"
-							value="%HOSTNAME%" pattern="^[0-9a-zA-Z][0-9a-zA-Z\\-]{0,30}[0-9a-zA-Z]" required><br>
+							value="" pattern="^[0-9a-zA-Z][0-9a-zA-Z\-]{0,30}[0-9a-zA-Z]" required><br>
 						<input type="checkbox" id="scan_wifi_on_start" name="scan_wifi_on_start" value=false>
 						<label for="scan_wifi_on_start" data-i18n="wifi.scan.enabled">Start with best WiFi</label><br><br>
 					</div>
@@ -301,7 +301,7 @@
 							<span class="fas fa-volume-down"></span>
 						</button>
 						</i><input data-provide="slider" type="number" data-slider-min="1" data-slider-max="21" min="1" max="21" class="form-control" id="setVolume"
-							data-slider-value="%CURRENT_VOLUME%" value="%CURRENT_VOLUME%" onchange="sendVolume(this.value)">
+							data-slider-value="" value="" onchange="sendVolume(this.value)">
 						<button type="button" class="btn btn-default btn-lg" onclick="sendControl(176)" data-i18n="[title]control.volup">
 							<span class="fas fa-volume-up"></span>
 						</button>
@@ -385,7 +385,7 @@
 				<div class="form-group col-md-12">
 					<label for="rfidIdMusic" data-i18n="files.rfid.idNumber">RFID-number (12 digits)</label>
 					<input type="text" class="form-control" id="rfidIdMusic" maxlength="12" pattern="[0-9]{12}"
-						   placeholder="%RFID_TAG_ID%" name="rfidIdMusic" required>
+						   placeholder="" name="rfidIdMusic" required>
 					<br>
 					<ul class="nav nav-tabs" id="SubTab" role="tablist">
 						<li class="nav-item">
@@ -467,25 +467,25 @@
 				  onsubmit="mqttSettings('mqttConfig'); return false">
 				<div class="form-check col-md-12">
 					<legend data-i18n="mqtt.title"></legend>
-					<input class="form-check-input" type="checkbox" value="1" id="mqttEnable" name="mqttEnable" %MQTT_ENABLE%>
+					<input class="form-check-input" type="checkbox" value="1" id="mqttEnable" name="mqttEnable">
 					<label class="form-check-label" for="mqttEnable" data-i18n="mqtt.enable"></label>
 				</div>
 				<div class="form-group my-2 col-md-12">
 					<label for="mqttClientId" data-i18n="[prepend]mqtt.clientId.title">:</label>
-					<input type="text" class="form-control" id="mqttClientId" minlength="7" maxlength="%MQTT_CLIENTID_LENGTH%"
-						  data-i18n="[placeholder]mqtt.clientId.placeholder" name="mqttClientId" value="%MQTT_CLIENTID%">
+					<input type="text" class="form-control" id="mqttClientId" minlength="7" maxlength="0"
+						  data-i18n="[placeholder]mqtt.clientId.placeholder" name="mqttClientId" value="">
 					<label for="mqttServer" data-i18n="[prepend]mqtt.server.title">:</label>
-					<input type="text" class="form-control" id="mqttServer" minlength="7" maxlength="%MQTT_SERVER_LENGTH%"
-						   data-i18n="[placeholder]mqtt.server.placeholder" name="mqttServer" value="%MQTT_SERVER%">
+					<input type="text" class="form-control" id="mqttServer" minlength="7" maxlength="0"
+						   data-i18n="[placeholder]mqtt.server.placeholder" name="mqttServer" value="">
 					<label for="mqttUser" data-i18n="[prepend]mqtt.user.title">:</label>
-					<input type="text" class="form-control" id="mqttUser" maxlength="%MQTT_USER_LENGTH%"
-						   data-i18n="[placeholder]mqtt.user.placeholder" name="mqttUser" value="%MQTT_USER%">
+					<input type="text" class="form-control" id="mqttUser" maxlength=""
+						   data-i18n="[placeholder]mqtt.user.placeholder" name="mqttUser" value="">
 					<label for="mqttPwd" data-i18n="[prepend]mqtt.pwd.title">:</label>
-					<input type="password" class="form-control" id="mqttPwd" maxlength="%MQTT_PWD_LENGTH%"
-						   data-i18n="[placeholder]mqtt.pwd.placeholder" name="mqttPwd" value="%MQTT_PWD%">
+					<input type="password" class="form-control" id="mqttPwd" maxlength=""
+						   data-i18n="[placeholder]mqtt.pwd.placeholder" name="mqttPwd" value="">
 					<label for="mqttPort" data-i18n="[prepend]mqtt.port.title">:</label>
 					<input type="number" class="form-control" id="mqttPort" min="1" max="65535"
-							data-i18n="[placeholder]mqtt.port.placeholder" name="mqttPort" value="%MQTT_PORT%" required>
+							data-i18n="[placeholder]mqtt.port.placeholder" name="mqttPort" value="" required>
 				</div>
 				<br>
 				<div class="text-center">
@@ -502,11 +502,10 @@
 				<div class="form-group col-md-12">
 					<legend data-i18n="ftp.title"></legend>
 					<label for="ftpUser" data-i18n="[prepend]ftp.user.title">:</label>
-					<input type="text" class="form-control" id="ftpUser" maxlength="%FTP_USER_LENGTH%"
-						data-i18n="[placeholder]ftp.user.placeholder" name="ftpUser" value="%FTP_USER%" required>
+					<input type="text" class="form-control" id="ftpUser" maxlength="0" data-i18n="[placeholder]ftp.user.placeholder" name="ftpUser" value="" required>
 					<label for="pwd" data-i18n="[prepend]ftp.pwd.title">:</label>
-					<input type="password" class="form-control" id="ftpPwd" maxlength="%FTP_PWD_LENGTH%" data-i18n="[placeholder]ftp.pwd.placeholder"
-						   name="ftpPwd" value="%FTP_PWD%" required>
+					<input type="password" class="form-control" id="ftpPwd" maxlength="0" data-i18n="[placeholder]ftp.pwd.placeholder"
+						   name="ftpPwd" value="" required>
 				</div>
 				<br>
 				<div class="text-center">
@@ -533,10 +532,10 @@
 					<legend data-i18n="bt.source.configtitle"></legend>
 					<label for="btDeviceName" data-i18n="[prepend]bt.device.title">:</label>
 					<input type="text" class="form-control" id="btDeviceName"
-						data-i18n="[placeholder]bt.device.placeholder" name="btDeviceName" value="%BT_DEVICE_NAME%"><br>
+						data-i18n="[placeholder]bt.device.placeholder" name="btDeviceName" value=""><br>
 					<label for="btPinCode" data-i18n="[prepend]bt.pincode.title">:</label>
 					<input type="text" class="form-control" id="btPinCode"
-						data-i18n="[placeholder]bt.pincode.placeholder" name="btPinCode" value="%BT_PINCODE%">
+						data-i18n="[placeholder]bt.pincode.placeholder" name="btPinCode" value="">
 				</div>
 				<br>
 				<div class="text-center">
@@ -575,18 +574,18 @@
 					<label for="initialVolume" data-i18n="[prepend]general.volume.restart">:</label>
 						<div class="text-center">
 					<i class="fas fa-volume-down fa-2x .icon-pos"></i> <input data-provide="slider" type="number" data-slider-min="1" data-slider-max="21" min="1" max="21" class="form-control" id="initialVolume" name="initialVolume"
-						data-slider-value="%INIT_VOLUME%"  value="%INIT_VOLUME%" required>  <i class="fas fa-volume-up fa-2x .icon-pos"></i></div>
+						data-slider-value=""  value="" required>  <i class="fas fa-volume-up fa-2x .icon-pos"></i></div>
 						<br>
 					<label for="maxVolumeSpeaker" data-i18n="[prepend]general.volume.speakerMax">:</label>
 						<div class="text-center">
 					 <i class="fas fa-volume-down fa-2x .icon-pos"></i>   <input data-provide="slider" type="number" data-slider-min="1" data-slider-max="21" min="1" max="21" class="form-control" id="maxVolumeSpeaker" name="maxVolumeSpeaker"
-						data-slider-value="%MAX_VOLUME_SPEAKER%"  value="%MAX_VOLUME_SPEAKER%" required>  <i class="fas fa-volume-up fa-2x .icon-pos"></i>
+						data-slider-value="1"  value="1" required>  <i class="fas fa-volume-up fa-2x .icon-pos"></i>
 						</div>
 						<br>
 					<label for="maxVolumeHeadphone" data-i18n="[prepend]general.volume.headphoneMax">:</label>
 						<div class="text-center">
 					<i class="fas fa-volume-down fa-2x .icon-pos"></i> <input data-provide="slider" type="number" data-slider-min="1" data-slider-max="21" min="1" max="21" class="form-control" id="maxVolumeHeadphone" name="maxVolumeHeadphone"
-						 data-slider-value="%MAX_VOLUME_HEADPHONE%" value="%MAX_VOLUME_HEADPHONE%" required>  <i class="fas fa-volume-up fa-2x .icon-pos"></i>
+						 data-slider-value="" value="" required>  <i class="fas fa-volume-up fa-2x .icon-pos"></i>
 						</div>
 				</fieldset>
 				</div>
@@ -598,12 +597,12 @@
 						<div class="text-center">
 							<i class="far fa-sun fa-2x .icon-pos"></i>
 						<input data-provide="slider" type="number" data-slider-min="0" data-slider-max="254" min="0" max="254" class="form-control" id="initBrightness" name="initBrightness"
-							   data-slider-value="%INIT_LED_BRIGHTNESS%"  value="%INIT_LED_BRIGHTNESS%" required><i class="fas fa-sun fa-2x .icon-pos"></i>
+							   data-slider-value="0"  value="0" required><i class="fas fa-sun fa-2x .icon-pos"></i>
 						</div>
 
 					<label for="nightBrightness" data-i18n="[prepend]general.neopixel.nightmode">:</label>
 						<div class="text-center">
-						<i class="far fa-sun fa-2x .icon-pos"></i><input data-provide="slider" type="number" data-slider-min="0" data-slider-max="255" min="0" max="255" class="form-control" id="nightBrightness" name="nightBrightness" data-slider-value="%NIGHT_LED_BRIGHTNESS%" value="%NIGHT_LED_BRIGHTNESS%" required><i class="fas fa-sun fa-2x .icon-pos"></i>
+						<i class="far fa-sun fa-2x .icon-pos"></i><input data-provide="slider" type="number" data-slider-min="0" data-slider-max="255" min="0" max="255" class="form-control" id="nightBrightness" name="nightBrightness" data-slider-value="" value="" required><i class="fas fa-sun fa-2x .icon-pos"></i>
 						</div>
 					</fieldset>
 				</div>
@@ -614,7 +613,7 @@
 
 						<label for="inactivityTime" data-i18n="general.sleep.incativity"></label>
 						<div class="text-center"><i class="fas fa-hourglass-start fa-2x .icon-pos"></i> <input type="number" data-provide="slider" data-slider-min="0" data-slider-max="30" min="1" max="120" class="form-control" id="inactivityTime" name="inactivityTime"
-						 data-slider-value="%MAX_INACTIVITY%"  value="%MAX_INACTIVITY%" required><i class="fas fa-hourglass-end fa-2x .icon-pos"></i></div>
+						 data-slider-value=""  value="" required><i class="fas fa-hourglass-end fa-2x .icon-pos"></i></div>
 					</fieldset>
 				</div>
 				<br>
@@ -627,27 +626,27 @@
 					<label for="warningLowVoltage" data-i18n="[prepend]general.battery.lowWarning">:</label>
 						<div class="text-center">
 						<i class="fas fa-battery-quarter fa-2x .icon-pos"></i> <input  data-provide="slider"  data-slider-step="0.1" data-slider-min="2.5" data-slider-max="5.0"  min="2.5" max="5.0" type="text" class="form-control" id="warningLowVoltage" name="warningLowVoltage"
-						data-slider-value="%WARNING_LOW_VOLTAGE%" value="%WARNING_LOW_VOLTAGE%" pattern="^\d{1,2}(\.\d{1,3})?" required> <i class="fas fa-battery-three-quarters fa-2x .icon-pos" fa-2x .icon-pos></i>
+						data-slider-value="" value="" pattern="^\d{1,2}(\.\d{1,3})?" required> <i class="fas fa-battery-three-quarters fa-2x .icon-pos" fa-2x .icon-pos></i>
 						</div>
 					<br>
 					<label for="voltageIndicatorLow" data-i18n="[prepend]general.battery.lowCritical">:</label>
 						<div class="text-center">
 						<i class="fas fa-battery-quarter fa-2x .icon-pos"></i> <input data-provide="slider" min="2.5" data-slider-step="0.1" data-slider-min="2.5" data-slider-max="5.0" max="5.0" type="text" class="form-control" id="voltageIndicatorLow" name="voltageIndicatorLow"
-						  data-slider-value="%VOLTAGE_INDICATOR_LOW%"  value="%VOLTAGE_INDICATOR_LOW%" pattern="^\d{1,2}(\.\d{1,3})?" required> <i class="fas fa-battery-three-quarters fa-2x .icon-pos" fa-2x .icon-pos></i>
+						  data-slider-value=""  value="" pattern="^\d{1,2}(\.\d{1,3})?" required> <i class="fas fa-battery-three-quarters fa-2x .icon-pos" fa-2x .icon-pos></i>
 						</div>
 						<br>
 						<label for="voltageIndicatorHigh" data-i18n="[prepend]general.battery.high">:</label>
 
 							<div class="text-center">
 								<i class="fas fa-battery-quarter fa-2x .icon-pos"></i><input data-provide="slider" data-slider-step="0.1"  data-slider-min="2.0" data-slider-max="5.0" min="2.0" max="5.0" type="text" class="form-control" id="voltageIndicatorHigh" name="voltageIndicatorHigh"
-						   data-slider-value="%VOLTAGE_INDICATOR_HIGH%"  value="%VOLTAGE_INDICATOR_HIGH%" pattern="^\d{1,2}(\.\d{1,3})?" required> <i class="fas fa-battery-three-quarters fa-2x .icon-pos" fa-2x .icon-pos></i>
+						   data-slider-value=""  value="" pattern="^\d{1,2}(\.\d{1,3})?" required> <i class="fas fa-battery-three-quarters fa-2x .icon-pos" fa-2x .icon-pos></i>
 						</div>
 
 						<br>
 					<label for="voltageCheckInterval" data-i18n="[prepend]general.battery.measureInterval">:</label>
 						<div class="text-center"><i class="fas fa-hourglass-start fa-2x .icon-pos"></i>
 							<input data-provide="slider" data-slider-min="1" data-slider-max="60" type="number" min="1" max="60" class="form-control" id="voltageCheckInterval"
-								   data-slider-value="%BATTERY_CHECK_INTERVAL%"  name="voltageCheckInterval" value="%BATTERY_CHECK_INTERVAL%" required><i class="fas fa-hourglass-end fa-2x .icon-pos"></i>
+								   data-slider-value=""  name="voltageCheckInterval" value="" required><i class="fas fa-hourglass-end fa-2x .icon-pos"></i>
 					</div>
 
 					</fieldset>
@@ -1383,6 +1382,7 @@
 
 		socket.onopen = function () {
 			setInterval(ping, 15000);
+			getSettings();
 			getTrack();
 			getCoverimage();
 		};
@@ -1446,8 +1446,61 @@
 				}
 			} if ("coverimg" in socketMsg) {
 				document.getElementById('coverimg').src = "/cover?" + new Date().getTime();
-		  }
+			} if ("settings" in socketMsg) {
+				fillSettings(socketMsg.settings);
+		  	}
 	  };
+	}
+
+	async function fillSettings(settings) {
+		document.getElementById("hostname").value = settings.hostname;
+		document.getElementById("rfidIdMusic").value = settings.rfidTagId;
+		// general
+		let genSettings = settings.general;
+		document.getElementById('maxVolumeSpeaker').value = genSettings.mVolSpeaker;
+		document.getElementById('initialVolume').value = genSettings.iVol;
+		volumeSlider.setValue(settings.volume);
+		document.getElementById('maxVolumeHeadphone').value = genSettings.mVolHeadphone;
+		document.getElementById('initBrightness').value = genSettings.iBright; 
+		document.getElementById('nightBrightness').value = genSettings.nBright;
+		document.getElementById('inactivityTime').value = genSettings.iTime;
+		document.getElementById('warningLowVoltage').value = genSettings.vWarning;
+		document.getElementById('voltageIndicatorLow').value = genSettings.vIndLow;
+		document.getElementById('voltageIndicatorHigh').value = genSettings.vIndHi;
+		document.getElementById('voltageCheckInterval').value = genSettings.vInt;
+
+		// ftp
+		let ftpSettings = settings.ftp;
+		if (ftpSettings) {
+			document.getElementById('nav-ftp-tab').setAttribute('data-visible', true);
+			document.getElementById("ftpUser").value = ftpSettings.ftpUser;
+			document.getElementById("ftpUser").setAttribute('max_length', ftpSettings.maxUserLength);
+			document.getElementById("ftpPwd").value = ftpSettings.ftpPwd;
+			document.getElementById("ftpPwd").setAttribute('max_length', ftpSettings.maxPwdLength);
+		}
+		// mqtt
+		let mqttSettings = settings.mqtt;
+		if (mqttSettings) {
+			// todo: get the bootstrap sliders to work:
+			document.getElementById('nav-mqtt-tab').setAttribute('data-visible', true);
+			document.getElementById('mqttEnable').checked = mqttSettings.mqttEnable;
+			document.getElementById('mqttClientId').value = mqttSettings.mqttClientId;
+			document.getElementById('mqttClientId').setAttribute('max_length', mqttSettings.mqttClientIdLength);
+			document.getElementById('mqttServer').value = mqttSettings.mqttServer;
+			document.getElementById('mqttServer').setAttribute('max_length', mqttSettings.mqttServerLength);
+			document.getElementById('mqttUser').value = mqttSettings.mqttUser;
+			document.getElementById('mqttUser').setAttribute('max_length', mqttSettings.maxUserLength);
+			document.getElementById('mqttPwd').value = mqttSettings.mqttPwd;
+			document.getElementById('mqttPwd').setAttribute('max_length', mqttSettings.maxPwdLength);
+			document.getElementById('mqttPort').value = mqttSettings.mqttPort;
+		}
+		// bluetooth
+		let btSettings = settings.bluetooth;
+		if (btSettings) {
+			document.getElementById('nav-bt-tab').setAttribute('data-visible', true);
+			document.getElementById('btDeviceName').value = btSettings.deviceName;
+			document.getElementById('btPinCode').value = btSettings.pinCode;
+		}
 	}
 
 	const wifiListSavedSSIDs = document.getElementById("wifiListSavedSSIDs");
@@ -1575,6 +1628,15 @@
 		socket.send(myJSON);
 	}
 
+	function getSettings() {
+		var myObj = {
+			"settings": {
+				settings: 'settings'
+			}
+		};
+		var myJSON = JSON.stringify(myObj);
+		socket.send(myJSON);
+	}
 
 	function genSettings(clickedId) {
 		lastIdclicked = clickedId;

--- a/html/management.html
+++ b/html/management.html
@@ -597,7 +597,7 @@
 						<div class="text-center">
 							<i class="far fa-sun fa-2x .icon-pos"></i>
 						<input data-provide="slider" type="number" data-slider-min="0" data-slider-max="254" min="0" max="254" class="form-control" id="initBrightness" name="initBrightness"
-							   data-slider-value="0"  value="0" required><i class="fas fa-sun fa-2x .icon-pos"></i>
+							   data-slider-value=""  value="" required><i class="fas fa-sun fa-2x .icon-pos"></i>
 						</div>
 
 					<label for="nightBrightness" data-i18n="[prepend]general.neopixel.nightmode">:</label>
@@ -1457,26 +1457,26 @@
 		document.getElementById("rfidIdMusic").value = settings.rfidTagId;
 		// general
 		let genSettings = settings.general;
-		document.getElementById('maxVolumeSpeaker').value = genSettings.mVolSpeaker;
-		document.getElementById('initialVolume').value = genSettings.iVol;
+		$('#initialVolume').bootstrapSlider('setValue', genSettings.iVol);
+		$('#maxVolumeSpeaker').bootstrapSlider('setValue', genSettings.mVolSpeaker);
 		volumeSlider.setValue(settings.volume);
-		document.getElementById('maxVolumeHeadphone').value = genSettings.mVolHeadphone;
-		document.getElementById('initBrightness').value = genSettings.iBright; 
-		document.getElementById('nightBrightness').value = genSettings.nBright;
-		document.getElementById('inactivityTime').value = genSettings.iTime;
-		document.getElementById('warningLowVoltage').value = genSettings.vWarning;
-		document.getElementById('voltageIndicatorLow').value = genSettings.vIndLow;
-		document.getElementById('voltageIndicatorHigh').value = genSettings.vIndHi;
-		document.getElementById('voltageCheckInterval').value = genSettings.vInt;
+		$('#maxVolumeHeadphone').bootstrapSlider('setValue', genSettings.mVolHeadphone);
+		$('#initBrightness').bootstrapSlider('setValue', genSettings.iBright);
+		$('#nightBrightness').bootstrapSlider('setValue', genSettings.nBright);
+		$('#inactivityTime').bootstrapSlider('setValue', genSettings.iTime);
+		$('#warningLowVoltage').bootstrapSlider('setValue', genSettings.vWarning);
+		$('#voltageIndicatorLow').bootstrapSlider('setValue', genSettings.vIndLow);
+		$('#voltageIndicatorHigh').bootstrapSlider('setValue', genSettings.vIndHi);
+		$('#voltageCheckInterval').bootstrapSlider('setValue', genSettings.vInt);
 
 		// ftp
 		let ftpSettings = settings.ftp;
 		if (ftpSettings) {
 			document.getElementById('nav-ftp-tab').setAttribute('data-visible', true);
 			document.getElementById("ftpUser").value = ftpSettings.ftpUser;
-			document.getElementById("ftpUser").setAttribute('max_length', ftpSettings.maxUserLength);
+			document.getElementById("ftpUser").setAttribute('maxlength', ftpSettings.maxUserLength);
 			document.getElementById("ftpPwd").value = ftpSettings.ftpPwd;
-			document.getElementById("ftpPwd").setAttribute('max_length', ftpSettings.maxPwdLength);
+			document.getElementById("ftpPwd").setAttribute('maxlength', ftpSettings.maxPwdLength);
 		}
 		// mqtt
 		let mqttSettings = settings.mqtt;
@@ -1485,13 +1485,13 @@
 			document.getElementById('nav-mqtt-tab').setAttribute('data-visible', true);
 			document.getElementById('mqttEnable').checked = mqttSettings.mqttEnable;
 			document.getElementById('mqttClientId').value = mqttSettings.mqttClientId;
-			document.getElementById('mqttClientId').setAttribute('max_length', mqttSettings.mqttClientIdLength);
+			document.getElementById('mqttClientId').setAttribute('maxlength', mqttSettings.mqttClientIdLength);
 			document.getElementById('mqttServer').value = mqttSettings.mqttServer;
-			document.getElementById('mqttServer').setAttribute('max_length', mqttSettings.mqttServerLength);
+			document.getElementById('mqttServer').setAttribute('maxlength', mqttSettings.mqttServerLength);
 			document.getElementById('mqttUser').value = mqttSettings.mqttUser;
-			document.getElementById('mqttUser').setAttribute('max_length', mqttSettings.maxUserLength);
+			document.getElementById('mqttUser').setAttribute('maxlength', mqttSettings.maxUserLength);
 			document.getElementById('mqttPwd').value = mqttSettings.mqttPwd;
-			document.getElementById('mqttPwd').setAttribute('max_length', mqttSettings.maxPwdLength);
+			document.getElementById('mqttPwd').setAttribute('maxlength', mqttSettings.maxPwdLength);
 			document.getElementById('mqttPort').value = mqttSettings.mqttPort;
 		}
 		// bluetooth

--- a/html/management.html
+++ b/html/management.html
@@ -154,7 +154,7 @@
 	<a class="reboot float-right nav-link openPopupRestart" href="javascript:void(0);"><i class="fas fa-redo"></i> <span data-i18n="restart">Restart</span></a>
 	<a class="reboot float-right nav-link" href="/shutdown"><i class="fas fa-power-off"></i> <span data-i18n="shutdown">Shutdown</span></a>
 	<a class="reboot float-right nav-link openPopupLog" href="javascript:void(0);"><i class="fas fa-book"></i> <span data-i18n="log">Log</span></a>
-	<a class="reboot float-right nav-link openPopupInfo" href="javascript:void(0);"><i class="fas fa-info"></i> <span data-i18n="info">Infos</span></a>
+	<a class="reboot float-right nav-link openPopupInfo" href="javascript:void(0);"><i class="fas fa-info"></i> <span data-i18n="info">Info</span></a>
 	<select class="form-control float-right" style="width:auto;padding-right:25px;" id="langSel" name="langSel">
 		<option value="de">de</option>
 		<option value="en">en</option>
@@ -1386,9 +1386,10 @@
 
 		socket.onopen = function () {
 			setInterval(ping, 15000);
-			requestSettings();
-			getTrack();
-			getCoverimage();
+			socket.send('{"settings":{}}');		// request settings
+			socket.send('{"ssids":{}}');		// request SSIDs
+			socket.send('{"trackinfo":{}}');	// get current track
+			socket.send('{"coverimg":{}}');		// get cover image
 		};
 
 		socket.onclose = function (e) {
@@ -1494,6 +1495,11 @@
 			document.getElementById("hostname").value = wifiSettings.hostname;
 			document.getElementById("scan_wifi_on_start").checked = wifiSettings.scanOnStart;
 		}
+		// ssids
+		let ssidSettings = settings.ssids;
+		if (ssidSettings) {	
+			rebuildSSIDList(ssidSettings);
+		}
 		// led
 		let ledSettings = settings.led;
 		if (ledSettings) {
@@ -1549,17 +1555,19 @@
 		fillSettings(defaults);
 	}
 
-	const wifiListSavedSSIDs = document.getElementById("wifiListSavedSSIDs");
-	async function rebuildSSIDList() {
-		let ssidList = await (await fetch("/savedSSIDs")).json();
-		let ssidActiveObj = await (await fetch("/activeSSID")).json();
-
-		console.log(ssidActiveObj);
-		let ssidActive = ssidActiveObj.active;
-
-		console.log(ssidList);
-		console.log(ssidActive);
-
+	const wifiListSavedSSIDs = document.getElementById("wifiListSavedSSIDs");	
+	async function rebuildSSIDList(data) {		
+		var ssidList;
+		var ssidActive;
+		if (data) {
+			ssidList = data.savedSSIDs;
+			ssidActive = data.active;
+		} else {
+			ssidList = await (await fetch("/savedSSIDs")).json();
+			let ssidActiveObj = await (await fetch("/activeSSID")).json();
+			console.log(ssidActiveObj);
+			ssidActive = ssidActiveObj.active;
+		}			
 		wifiListSavedSSIDs.innerHTML = "";
 
 		for (let ssid of ssidList) {
@@ -1592,12 +1600,7 @@
 			ssidElem.appendChild(deleteSpan);
 
 			wifiListSavedSSIDs.appendChild(ssidElem);
-		}	
-	}
-
-	function onWifiTabOpened() {
-		console.log("wifi tab opened!");
-		rebuildSSIDList();
+		}
 	}
 
 	async function deleteSSID(ssid) {
@@ -1606,20 +1609,6 @@
 		await fetch("/savedSSIDs/" + ssid, {method: "DELETE"});
 		await rebuildSSIDList();
 	}
-
-
-    const config = {attributes: true};
-	const wifiTab = document.getElementById("nav-wifi-tab");
-	var wifiTabWasActive = false;
-	const wifiTabObserver = new MutationObserver((mutationList, observer) => {
-		if (!wifiTabWasActive && wifiTab.classList.contains("active")) {
-			wifiTabWasActive = true;
-			onWifiTabOpened();
-		} else {
-			wifiTabWasActive = false;
-		}
-	})
-	wifiTabObserver.observe(wifiTab, config);
 
 
 	function ping() {
@@ -1637,36 +1626,6 @@
 
 	function pong() {
 		clearTimeout(tm);
-	}
-
-	function getTrack() {
-		var myObj = {
-			"trackinfo": {
-				trackinfo: 'trackinfo'
-			}
-		};
-		var myJSON = JSON.stringify(myObj);
-		socket.send(myJSON);
-	}
-
-	function getCoverimage() {
-		var myObj = {
-			"coverimg": {
-				coverimg: 'coverimg'
-			}
-		};
-		var myJSON = JSON.stringify(myObj);
-		socket.send(myJSON);
-	}
-
-	function requestSettings() {
-		var myObj = {
-			"settings": {
-				settings: 'settings'
-			}
-		};
-		var myJSON = JSON.stringify(myObj);
-		socket.send(myJSON);
 	}
 
 	function genSettings(clickedId) {

--- a/html/management.html
+++ b/html/management.html
@@ -653,8 +653,8 @@
 				</div>
 <br>
 				<div class="text-center">
-					<button type="reset" class="btn btn-secondary" data-i18n="reset" onclick="resetSettings()"></button>&nbsp
-					<button type="submit" class="btn btn-primary" data-i18n="submit"></button>
+				<button type="reset" class="btn btn-secondary" data-i18n="reset" onclick="resetSettings()"></button>&nbsp
+				<button type="submit" class="btn btn-primary" data-i18n="submit"></button>
 				</div>
 			</form>
 		</div>

--- a/html/management.html
+++ b/html/management.html
@@ -334,6 +334,8 @@
 							<option value="140" data-i18n="files.rfid.mod.cmd.140"></option>
 							<option value="141" data-i18n="files.rfid.mod.cmd.141"></option>
 							<option value="150" data-i18n="files.rfid.mod.cmd.150"></option>
+							<option value="151" data-i18n="files.rfid.mod.cmd.151"></option>
+							<option value="152" data-i18n="files.rfid.mod.cmd.152"></option>
 							<option value="0" data-i18n="files.rfid.mod.cmd.0"></option>
 							<option value="170" data-i18n="files.rfid.mod.cmd.170"></option>
 							<option value="171" data-i18n="files.rfid.mod.cmd.171"></option>
@@ -438,6 +440,8 @@
 								<option value="140" data-i18n="files.rfid.mod.cmd.140"></option>
 								<option value="141" data-i18n="files.rfid.mod.cmd.141"></option>
 								<option value="150" data-i18n="files.rfid.mod.cmd.150"></option>
+								<option value="151" data-i18n="files.rfid.mod.cmd.151"></option>
+								<option value="152" data-i18n="files.rfid.mod.cmd.152"></option>
 								<option value="0" data-i18n="files.rfid.mod.cmd.0"></option>
 								<option value="170" data-i18n="files.rfid.mod.cmd.170"></option>
 								<option value="171" data-i18n="files.rfid.mod.cmd.171"></option>
@@ -1382,7 +1386,7 @@
 
 		socket.onopen = function () {
 			setInterval(ping, 15000);
-			getSettings();
+			requestSettings();
 			getTrack();
 			getCoverimage();
 		};
@@ -1490,12 +1494,12 @@
 			document.getElementById("hostname").value = wifiSettings.hostname;
 			document.getElementById("scan_wifi_on_start").checked = wifiSettings.scanOnStart;
 		}
-		// neopixel
-		let neopixelSettings = settings.neopixel;
-		if (neopixelSettings) {
+		// led
+		let ledSettings = settings.led;
+		if (ledSettings) {
 			document.getElementById('neopixelConfig').setAttribute('data-visible', true);
-			$('#initBrightness').bootstrapSlider('setValue', neopixelSettings.initBrightness);
-			$('#nightBrightness').bootstrapSlider('setValue', neopixelSettings.nightBrightness);
+			$('#initBrightness').bootstrapSlider('setValue', ledSettings.initBrightness);
+			$('#nightBrightness').bootstrapSlider('setValue', ledSettings.nightBrightness);
 		}
 		// battery
 		let batSettings = settings.battery;
@@ -1522,9 +1526,9 @@
 			document.getElementById('nav-mqtt-tab').setAttribute('data-visible', true);
 			document.getElementById('mqttEnable').checked = mqttSettings.enable;
 			document.getElementById('mqttClientId').value = mqttSettings.clientID;
-			document.getElementById('mqttClientId').setAttribute('maxlength', mqttSettings.mqttClientIdLength);
+			document.getElementById('mqttClientId').setAttribute('maxlength', mqttSettings.maxClientIdLength);
 			document.getElementById('mqttServer').value = mqttSettings.server;
-			document.getElementById('mqttServer').setAttribute('maxlength', mqttSettings.mqttServerLength);
+			document.getElementById('mqttServer').setAttribute('maxlength', mqttSettings.maxServerLength);
 			document.getElementById('mqttUser').value = mqttSettings.username;
 			document.getElementById('mqttUser').setAttribute('maxlength', mqttSettings.maxUserLength);
 			document.getElementById('mqttPwd').value = mqttSettings.password;
@@ -1655,7 +1659,7 @@
 		socket.send(myJSON);
 	}
 
-	function getSettings() {
+	function requestSettings() {
 		var myObj = {
 			"settings": {
 				settings: 'settings'
@@ -1673,7 +1677,7 @@
 				maxVolumeSp: document.getElementById('maxVolumeSpeaker').value,
 				maxVolumeHp: document.getElementById('maxVolumeHeadphone').value, 
 				sleepInactivity: document.getElementById('inactivityTime').value},
-			"neopixel": {
+			"led": {
 				initBrightness: document.getElementById('initBrightness').value,
 				nightBrightness: document.getElementById('nightBrightness').value},
 			"battery": {
@@ -1779,7 +1783,7 @@
 
 		var myObj = { 
 			hostname: hostname,
-			scanwifionstart: scanWifi
+			scanOnStart: scanWifi
 		};
 		
 		await fetch("/wificonfig", {

--- a/html/management.html
+++ b/html/management.html
@@ -1681,8 +1681,8 @@
 			"general": {
 				iVol: document.getElementById('initialVolume').value,
 				mVolSpeaker: document.getElementById('maxVolumeSpeaker').value,
-				mVolHeadphone: document.getElementById('maxVolumeHeadphone').value },
-				iTime: document.getElementById('inactivityTime').value,
+				mVolHeadphone: document.getElementById('maxVolumeHeadphone').value, 
+				iTime: document.getElementById('inactivityTime').value},
 			"neopixel": {
 				iBright: document.getElementById('initBrightness').value,
 				nBright: document.getElementById('nightBrightness').value},

--- a/processHtml.py
+++ b/processHtml.py
@@ -24,13 +24,12 @@ OUTPUT_DIR = (
 )  # pylint: disable=undefined-variable
 HTML_DIR = Path("html").absolute()
 # List of files, which will only be minifed but not compressed (f.e. html files with templates)
-WWW_FILES = [
-    Path("management.html"),
-    Path("accesspoint.html"),
-]
+WWW_FILES = []
 # list of all files, which shall be compressed before embedding
 # files with ".json" ending will be minifed before compression, ".js" will not be changed!
 BINARY_FILES =[
+    Path("management.html"),
+    Path("accesspoint.html"),
     Path("js/i18next.min.js"),
     Path("js/i18nextHttpBackend.min.js"),
     Path("js/loc_i18next.min.js"),

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -23,7 +23,7 @@ typedef struct { // Bit field
 	bool newPlayMono:                   1;      // true if mono; false if stereo (helper)
 	bool currentPlayMono:               1;      // true if mono; false if stereo
 	bool isWebstream:                   1;      // Indicates if track currenty played is a webstream
-	bool tellIpAddress:                 1;      // If true current IP-address is spoken
+	uint8_t tellMode:                   2;      // Tell mode for text to speech announcments
 	bool currentSpeechActive:           1;      // If speech-play is active
 	bool lastSpeechActive:              1;      // If speech-play was active
 	size_t coverFilePos;                        // current cover file position

--- a/src/Cmd.cpp
+++ b/src/Cmd.cpp
@@ -275,7 +275,20 @@ void Cmd_Action(const uint16_t mod) {
 
 		case CMD_TELL_IP_ADDRESS: {
 			if (Wlan_IsConnected()) {
-				gPlayProperties.tellIpAddress = true;
+				gPlayProperties.tellMode = TTS_IP_ADDRESS;
+				gPlayProperties.currentSpeechActive = true;
+				gPlayProperties.lastSpeechActive = true;
+				System_IndicateOk();
+			} else {
+				Log_Println(unableToTellIpAddress, LOGLEVEL_ERROR);
+				System_IndicateError();
+			}
+			break;
+		}
+		
+		case CMD_TELL_CURRENT_TIME: {
+			if (Wlan_IsConnected()) {
+				gPlayProperties.tellMode = TTS_CURRENT_TIME;
 				gPlayProperties.currentSpeechActive = true;
 				gPlayProperties.lastSpeechActive = true;
 				System_IndicateOk();

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -197,19 +197,12 @@ void System_PreparePowerDown(void) {
 	SdCard_Exit();
 
 	Serial.flush();
-	// switch off power
-	Power_PeripheralOff();
-	delay(200);
-	#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
-		Rfid_Exit();
-	#endif
-	#ifdef PORT_EXPANDER_ENABLE
-		Port_Exit();
-	#endif
 }
 
 void System_Restart(void) {
+	// prepare power down (shutdown common modules)
 	System_PreparePowerDown();
+	// restart the ESP-32
 	Log_Println("restarting..", LOGLEVEL_NOTICE);
 	ESP.restart();
 }
@@ -223,9 +216,20 @@ void System_DeepSleepManager(void) {
 
 		System_Sleeping = true;
 		Log_Println(goToSleepNow, LOGLEVEL_NOTICE);
-
+		// prepare power down (shutdown common modules)
 		System_PreparePowerDown();
-
+		// switch off power
+		Power_PeripheralOff();
+		// time to settle down..
+		delay(200);
+		// .. for LPCD
+		#if defined (RFID_READER_TYPE_MFRC522_SPI) || defined (RFID_READER_TYPE_MFRC522_I2C) || defined(RFID_READER_TYPE_PN5180)
+			Rfid_Exit();
+		#endif
+		#ifdef PORT_EXPANDER_ENABLE
+			Port_Exit();
+		#endif
+		// goto sleep now
 		Log_Println("deep-sleep, good night.......", LOGLEVEL_NOTICE);
 		esp_deep_sleep_start();
 	}

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -312,6 +312,7 @@ void webserverStart(void) {
 		// software/wifi/heap/psram-info
 		wServer.on(
 			"/info", HTTP_GET, [](AsyncWebServerRequest *request) {
+				char buffer[128];
 				String info = "ESPuino " + (String) softwareRevision;
 				info += "\nESPuino " + (String) gitRevision;
 				info += "\nArduino version: " + String(ESP_ARDUINO_VERSION_MAJOR) + '.' + String(ESP_ARDUINO_VERSION_MINOR) + '.' + String(ESP_ARDUINO_VERSION_PATCH);
@@ -338,14 +339,12 @@ void webserverStart(void) {
 					}
 				#endif
 				#ifdef BATTERY_MEASURE_ENABLE
-					char buffer[128];
 					snprintf(buffer, sizeof(buffer), currentVoltageMsg, Battery_GetVoltage());
 					info += "\n" + String(buffer);
 					snprintf(buffer, sizeof(buffer), currentChargeMsg, Battery_EstimateLevel() * 100);
 					info += "\n" + String(buffer);
 				#endif
                 #ifdef HALLEFFECT_SENSOR_ENABLE
-					char buffer[128];
 					uint16_t sva = gHallEffectSensor.readSensorValueAverage(true);
 					int diff = sva-gHallEffectSensor.NullFieldValue();
 					snprintf(buffer, sizeof(buffer), "\nHallEffectSensor NullFieldValue:%d, actual:%d, diff:%d, LastWaitFor_State:%d (waited:%d ms)", gHallEffectSensor.NullFieldValue(), sva, diff, gHallEffectSensor.LastWaitForState(), gHallEffectSensor.LastWaitForStateMS());
@@ -617,7 +616,7 @@ bool JSONToSettings(JsonObject doc) {
 		// Check if settings were written successfully
 		if (gPrefsSettings.getString("btDeviceName", "") != _btDeviceName ||
 			gPrefsSettings.getString("btPinCode", "") != btPinCode) {
-				Log_Println("JSONToSettings: Failed to assign bluetooth general settings", LOGLEVEL_DEBUG);
+				Log_Println("JSONToSettings: Failed to assign bluetooth settings", LOGLEVEL_DEBUG);
 				return false;
 		}
 	} else if (doc.containsKey("rfidMod")) {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -712,7 +712,7 @@ static void settingsToJSON(JsonObject obj, String section) {
 			batteryObj["vInt"].set(gPrefsSettings.getUInt("vCheckIntv", s_batteryCheckInterval));
 		}
 	#endif
-	if ((section == "") || (section == "defaults")) {
+	if (section == "defaults") {
 		// default factory settings
 		JsonObject defaultsObj = obj.createNestedObject("defaults");
 		defaultsObj["iVol"].set(5u);			// AUDIOPLAYER_VOLUME_INIT

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -761,8 +761,7 @@ static void settingsToJSON(JsonObject obj, String section) {
 	// Bluetooth
 	#ifdef BLUETOOTH_ENABLE
 		if ((section == "") || (section == "bluetooth")) {
-			JsonObject btObj = obj.createNestedObject("bluetooth");
-			btObj["enabled"].set(true);	
+			JsonObject btObj = obj.createNestedObject("bluetooth");	
 			btObj["deviceName"] = gPrefsSettings.getString("btDeviceName", "");
 			btObj["pinCode"] = gPrefsSettings.getString("btPinCode", "");
 		}

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -667,7 +667,6 @@ static void settingsToJSON(JsonObject obj, String section) {
 		JsonObject curObj = obj.createNestedObject("current");
 		curObj["volume"].set(AudioPlayer_GetCurrentVolume());
 		curObj["rfidTagId"] = String(gCurrentRfidTagId);
-		curObj["hostname"] = Wlan_GetHostname();
 	}
 	if ((section == "") || (section == "general")) {
 		// general settings

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -521,9 +521,9 @@ static void settingsToJSON(JsonObject obj) {
 	generalObj["iBright"].set(gPrefsSettings.getUInt("iLedBrightness", 0));
 	generalObj["nBright"].set(gPrefsSettings.getUInt("nLedBrightness", 0));
 	generalObj["iTime"].set(gPrefsSettings.getUInt("mInactiviyT", 0));
-	generalObj["vWarning"].set(gPrefsSettings.getUInt("wLowVoltage", 0));
-	generalObj["vIndLow"].set(gPrefsSettings.getUInt("vIndicatorLow", 0));
-	generalObj["vIndHigh"].set(gPrefsSettings.getUInt("vIndicatorHigh", 0));
+	generalObj["vWarning"].set(gPrefsSettings.getFloat("wLowVoltage", 0.0));
+	generalObj["vIndLow"].set(gPrefsSettings.getFloat("vIndicatorLow", 0.0));
+	generalObj["vIndHi"].set(gPrefsSettings.getFloat("vIndicatorHigh", 0.0));
 	generalObj["vInt"].set(gPrefsSettings.getUInt("vCheckIntv", 0));
 	// FTP
 	#ifdef FTP_ENABLE
@@ -579,8 +579,8 @@ bool JSONToSettings(JsonObject doc) {
 		gPrefsSettings.putUInt("initVolume", iVol);
 		gPrefsSettings.putUInt("maxVolumeSp", mVolSpeaker);
 		gPrefsSettings.putUInt("maxVolumeHp", mVolHeadphone);
-		gPrefsSettings.putUChar("iLedBrightness", iBright);
-		gPrefsSettings.putUChar("nLedBrightness", nBright);
+		gPrefsSettings.putUInt("iLedBrightness", iBright);
+		gPrefsSettings.putUInt("nLedBrightness", nBright);
 		gPrefsSettings.putUInt("mInactiviyT", iTime);
 		gPrefsSettings.putFloat("wLowVoltage", vWarning);
 		gPrefsSettings.putFloat("vIndicatorLow", vIndLow);
@@ -591,8 +591,8 @@ bool JSONToSettings(JsonObject doc) {
 		if (gPrefsSettings.getUInt("initVolume", 0) != iVol ||
 			gPrefsSettings.getUInt("maxVolumeSp", 0) != mVolSpeaker ||
 			gPrefsSettings.getUInt("maxVolumeHp", 0) != mVolHeadphone ||
-			gPrefsSettings.getUChar("iLedBrightness", 0) != iBright ||
-			gPrefsSettings.getUChar("nLedBrightness", 0) != nBright ||
+			gPrefsSettings.getUInt("iLedBrightness", 0) != iBright ||
+			gPrefsSettings.getUInt("nLedBrightness", 0) != nBright ||
 			gPrefsSettings.getUInt("mInactiviyT", 0) != iTime ||
 			gPrefsSettings.getFloat("wLowVoltage", 999.99) != vWarning ||
 			gPrefsSettings.getFloat("vIndicatorLow", 999.99) != vIndLow ||

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -516,61 +516,45 @@ bool JSONToSettings(JsonObject doc) {
 		return false;
 	}
 	if (doc.containsKey("general")) {
-		uint8_t iVol = doc["general"]["iVol"].as<uint8_t>();
-		uint8_t mVolSpeaker = doc["general"]["mVolSpeaker"].as<uint8_t>();
-		uint8_t mVolHeadphone = doc["general"]["mVolHeadphone"].as<uint8_t>();
-		uint8_t iTime = doc["general"]["iTime"].as<uint8_t>();
-
-		gPrefsSettings.putUInt("initVolume", iVol);
-		gPrefsSettings.putUInt("maxVolumeSp", mVolSpeaker);
-		gPrefsSettings.putUInt("maxVolumeHp", mVolHeadphone);
-		gPrefsSettings.putUInt("mInactiviyT", iTime);
-		// Check if settings were written successfully
-		if (gPrefsSettings.getUInt("initVolume", 0) != iVol ||
-			gPrefsSettings.getUInt("maxVolumeSp", 0) != mVolSpeaker ||
-			gPrefsSettings.getUInt("maxVolumeHp", 0) != mVolHeadphone ||
-			gPrefsSettings.getUInt("mInactiviyT", 0) != iTime) {
+		// general settings
+		if (gPrefsSettings.putUInt("initVolume", doc["general"]["initVolume"].as<uint8_t>()) == 0  ||
+			gPrefsSettings.putUInt("maxVolumeSp", doc["general"]["maxVolumeSp"].as<uint8_t>()) == 0  ||
+			gPrefsSettings.putUInt("maxVolumeHp", doc["general"]["maxVolumeHp"].as<uint8_t>()) == 0  ||
+			gPrefsSettings.putUInt("mInactiviyT", doc["general"]["sleepInactivity"].as<uint8_t>()) == 0 ) {
 				Log_Println("Failed to save general settings", LOGLEVEL_ERROR);
 				return false;
 			}
 	}
+	if (doc.containsKey("wifi")) {
+		// WiFi settings
+		static String hostName = doc["wifi"]["hostname"];		
+		if (((!Wlan_SetHostname(hostName)) || gPrefsSettings.putBool("ScanWiFiOnStart", doc["wifi"]["scanOnStart"].as<bool>()) == 0))  {
+				Log_Println("Failed to save wifi settings", LOGLEVEL_ERROR);
+				return false;
+		}
+	}
 	if (doc.containsKey("neopixel")) {
-		uint8_t iBright = doc["neopixel"]["iBright"].as<uint8_t>();
-		uint8_t nBright = doc["neopixel"]["nBright"].as<uint8_t>();
-
-		gPrefsSettings.putUInt("iLedBrightness", iBright);
-		gPrefsSettings.putUInt("nLedBrightness", nBright);
-		// Check if settings were written successfully
-		if (gPrefsSettings.getUInt("iLedBrightness", 0) != iBright ||
-			gPrefsSettings.getUInt("nLedBrightness", 0) != nBright) {
+		// Neopixel settings
+		if (gPrefsSettings.putUInt("iLedBrightness", doc["neopixel"]["initBrightness"].as<uint8_t>()) == 0  ||
+			gPrefsSettings.putUInt("nLedBrightness", doc["neopixel"]["nightBrightness"].as<uint8_t>()) == 0 ) {
 				Log_Println("Failed to save neopixel settings", LOGLEVEL_ERROR);
 				return false;
 		}
 	}
 	if (doc.containsKey("battery")) {
-		float vWarning = doc["battery"]["vWarning"].as<float>();
-		float vIndLow = doc["battery"]["vIndLow"].as<float>();
-		float vIndHi = doc["battery"]["vIndHi"].as<float>();
-		uint8_t vInt = doc["battery"]["vInt"].as<uint8_t>();
-
-		gPrefsSettings.putFloat("wLowVoltage", vWarning);
-		gPrefsSettings.putFloat("vIndicatorLow", vIndLow);
-		gPrefsSettings.putFloat("vIndicatorHigh", vIndHi);
-		gPrefsSettings.putUInt("vCheckIntv", vInt);
-
-		// Check if settings were written successfully
-		if (gPrefsSettings.getFloat("wLowVoltage", 999.99) != vWarning ||
-			gPrefsSettings.getFloat("vIndicatorLow", 999.99) != vIndLow ||
-			gPrefsSettings.getFloat("vIndicatorHigh", 999.99) != vIndHi ||
-			gPrefsSettings.getUInt("vCheckIntv", 17777) != vInt) {
+		// Battery settings
+		if (gPrefsSettings.putFloat("wLowVoltage", doc["battery"]["warnLowVoltage"].as<float>()) == 0  ||
+			gPrefsSettings.putFloat("vIndicatorLow", doc["battery"]["indicatorLow"].as<float>()) == 0  ||
+			gPrefsSettings.putFloat("vIndicatorHigh", doc["battery"]["indicatorHi"].as<float>()) == 0  ||
+			gPrefsSettings.putUInt("vCheckIntv", doc["battery"]["voltageCheckInterval"].as<uint8_t>()) == 0 ) {
 				Log_Println("Failed to save battery settings", LOGLEVEL_ERROR);
 				return false;
 			}
 		Battery_Init();
 	} 
 	if (doc.containsKey("ftp")) {
-		const char *_ftpUser = doc["ftp"]["ftpUser"];
-		const char *_ftpPwd = doc["ftp"]["ftpPwd"];
+		const char *_ftpUser = doc["ftp"]["username"];
+		const char *_ftpPwd = doc["ftp"]["password"];
 
 		gPrefsSettings.putString("ftpuser", (String)_ftpUser);
 		gPrefsSettings.putString("ftppassword", (String)_ftpPwd);
@@ -587,12 +571,12 @@ bool JSONToSettings(JsonObject doc) {
 		}
 	} 
 	if (doc.containsKey("mqtt")) {
-		uint8_t _mqttEnable = doc["mqtt"]["mqttEnable"].as<uint8_t>();
-		const char *_mqttClientId = doc["mqtt"]["mqttClientId"];
-		const char *_mqttServer = doc["mqtt"]["mqttServer"];
-		const char *_mqttUser = doc["mqtt"]["mqttUser"];
-		const char *_mqttPwd = doc["mqtt"]["mqttPwd"];
-		uint16_t _mqttPort = doc["mqtt"]["mqttPort"].as<uint16_t>();
+		uint8_t _mqttEnable = doc["mqtt"]["enable"].as<uint8_t>();
+		const char *_mqttClientId = doc["mqtt"]["clientID"];
+		const char *_mqttServer = doc["mqtt"]["server"];
+		const char *_mqttUser = doc["mqtt"]["username"];
+		const char *_mqttPwd = doc["mqtt"]["password"];
+		uint16_t _mqttPort = doc["mqtt"]["port"].as<uint16_t>();
 
 		gPrefsSettings.putUChar("enableMQTT", _mqttEnable);
 		gPrefsSettings.putString("mqttClientId", (String)_mqttClientId);
@@ -688,53 +672,59 @@ static void settingsToJSON(JsonObject obj, String section) {
 	if ((section == "") || (section == "general")) {
 		// general settings
 		JsonObject generalObj = obj.createNestedObject("general");
-		generalObj["iVol"].set(gPrefsSettings.getUInt("initVolume", 0));
-		generalObj["mVolSpeaker"].set(gPrefsSettings.getUInt("maxVolumeSp", 0));
-		generalObj["mVolHeadphone"].set(gPrefsSettings.getUInt("maxVolumeHp", 0));
-		generalObj["iTime"].set(gPrefsSettings.getUInt("mInactiviyT", 0));
+		generalObj["initVolume"].set(gPrefsSettings.getUInt("initVolume", 0));
+		generalObj["maxVolumeSp"].set(gPrefsSettings.getUInt("maxVolumeSp", 0));
+		generalObj["maxVolumeHp"].set(gPrefsSettings.getUInt("maxVolumeHp", 0));
+		generalObj["sleepInactivity"].set(gPrefsSettings.getUInt("mInactiviyT", 0));
+	}
+	if ((section == "") || (section == "wifi")) {
+		// WiFi settings
+		JsonObject wifiObj = obj.createNestedObject("wifi");
+		wifiObj["hostname"] = Wlan_GetHostname();
+		wifiObj["scanOnStart"].set(gPrefsSettings.getBool("ScanWiFiOnStart", false));
 	}
 	#ifdef NEOPIXEL_ENABLE
 		if ((section == "") || (section == "neopixel")) {
 			// Neopixel settings
 			JsonObject neopixelObj = obj.createNestedObject("neopixel");
-			neopixelObj["iBright"].set(gPrefsSettings.getUInt("iLedBrightness", 0));
-			neopixelObj["nBright"].set(gPrefsSettings.getUInt("nLedBrightness", 0));
+			neopixelObj["initBrightness"].set(gPrefsSettings.getUInt("iLedBrightness", 0));
+			neopixelObj["nightBrightness"].set(gPrefsSettings.getUInt("nLedBrightness", 0));
 		}
 	#endif
 	#ifdef MEASURE_BATTERY_VOLTAGE
 		if ((section == "") || (section == "battery")) {
 			// battery settings
 			JsonObject batteryObj = obj.createNestedObject("battery");
-			batteryObj["vWarning"].set(gPrefsSettings.getFloat("wLowVoltage", s_warningLowVoltage));
-			batteryObj["vIndLow"].set(gPrefsSettings.getFloat("vIndicatorLow", s_voltageIndicatorLow));
-			batteryObj["vIndHi"].set(gPrefsSettings.getFloat("vIndicatorHigh", s_voltageIndicatorHigh));
-			batteryObj["vInt"].set(gPrefsSettings.getUInt("vCheckIntv", s_batteryCheckInterval));
+			batteryObj["warnLowVoltage"].set(gPrefsSettings.getFloat("wLowVoltage", s_warningLowVoltage));
+			batteryObj["indicatorLow"].set(gPrefsSettings.getFloat("vIndicatorLow", s_voltageIndicatorLow));
+			batteryObj["indicatorHi"].set(gPrefsSettings.getFloat("vIndicatorHigh", s_voltageIndicatorHigh));
+			batteryObj["voltageCheckInterval"].set(gPrefsSettings.getUInt("vCheckIntv", s_batteryCheckInterval));
 		}
 	#endif
 	if (section == "defaults") {
 		// default factory settings
 		JsonObject defaultsObj = obj.createNestedObject("defaults");
-		defaultsObj["iVol"].set(5u);			// AUDIOPLAYER_VOLUME_INIT
-		defaultsObj["mVolSpeaker"].set(21u);	// AUDIOPLAYER_VOLUME_MAX
-		defaultsObj["mVolHeadphone"].set(18u);	// gPrefsSettings.getUInt("maxVolumeHp", 0));
+		defaultsObj["initVolume"].set(3u);				// AUDIOPLAYER_VOLUME_INIT
+		defaultsObj["maxVolumeSp"].set(21u);			// AUDIOPLAYER_VOLUME_MAX
+		defaultsObj["maxVolumeHp"].set(18u);			// gPrefsSettings.getUInt("maxVolumeHp", 0));
+		defaultsObj["sleepInactivity"].set(10u);		// System_MaxInactivityTime
 		#ifdef NEOPIXEL_ENABLE
-			defaultsObj["iBright"].set(16u);		// LED_INITIAL_BRIGHTNESS
-			defaultsObj["nBright"].set(2u);			// LED_INITIAL_NIGHT_BRIGHTNESS
+			defaultsObj["initBrightness"].set(16u);		// LED_INITIAL_BRIGHTNESS
+			defaultsObj["nightBrightness"].set(2u);		// LED_INITIAL_NIGHT_BRIGHTNESS
 		#endif
-		defaultsObj["iTime"].set(10u);			// System_MaxInactivityTime
 		#ifdef MEASURE_BATTERY_VOLTAGE
-			defaultsObj["vWarning"].set(s_warningLowVoltage);
-			defaultsObj["vIndLow"].set(s_voltageIndicatorLow);
-			defaultsObj["vIndHi"].set(s_voltageIndicatorHigh);
-			defaultsObj["vInt"].set(s_batteryCheckInterval);
+			defaultsObj["warnLowVoltage"].set(s_warningLowVoltage);
+			defaultsObj["indicatorLow"].set(s_voltageIndicatorLow);
+			defaultsObj["indicatorHi"].set(s_voltageIndicatorHigh);
+			defaultsObj["voltageCheckInterval"].set(s_batteryCheckInterval);
 		#endif
 	}
 	// FTP
 	#ifdef FTP_ENABLE
 		if ((section == "") || (section == "ftp")) {
 			JsonObject ftpObj = obj.createNestedObject("ftp");
-			ftpObj["ftpUser"] = gPrefsSettings.getString("ftpuser", "-1");
-			ftpObj["ftpPwd"] = gPrefsSettings.getString("ftppassword", "-1");
+			ftpObj["username"] = gPrefsSettings.getString("ftpuser", "-1");
+			ftpObj["password"] = gPrefsSettings.getString("ftppassword", "-1");
 			ftpObj["maxUserLength"].set(ftpUserLength - 1);
 			ftpObj["maxPwdLength"].set(ftpUserLength - 1);
 		}
@@ -744,12 +734,12 @@ static void settingsToJSON(JsonObject obj, String section) {
 	#ifdef MQTT_ENABLE
 		if ((section == "") || (section == "mqtt")) {
 			JsonObject mqttObj = obj.createNestedObject("mqtt");
-			mqttObj["mqttEnable"].set(Mqtt_IsEnabled());
-				mqttObj["mqttClientId"] = gPrefsSettings.getString("mqttClientId", "-1");
-			mqttObj["mqttServer"] = gPrefsSettings.getString("mqttServer", "-1");
-			mqttObj["mqttPort"].set(gPrefsSettings.getUInt("mqttPort", 0));
-			mqttObj["mqttUser"] = gPrefsSettings.getString("mqttUser", "-1");
-			mqttObj["mqttPwd"] = gPrefsSettings.getString("mqttPassword", "-1");
+			mqttObj["enable"].set(Mqtt_IsEnabled());
+				mqttObj["clientID"] = gPrefsSettings.getString("mqttClientId", "-1");
+			mqttObj["server"] = gPrefsSettings.getString("mqttServer", "-1");
+			mqttObj["port"].set(gPrefsSettings.getUInt("mqttPort", 0));
+			mqttObj["username"] = gPrefsSettings.getString("mqttUser", "-1");
+			mqttObj["password"] = gPrefsSettings.getString("mqttPassword", "-1");
 			mqttObj["maxUserLength"].set(mqttUserLength - 1);
 			mqttObj["maxPwdLength"].set(mqttPasswordLength - 1);
 			mqttObj["maxClientIdLength"].set(mqttClientIdLength - 1);

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -530,7 +530,7 @@ bool JSONToSettings(JsonObject doc) {
 			gPrefsSettings.getUInt("maxVolumeSp", 0) != mVolSpeaker ||
 			gPrefsSettings.getUInt("maxVolumeHp", 0) != mVolHeadphone ||
 			gPrefsSettings.getUInt("mInactiviyT", 0) != iTime) {
-				Log_Println("JSONToSettings: Failed to assign general settings", LOGLEVEL_DEBUG);
+				Log_Println("Failed to save general settings", LOGLEVEL_ERROR);
 				return false;
 			}
 	}
@@ -543,7 +543,7 @@ bool JSONToSettings(JsonObject doc) {
 		// Check if settings were written successfully
 		if (gPrefsSettings.getUInt("iLedBrightness", 0) != iBright ||
 			gPrefsSettings.getUInt("nLedBrightness", 0) != nBright) {
-				Log_Println("JSONToSettings: Failed to assign neopixel settings", LOGLEVEL_DEBUG);
+				Log_Println("Failed to save neopixel settings", LOGLEVEL_ERROR);
 				return false;
 		}
 	}
@@ -563,7 +563,7 @@ bool JSONToSettings(JsonObject doc) {
 			gPrefsSettings.getFloat("vIndicatorLow", 999.99) != vIndLow ||
 			gPrefsSettings.getFloat("vIndicatorHigh", 999.99) != vIndHi ||
 			gPrefsSettings.getUInt("vCheckIntv", 17777) != vInt) {
-				Log_Println("JSONToSettings: Failed to assign battery settings", LOGLEVEL_DEBUG);
+				Log_Println("Failed to save battery settings", LOGLEVEL_ERROR);
 				return false;
 			}
 		Battery_Init();
@@ -577,7 +577,7 @@ bool JSONToSettings(JsonObject doc) {
 		// Check if settings were written successfully
 		if (!(String(_ftpUser).equals(gPrefsSettings.getString("ftpuser", "-1")) ||
 			  String(_ftpPwd).equals(gPrefsSettings.getString("ftppassword", "-1")))) {
-			Log_Println("JSONToSettings: Failed to assign ftp settings", LOGLEVEL_DEBUG);
+			Log_Println("Failed to save ftp settings", LOGLEVEL_ERROR);
 			return false;
 		}
 	} else if (doc.containsKey("ftpStatus")) {
@@ -603,7 +603,7 @@ bool JSONToSettings(JsonObject doc) {
 
 		if ((gPrefsSettings.getUChar("enableMQTT", 99) != _mqttEnable) ||
 			(!String(_mqttServer).equals(gPrefsSettings.getString("mqttServer", "-1")))) {
-			Log_Println("JSONToSettings: Failed to assign mqtt settings", LOGLEVEL_DEBUG);
+			Log_Println("Failed to save mqtt settings", LOGLEVEL_ERROR);
 			return false;
 		}
 	} 
@@ -616,7 +616,7 @@ bool JSONToSettings(JsonObject doc) {
 		// Check if settings were written successfully
 		if (gPrefsSettings.getString("btDeviceName", "") != _btDeviceName ||
 			gPrefsSettings.getString("btPinCode", "") != btPinCode) {
-				Log_Println("JSONToSettings: Failed to assign bluetooth settings", LOGLEVEL_DEBUG);
+				Log_Println("Failed to save bluetooth settings", LOGLEVEL_ERROR);
 				return false;
 		}
 	} else if (doc.containsKey("rfidMod")) {

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -436,10 +436,37 @@ void Wlan_Cyclic(void) {
 	}
 }
 
+
+bool Wlan_ValidateHostname(String newHostname) {
+	size_t len = newHostname.length();
+	const char *hostname = newHostname.c_str();
+
+	// validation: first char alphanumerical, then alphanumerical or '-', last char alphanumerical
+	// These rules are mainly for mDNS purposes, a "pretty" hostname could have far fewer restrictions
+	bool validated = true;
+	if(len < 2 || len > 32) {
+		validated = false;
+	}
+
+	if(!isAlphaNumeric(hostname[0]) || !isAlphaNumeric(hostname[len-1])) {
+		validated = false;
+	}
+
+	for(int i = 0; i < len; i++) {
+		if(!isAlphaNumeric(hostname[i]) && hostname[i] != '-') {
+			validated = false;
+			break;
+		}
+	}
+
+	return validated;
+}
+
 bool Wlan_SetHostname(String newHostname) {
 	// hostname should just be applied after reboot
 	gPrefsSettings.putString("Hostname", newHostname);
-	return true;
+	// check if hostname is written
+	return (gPrefsSettings.getString("Hostname", "-1") == newHostname);
 }
 
 bool Wlan_AddNetworkSettings(WiFiSettings settings) {

--- a/src/Wlan.h
+++ b/src/Wlan.h
@@ -20,6 +20,7 @@ size_t Wlan_GetSSIDs(String*, size_t);
 const String Wlan_GetCurrentSSID();
 const String Wlan_GetHostname();
 bool Wlan_DeleteNetwork(String);
+bool Wlan_ValidateHostname(String);
 bool Wlan_SetHostname(String);
 bool Wlan_IsConnected(void);
 void Wlan_ToggleEnable(void);

--- a/src/values.h
+++ b/src/values.h
@@ -51,6 +51,7 @@
 #define CMD_TOGGLE_BLUETOOTH_SOURCE_MODE 141        // Toggles Normal/Bluetooth source Mode
 #define CMD_ENABLE_FTP_SERVER           150         // Enables FTP-server
 #define CMD_TELL_IP_ADDRESS             151         // Command: ESPuino announces its IP-address via speech
+#define CMD_TELL_CURRENT_TIME           152         // Command: ESPuino announces current time via speech
 
 #define CMD_PLAYPAUSE                   170         // Command: play/pause
 #define CMD_PREVTRACK                   171         // Command: previous track
@@ -77,6 +78,11 @@
 #define SEEK_NORMAL                     0           // Normal play
 #define SEEK_FORWARDS                   1           // Seek forwards
 #define SEEK_BACKWARDS                  2           // Seek backwards
+
+// TTS
+#define TTS_NONE                        0           // Do nothng (IDLE)
+#define TTS_IP_ADDRESS                  1           // Tell IP-address
+#define TTS_CURRENT_TIME                2           // Tell current time
 
 // supported languages
 #define DE                              1


### PR DESCRIPTION
- remove the template processor to make current UI and backend independant
- Load settings on document complete
- Hide/show controls dependant on compiler flags (Neopixel, battery)
- New HTTP GET endpoint "/settings" to load all settings or with param "section" a single settings section ('ftp', 'mqtt', 'bluetooth', 'neopixel', 'battery', 'defaults')
- Bugfix: Reset settings to factory defaults  