### PR TITLE
.editorconfig: Fix tab width and remove duplicate setting from VSCode settings.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*] # Loosely following the kernel coding style: https://www.kernel.org/doc/html/v4.10/process/coding-style.html
 charset = utf-8
 end_of_line = lf
-indent_size = 8
+indent_size = 4
 indent_style = tab
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "cmake.configureOnOpen": false,
-    "editor.tabSize": 4,
     "gitlens.advanced.blame.customArguments": [
 	"--ignore-revs-file", ".git-blame-ignore-revs"
     ]


### PR DESCRIPTION
The new formatting defined in .clang-format uses a tab width of 4. Fix this in .editorconfig and remove the setting in settings.json. We don't need it there.