### PR TITLE
improve port expander handling

### DIFF
--- a/src/Port.cpp
+++ b/src/Port.cpp
@@ -201,7 +201,7 @@ void Port_WriteInitMaskForOutputChannels(void) {
 	i2cBusTwo.write(0x02); // Pointer to first output-register
 	i2cBusTwo.endTransmission(false);
 	i2cBusTwo.requestFrom(expanderI2cAddress, static_cast<size_t>(portsToWrite), true); // ...and read the contents
-	if (i2cBusTwo.available()) {
+	if (i2cBusTwo.available() == portsToWrite) {
 		for (uint8_t i = 0; i < portsToWrite; i++) {
 			Port_ExpanderPortsOutputChannelStatus[i] = i2cBusTwo.read();
 		}
@@ -354,23 +354,25 @@ void Port_ExpanderHandler(void) {
 	}
 	#endif
 
-	for (uint8_t i = 0; i < 2; i++) {
-		i2cBusTwo.beginTransmission(expanderI2cAddress);
-		i2cBusTwo.write(0x00 + i); // Pointer to input-register...
-		uint8_t error = i2cBusTwo.endTransmission();
-		if (error != 0) {
-			Log_Printf(LOGLEVEL_ERROR, "Error in endTransmission(): %d", error);
+	i2cBusTwo.beginTransmission(expanderI2cAddress);
+	i2cBusTwo.write(0x00); // Pointer to input-register...
+	uint8_t error = i2cBusTwo.endTransmission(false);
+	if (error != 0) {
+		Log_Printf(LOGLEVEL_ERROR, "Error in endTransmission(): %d", error);
+		i2cBusTwo.endTransmission(true);
 
-			#ifdef PE_INTERRUPT_PIN_ENABLE
-			Port_AllowReadFromPortExpander = true;
-			#endif
+		#ifdef PE_INTERRUPT_PIN_ENABLE
+		Port_AllowReadFromPortExpander = true;
+		#endif
 
-			return;
-		}
-		i2cBusTwo.requestFrom(expanderI2cAddress, 1u); // ...and read its byte
+		return;
+	}
+	i2cBusTwo.requestFrom(expanderI2cAddress, 2u); // ...and read its bytes
 
-		if (i2cBusTwo.available()) {
+	if (i2cBusTwo.available() == 2) {
+		for (uint8_t i = 0; i < 2; i++) {
 			inputRegisterBuffer[i] = i2cBusTwo.read(); // Cache current readout
+
 			// Check if input-register changed. If so, don't use the value immediately
 			// but wait another cycle instead (=> rudimentary debounce).
 			// Added because there've been "ghost"-events occasionally with Arduino2 (https://forum.espuino.de/t/aktueller-stand-esp32-arduino-2/1389/55)
@@ -396,13 +398,13 @@ void Port_ExpanderHandler(void) {
 // Make sure ports are read finally at shutdown in order to clear any active IRQs that could cause re-wakeup immediately
 void Port_Exit(void) {
 	Port_MakeSomeChannelsOutputForShutdown();
-	for (uint8_t i = 0; i < 2; i++) {
-		i2cBusTwo.beginTransmission(expanderI2cAddress);
-		i2cBusTwo.write(0x00 + i); // Pointer to input-register...
-		i2cBusTwo.endTransmission();
-		i2cBusTwo.requestFrom(expanderI2cAddress, 1u); // ...and read its byte
+	i2cBusTwo.beginTransmission(expanderI2cAddress);
+	i2cBusTwo.write(0x00); // Pointer to input-registers...
+	i2cBusTwo.endTransmission();
+	i2cBusTwo.requestFrom(expanderI2cAddress, 2u); // ...and read its bytes
 
-		if (i2cBusTwo.available()) {
+	if (i2cBusTwo.available() == 2) {
+		for (uint8_t i = 0; i < 2; i++) {
 			Port_ExpanderPortsInputChannelStatus[i] = i2cBusTwo.read();
 		}
 	}

--- a/src/Port.cpp
+++ b/src/Port.cpp
@@ -406,7 +406,10 @@ void Port_Test(void) {
 
 	#ifdef PE_INTERRUPT_PIN_ENABLE
 void IRAM_ATTR PORT_ExpanderISR(void) {
-	Port_AllowReadFromPortExpander = true;
+	// check if the interrupt pin is actually low and only if it is
+	// trigger the handler (there are a lot of false calls to this ISR
+	// where the interrupt pin isn't low...)
+	Port_AllowReadFromPortExpander = !digitalRead(PE_INTERRUPT_PIN);
 }
 	#endif
 #endif


### PR DESCRIPTION
This is a collection of changes I made for the port expander:

__prevent the PE ISR from doing anything if there was no real interrupt__
I've seen the ISR being called all the time and thus Port_ExpanderHandler() accessing the bus every time it gets called. That wastes a lot of time which can be spent more useful. So I added a check in the ISR if there was really an interrupt request from the PE.

__correct interrupt mode for the PE__
The PCA9555 interrupt output is level low, not falling edge. That is not very different if there is only one device using the line but there is a small chance that input register 0 changes while reading input register 1. And in that case the interrupt line would stay low which won't be detected when it is set for falling edge.
So using ONLOW fixes that but requires that the interrupt is disabled in the ISR and re-enabled after reading the input registers.

__speed up access to the PE__
The current implementation isn't wrong, just horribly slow because to read 2 bytes from the PE it puts 3 unnecessary bytes on the bus plus i2c timing overhead.

__make the debouncer work per bit__
I didn't encounter an issue but if one of the bits in the input registers was changing all the time, all the other bits would be ignored. There shouldn't be a debouncer at all but until there is a thread safe i2c handling, that can't be avoided.