### PR TITLE
/rfid endpoint - Serve with chunked response

### DIFF
--- a/html/management.html
+++ b/html/management.html
@@ -1746,7 +1746,7 @@
 
 	const rfidListSavedAssignments = document.getElementById("rfidListSavedAssignments");	
 	async function rebuildRFIDList() {
-		var rfidList = await (await fetch("/rfid")).json();
+		var rfidList = await (await fetch("/rfid/details")).json();
 		var rfidActive = document.getElementById('rfidIdMusic').value;
 
 		rfidListSavedAssignments.innerHTML = "";

--- a/html/management.html
+++ b/html/management.html
@@ -1746,7 +1746,7 @@
 
 	const rfidListSavedAssignments = document.getElementById("rfidListSavedAssignments");	
 	async function rebuildRFIDList() {
-		var rfidList = await (await fetch("/rfid/details")).json();
+		var rfidList = await (await fetch("/rfid")).json();
 		var rfidActive = document.getElementById('rfidIdMusic').value;
 
 		rfidListSavedAssignments.innerHTML = "";

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1753,7 +1753,7 @@ static void handleGetRFIDRequest(AsyncWebServerRequest *request) {
 					Log_Println("/rfid: Buffer too small", LOGLEVEL_ERROR);
 					return 0;
 				}
-				len += snprintf(((char *) buffer), maxLen-len, "[%s", json.c_str());
+				len += snprintf(((char *) buffer), maxLen - len, "[%s", json.c_str());
 				nvsIndex++;
 			}
 			while (nvsIndex < nvsKeys.size()) {
@@ -1762,12 +1762,12 @@ static void handleGetRFIDRequest(AsyncWebServerRequest *request) {
 				if ((len + json.length()) >= maxLen) {
 					break;
 				}
-				len += snprintf(((char *) buffer + len), maxLen-len, ",%s", json.c_str());
+				len += snprintf(((char *) buffer + len), maxLen - len, ",%s", json.c_str());
 				nvsIndex++;
 			}
 			if (nvsIndex == nvsKeys.size()) {
 				// finish
-				len += snprintf(((char *) buffer + len), maxLen-len, "]");
+				len += snprintf(((char *) buffer + len), maxLen - len, "]");
 				nvsIndex++;
 			}
 			return len;

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1751,7 +1751,7 @@ static void handleGetRFIDRequest(AsyncWebServerRequest *request) {
 				json = tagIdToJsonStr(nvsKeys[nvsIndex].c_str(), idsOnly);
 				if (json.length() >= maxLen) {
 					Log_Println("/rfid: Buffer too small", LOGLEVEL_ERROR);
-					return 0;
+					return len;
 				}
 				len += snprintf(((char *) buffer), maxLen - len, "[%s", json.c_str());
 				nvsIndex++;

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -457,7 +457,7 @@ void webserverStart(void) {
 
 		// RFID
 		wServer.on("/rfid", HTTP_GET, handleGetRFIDRequest);
-		wServer.addRewrite(new OneParamRewrite("/rfid/ids", "/rfid?ids=true"));
+		wServer.addRewrite(new OneParamRewrite("/rfid/ids-only", "/rfid?ids-only=true"));
 		wServer.addHandler(new AsyncCallbackJsonWebHandler("/rfid", handlePostRFIDRequest));
 		wServer.addRewrite(new OneParamRewrite("/rfid/{id}", "/rfid?id={id}"));
 		wServer.on("/rfid", HTTP_DELETE, handleDeleteRFIDRequest);
@@ -1709,8 +1709,8 @@ static String tagIdToJsonStr(const char *key, const bool nameOnly) {
 }
 
 // Handles rfid-assignments requests (GET)
-// /rfid returns an array of tag-id keys
-// /rfid/details returns an array of tag-ids and details. Optional GET param "id" to list only a single assignment.
+// /rfid returns an array of tag-ids and details. Optional GET param "id" to list only a single assignment.
+// /rfid/ids-only returns an array of tag-id keys
 static void handleGetRFIDRequest(AsyncWebServerRequest *request) {
 
 	String tagId = "";
@@ -1726,7 +1726,7 @@ static void handleGetRFIDRequest(AsyncWebServerRequest *request) {
 		return;
 	}
 	// get tag details or just an array of id's
-	bool idsOnly = request->hasParam("ids");
+	bool idsOnly = request->hasParam("ids-only");
 
 	std::vector<String> nvsKeys {};
 	static size_t nvsIndex;

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1729,7 +1729,7 @@ static void handleGetRFIDRequest(AsyncWebServerRequest *request) {
 	bool idsOnly = request->hasParam("ids");
 
 	std::vector<String> nvsKeys {};
-	static uint16_t nvsIndex;
+	static size_t nvsIndex;
 	nvsKeys.clear();
 	// Dumps all RFID-keys from NVS into key array
 	listNVSKeys("rfidTags", &nvsKeys, DumpNvsToArrayCallback);
@@ -1741,7 +1741,7 @@ static void handleGetRFIDRequest(AsyncWebServerRequest *request) {
 	// construct chunked repsonse
 	nvsIndex = 0;
 	AsyncWebServerResponse *response = request->beginChunkedResponse("application/json",
-		[nvsKeys = std::move(nvsKeys), idsOnly](uint8_t *buffer, size_t maxLen, size_t index) {
+		[nvsKeys = std::move(nvsKeys), idsOnly](uint8_t *buffer, size_t maxLen, size_t index) -> size_t {
 			maxLen = maxLen >> 1; // some sort of bug with actual size available, reduce the len
 			size_t len = 0;
 			String json;
@@ -1772,7 +1772,6 @@ static void handleGetRFIDRequest(AsyncWebServerRequest *request) {
 			}
 			return len;
 		});
-	nvsKeys.clear();
 	request->send(response);
 }
 

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1708,7 +1708,6 @@ static String tagIdToJsonStr(const char *key, const bool withDetails) {
 	}
 }
 
-
 // Handles rfid-assignments requests (GET)
 // /rfid returns an array of tag-id keys
 // /rfid/details returns an array of tag-ids and details. Optional GET param "id" to list only a single assignment.


### PR DESCRIPTION
/rfid endpoint:

A static buffer of 8KB is currently used to list the RFID tags. If this buffer is full, the returned JSON is truncated and not all entries are displayed in the web interface. . This happens with me from approx. 60 entries (depends on path length). It could also lead to a low memory situation and, in the worst case, to a crash.

With this PR, a list is first created holding the keys only and later the details such as path and game mode are sent as a chunked response with a smaller buffer. 
No changes in the delivered JSON except that it is always complete