### PR TITLE
Fix a nullptr access after trying to replay an invalid filename

### DIFF
--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -240,6 +240,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 	if (files != NULL) { // If **ptr already exists, de-allocate its memory
 		Log_Printf(LOGLEVEL_DEBUG, releaseMemoryOfOldPlaylist, ESP.getFreeHeap());
 		freeMultiCharArray(files, strtoul(files[0], NULL, 10) + 1);
+		files = nullptr;
 		Log_Printf(LOGLEVEL_DEBUG, freeMemoryAfterFree, ESP.getFreeHeap());
 	}
 
@@ -402,6 +403,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 		Log_Println(unableToAllocateMemForPlaylist, LOGLEVEL_ERROR);
 		System_IndicateError();
 		freeMultiCharArray(files, cnt + 1);
+		files = nullptr;
 		return nullptr;
 	}
 	snprintf(files[0], 5, "%u", cnt);


### PR DESCRIPTION
Moin!

The static `files` list inside `SdCard_ReturnPlaylist()` needs to be invalidated after freeing. Calling `freeMultiCharArray()` is not sufficient since the "outer" pointer is never set to null.

I'm able to trigger a nullptr access by trying to replay a non-existent file:
- replay file(s) with card A
- try to replay non-existent file(s) with card B -> `files` is freed, but not allocated again
- try to replay with card A again -> `files` is still non-null, but `files[0]` is null, which will crash when accessed by the stroul() call in line 242

```
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x4008cc6a  PS      : 0x00060930  A0      : 0x8008cd92  A1      : 0x3ffd61b0  
A2      : 0x3ffd6728  A3      : 0x00000000  A4      : 0x00000000  A5      : 0x0000000a  
A6      : 0x00000000  A7      : 0x00000000  A8      : 0x00000001  A9      : 0x3ffd61a0  
A10     : 0x00000008  A11     : 0x3f447c89  A12     : 0x3ff96355  A13     : 0x3ffd603c  
A14     : 0x3ffce91c  A15     : 0x3ffd603c  SAR     : 0x00000004  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00000000  LBEG    : 0x4008c7b9  LEND    : 0x4008c7c9  LCOUNT  : 0xfffffff8  

Backtrace: 0x4008cc67:0x3ffd61b0 0x4008cd8f:0x3ffd61e0 0x400d7dcd:0x3ffd6200 0x400d4293:0x3ffd6360 0x400d7665:0x3ffd64a0 0x400e4413:0x3ffd6600 0x40123a59:0x3ffd6620

  #0  0x4008cc67:0x3ffd61b0 in _strtoul_l at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/newlib/newlib/libc/stdlib/strtoul.c:148
  #1  0x4008cd8f:0x3ffd61e0 in strtoul at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/newlib/newlib/libc/stdlib/strtoul.c:216
  #2  0x400d7dcd:0x3ffd6200 in SdCard_ReturnPlaylist(char const*, unsigned int) at src/SdCard.cpp:242
  #3  0x400d4293:0x3ffd6360 in AudioPlayer_TrackQueueDispatcher(char const*, unsigned int, unsigned int, unsigned short) at src/AudioPlayer.cpp:951
  #4  0x400d7665:0x3ffd64a0 in Rfid_PreferenceLookupHandler() at src/RfidCommon.cpp:100
  #5  0x400e4413:0x3ffd6600 in loop() at src/main.cpp:267
  #6  0x40123a59:0x3ffd6620 in loopTask(void*) at ~/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:50

```