### PR TITLE
bugfix_same_rfid_twice init

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -817,8 +817,14 @@ void AudioPlayer_Task(void *parameter) {
 		//esp_task_wdt_reset(); // Don't forget to feed the dog!
 
 		#ifdef DONT_ACCEPT_SAME_RFID_TWICE_ENABLE
+			static uint8_t resetOnNextIdle = false;
 			if (gPlayProperties.playlistFinished || gPlayProperties.playMode == NO_PLAYLIST) {
-				strncpy(gOldRfidTagId, "X", cardIdStringSize-1);     // Set old rfid-id to crap in order to allow to re-apply an rfid-tag after playback is finished
+				if (resetOnNextIdle) {
+					Rfid_ResetOldRfid();
+					resetOnNextIdle = false;
+				}
+			} else {
+				resetOnNextIdle = true;
 			}
 		#endif
 	}

--- a/src/Rfid.h
+++ b/src/Rfid.h
@@ -12,7 +12,7 @@ extern char gCurrentRfidTagId[cardIdStringSize];
 #endif
 
 #ifdef DONT_ACCEPT_SAME_RFID_TWICE_ENABLE
-	extern char gOldRfidTagId[cardIdStringSize];
+	void Rfid_ResetOldRfid(void);
 #endif
 
 void Rfid_Init(void);

--- a/src/RfidCommon.cpp
+++ b/src/RfidCommon.cpp
@@ -104,6 +104,12 @@ void Rfid_PreferenceLookupHandler(void) {
 	#endif
 }
 
+#ifdef DONT_ACCEPT_SAME_RFID_TWICE_ENABLE
+void Rfid_ResetOldRfid(){
+	strncpy(gOldRfidTagId, "X", cardIdStringSize-1);
+}
+#endif
+
 #if defined (RFID_READER_ENABLED)
 	extern TaskHandle_t rfidTaskHandle;
 #endif

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -661,7 +661,7 @@ bool JSONToSettings(JsonObject doc) {
 		snprintf(rfidString, sizeof(rfidString) / sizeof(rfidString[0]), "%s%s%s0%s%u%s0", stringDelimiter, _fileOrUrlAscii, stringDelimiter, stringDelimiter, _playMode, stringDelimiter);
 		gPrefsRfid.putString(_rfidIdAssinId, rfidString);
 		#ifdef DONT_ACCEPT_SAME_RFID_TWICE_ENABLE
-			strncpy(gOldRfidTagId, "X", cardIdStringSize-1);     // Set old rfid-id to crap in order to allow to re-apply a new assigned rfid-tag exactly once
+			Rfid_ResetOldRfid();     // Set old rfid-id to crap in order to allow to re-apply a new assigned rfid-tag exactly once
 		#endif
 
 		String s = gPrefsRfid.getString(_rfidIdAssinId, "-1");


### PR DESCRIPTION
Found a small issue:
when using the function "DONT_ACCEPT_SAME_RFID_TWICE" it only works the 2nd time because the Audioplayer resets this function until it starts playing.

Additionally I would suggest to also remove Line 47 in RfidCommon.cpp.
https://github.com/biologist79/ESPuino/blob/dev/src/RfidCommon.cpp#L47
In my opinion there is no need to accept unused cards as "last used" cards since they have no function yet. This prevents wrong UID-Readouts (that can happen with a not so ideal distance to the reader) from messing with the current audio playback.
What's your opinion on that?