### PR TITLE
improve port expander handling

### DIFF
--- a/src/Port.cpp
+++ b/src/Port.cpp
@@ -406,7 +406,10 @@ void Port_Test(void) {
 
 	#ifdef PE_INTERRUPT_PIN_ENABLE
 void IRAM_ATTR PORT_ExpanderISR(void) {
-	Port_AllowReadFromPortExpander = true;
+	// check if the interrupt pin is actually low and only if it is
+	// trigger the handler (there are a lot of false calls to this ISR
+	// where the interrupt pin isn't low...)
+	Port_AllowReadFromPortExpander = !digitalRead(PE_INTERRUPT_PIN);
 }
 	#endif
 #endif

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -20,7 +20,7 @@ void SdCard_Init(void) {
 #ifdef NO_SDCARD
 	// Initialize without any SD card, e.g. for webplayer only
 	Log_Println("Init without SD card ", LOGLEVEL_NOTICE);
-	return
+	return;
 #endif
 
 #ifndef SINGLE_SPI_ENABLE


### PR DESCRIPTION
This is a collection of changes I made for the port expander:

- prevent the PE ISR from doing anything if there was no real interrupt (no idea where those spurious interrupts come from)
- speed up access to the PE
- make the debouncer work per bit