### PR TITLE
improve progress calculation/indication

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -400,13 +400,16 @@ void AudioPlayer_Task(void *parameter) {
 			AudioPlayer_CurrentTime = audio->getAudioCurrentTime();
 			AudioPlayer_FileDuration = audio->getAudioFileDuration();
 			// Calculate relative position in file (for trackprogress neopixel & web-ui)
-			if (!gPlayProperties.playlistFinished && !gPlayProperties.isWebstream) {
-				if (!gPlayProperties.pausePlay && (gPlayProperties.seekmode != SEEK_POS_PERCENT) && (audio->getFileSize() > 0)) { // To progress necessary when paused
-					gPlayProperties.currentRelPos = ((double) (audio->getFilePos() - audio->inBufferFilled()) / (double) audio->getFileSize()) * 100;
+			uint32_t fileSize = audio->getFileSize();
+			gPlayProperties.audioFileSize = fileSize;
+			if (!gPlayProperties.playlistFinished && fileSize > 0) {
+				// for local files and web files with known size
+				if (!gPlayProperties.pausePlay && (gPlayProperties.seekmode != SEEK_POS_PERCENT)) { // To progress necessary when paused
+					gPlayProperties.currentRelPos = ((double) (audio->getFilePos() - audio->getAudioDataStartPos() - audio->inBufferFilled()) / fileSize) * 100;
 				}
 			} else {
-				// calc current fillbuffer percent for webstream
 				if (gPlayProperties.isWebstream && (audio->inBufferSize() > 0)) {
+					// calc current fillbuffer percent for webstream with unknown size/end
 					gPlayProperties.currentRelPos = (double) (audio->inBufferFilled() / (double) audio->inBufferSize()) * 100;
 				} else {
 					gPlayProperties.currentRelPos = 0;

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -28,6 +28,7 @@ typedef struct { // Bit field
 	bool lastSpeechActive		 : 1; // If speech-play was active
 	size_t coverFilePos; // current cover file position
 	size_t coverFileSize; // current cover file size
+	size_t audioFileSize; // file size of current audio file
 } playProps;
 
 extern playProps gPlayProperties;

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -348,10 +348,10 @@ static void Led_Task(void *parameter) {
 			nextAnimation = LedAnimationType::Idle;
 		} else if (gPlayProperties.pausePlay && !gPlayProperties.isWebstream) {
 			nextAnimation = LedAnimationType::Pause;
-		} else if (gPlayProperties.isWebstream) { // also animate pause in the webstream animation
-			nextAnimation = LedAnimationType::Webstream;
-		} else if ((gPlayProperties.playMode != BUSY) && (gPlayProperties.playMode != NO_PLAYLIST)) {
+		} else if ((gPlayProperties.playMode != BUSY) && (gPlayProperties.playMode != NO_PLAYLIST) && gPlayProperties.audioFileSize > 0) { // progress for a file/stream with known size
 			nextAnimation = LedAnimationType::Progress;
+		} else if (gPlayProperties.isWebstream) { // webstream animation (for streams with unknown size); pause animation is also handled by the webstream animation function
+			nextAnimation = LedAnimationType::Webstream;
 		} else if (gPlayProperties.playMode == NO_PLAYLIST) {
 			nextAnimation = LedAnimationType::Idle;
 		} else if (gPlayProperties.playMode == BUSY) {


### PR DESCRIPTION
This improved the `gPlayProperties.currentRelPos` calculation by making it dependent on the availability of the file size instead of the `isWebstream` flag. Accuracy is also slightly improved by subtracting the metadata header size (`audio->getAudioDataStartPos()`) of the file. 
LED animations will also check for the available file size instead of the `isWebstream` flag.
This enables correct progress indication when streaming static files.