### PR TITLE
Wait when trying to play a webstream while connecting to wifi

### DIFF
--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -496,18 +496,6 @@ void handleWifiStateConnectionSuccess() {
 	delete dnsServer;
 	dnsServer = nullptr;
 
-	bool playLastRfidAfterReboot;
-#ifdef PLAY_LAST_RFID_AFTER_REBOOT
-	playLastRfidAfterReboot = gPrefsSettings.getBool("playLastOnBoot", true);
-#else
-	playLastRfidAfterReboot = gPrefsSettings.getBool("playLastOnBoot", false);
-#endif
-
-	if (playLastRfidAfterReboot && gPlayLastRfIdWhenWiFiConnected && gTriedToConnectToHost) {
-		gPlayLastRfIdWhenWiFiConnected = false;
-		recoverLastRfidPlayedFromNvs(true);
-	}
-
 	wifiState = WIFI_STATE_CONNECTED;
 	Mqtt_OnWifiConnected();
 }
@@ -720,7 +708,7 @@ bool Wlan_DeleteNetwork(String ssid) {
 }
 
 bool Wlan_ConnectionTryInProgress(void) {
-	return wifiState == WIFI_STATE_SCAN_CONN;
+	return wifiState == WIFI_STATE_INIT || wifiState == WIFI_STATE_CONNECT_LAST || wifiState == WIFI_STATE_SCAN_CONN;
 }
 
 String Wlan_GetIpAddress(void) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,9 +30,6 @@
 
 #include <Wire.h>
 
-bool gPlayLastRfIdWhenWiFiConnected = false;
-bool gTriedToConnectToHost = false;
-
 static constexpr const char *logo = R"literal(
  _____   ____    ____            _
 | ____| / ___|  |  _ \   _   _  (_)  _ __     ___
@@ -94,8 +91,8 @@ void recoverBootCountFromNvs(void) {
 }
 
 // Get last RFID-tag applied from NVS
-void recoverLastRfidPlayedFromNvs(bool force) {
-	if (recoverLastRfid || force) {
+void recoverLastRfidPlayedFromNvs() {
+	if (recoverLastRfid) {
 		if (System_GetOperationMode() == OPMODE_BLUETOOTH_SINK) { // Don't recover if BT-mode is desired
 			recoverLastRfid = false;
 			return;
@@ -106,7 +103,6 @@ void recoverLastRfidPlayedFromNvs(bool force) {
 			Log_Println(unableToRestoreLastRfidFromNVS, LOGLEVEL_INFO);
 		} else {
 			xQueueSend(gRfidCardQueue, lastRfidPlayed.c_str(), 0);
-			gPlayLastRfIdWhenWiFiConnected = !force;
 			Log_Printf(LOGLEVEL_INFO, restoredLastRfidFromNVS, lastRfidPlayed.c_str());
 		}
 	}

--- a/src/main.h
+++ b/src/main.h
@@ -1,6 +1,3 @@
 #pragma once
 
-extern bool gPlayLastRfIdWhenWiFiConnected;
-extern bool gTriedToConnectToHost;
-
-extern void recoverLastRfidPlayedFromNvs(bool force = false);
+extern void recoverLastRfidPlayedFromNvs();

--- a/src/revision.h
+++ b/src/revision.h
@@ -1,4 +1,5 @@
 #pragma once
 
 #include "gitrevision.h"
-constexpr const char softwareRevision[] = "Software-revision: 20250515-1-DEV";
+
+constexpr const char softwareRevision[] = "Software-revision: 20250613-1-DEV";


### PR DESCRIPTION
The previous code had some issues. First of all, with DONT_ACCEPT_SAME_RFID_TWICE it would not work at all. But without a change, not even that works correctly (due to gTriedToConnectToHost never being set).

IMHO the code is simplified a lot. The whole control flow can be simplified if we just wait until a connection try hast completed.

The behavior will be slightly different. Most importantly, loading a webstream as the last played rfid now works consistently. Further, the error handling of playing a webstream while disconnected is shifted to the audio library and is handled like any other error.