### PR TITLE
fix wrong states on PE output pins (and SD-card failure on restart)

### DIFF
--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -20,7 +20,7 @@ void SdCard_Init(void) {
 #ifdef NO_SDCARD
 	// Initialize without any SD card, e.g. for webplayer only
 	Log_Println("Init without SD card ", LOGLEVEL_NOTICE);
-	return
+	return;
 #endif
 
 #ifndef SINGLE_SPI_ENABLE


### PR DESCRIPTION
The output register status buffer was initialized fix to {0xff,0xff} although the output registers were set to {0x00,0x00}. That buffer is used by Port_Write() to determine the values of the bits for the other pins. So those get set to 1 (high).

Since the peripheral power on the Espuino 4-layer mini PCB is switched on by setting a pin on the PCA9555 low, that power is first turned on (by Port_Init()), then turned off (by the Port_Write() call in AudioPlayer_Init()) and then turned on again (by Power_PeripheralOn()). That caused a 12.5 millisecond disruption of the external 3.3V which some SD-cards don't like.