### PR TITLE
keep original mtime for gzip compressed files

### DIFF
--- a/processHtml.py
+++ b/processHtml.py
@@ -81,8 +81,11 @@ class HtmlHeaderProcessor:
             with binary_path.open(mode="r", encoding="utf-8") as f:
                 content = f.read()
 
+        # get status of the file (copy modified time to gzip header)
+        stinfo = os.stat(binary_path)
+
         # compress content
-        data = gzip.compress(content.encode())
+        data = gzip.compress(content.encode(), mtime=stinfo.st_mtime)
 
         with header_path.open(mode="a", encoding="utf-8") as header_file:
             varName = binary_path.name.split('.')[0]


### PR DESCRIPTION
This makes sure that the gzip header has the same modified time as the original source file.

As a result the HTMLbinary.h content only changes if the source files are actually modified (avoiding uneccesary Web.o rebuilds).