### PR TITLE
Reduce WiFi memory consumption

### DIFF
--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -166,11 +166,13 @@
 			};
 			
 			if (static) {
-				myObj[static_addr] = document.getElementById('static_addr').value;
-				myObj[static_gateway] = document.getElementById('static_gateway').value;
-				myObj[static_subnet] = document.getElementById('static_subnet').value;
-				myObj[static_dns1] = document.getElementById('static_dns1').value;
-				myObj[static_dns2] = document.getElementById('static_dns2').value;
+				myObj = {...myObj,
+					static_addr: document.getElementById('static_addr').value,
+					static_gateway: document.getElementById('static_gateway').value,
+					static_subnet: document.getElementById('static_subnet').value,
+					static_dns1: document.getElementById('static_dns1').value,
+					static_dns2: document.getElementById('static_dns2').value,
+				};
 			}
 
 			await fetch("/savedSSIDs", {

--- a/html/management.html
+++ b/html/management.html
@@ -2069,11 +2069,13 @@
 		};
 
 		if (static) {
-			myObj[static_addr] = document.getElementById('static_addr').value;
-			myObj[static_gateway] = document.getElementById('static_gateway').value;
-			myObj[static_subnet] = document.getElementById('static_subnet').value;
-			myObj[static_dns1] = document.getElementById('static_dns1').value;
-			myObj[static_dns2] = document.getElementById('static_dns2').value;
+			myObj = {...myObj,
+				static_addr: document.getElementById('static_addr').value,
+				static_gateway: document.getElementById('static_gateway').value,
+				static_subnet: document.getElementById('static_subnet').value,
+				static_dns1: document.getElementById('static_dns1').value,
+				static_dns2: document.getElementById('static_dns2').value,
+			};
 		}
 
 		await fetch("/savedSSIDs", {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1693,7 +1693,7 @@ void handlePostSavedSSIDs(AsyncWebServerRequest *request, JsonVariant &json) {
 		networkSettings.staticIp.dns1 = IPAddress().fromString(json["static_dns2"].as<const char *>());
 	}
 
-	if (!networkSettings) {
+	if (!networkSettings.isValid()) {
 		// The data was corrupted, so user error
 		request->send(400, "text/plain; charset=utf-8", "error adding network");
 		return;

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -93,6 +93,18 @@ static void settingsToJSON(JsonObject obj, const String section);
 static bool JSONToSettings(JsonObject obj);
 static void webserverStart(void);
 
+// IPAddress converters, for a description see: https://arduinojson.org/news/2021/05/04/version-6-18-0/
+void convertFromJson(JsonVariantConst src, IPAddress &dst) {
+	dst.fromString(src.as<const char *>());
+}
+bool canConvertFromJson(JsonVariantConst src, const IPAddress &) {
+	if (!src.is<const char *>()) {
+		return false; // this is not a string
+	}
+	IPAddress dst;
+	return dst.fromString(src.as<const char *>());
+}
+
 // If PSRAM is available use it allocate memory for JSON-objects
 struct SpiRamAllocator {
 	void *allocate(size_t size) {
@@ -1685,12 +1697,12 @@ void handlePostSavedSSIDs(AsyncWebServerRequest *request, JsonVariant &json) {
 	networkSettings.ssid = json["ssid"].as<const char *>();
 	networkSettings.password = json["pwd"].as<const char *>();
 
-	if (json["static"]) {
-		networkSettings.staticIp.addr = IPAddress().fromString(json["static_addr"].as<const char *>());
-		networkSettings.staticIp.subnet = IPAddress().fromString(json["static_subnet"].as<const char *>());
-		networkSettings.staticIp.gateway = IPAddress().fromString(json["static_gateway"].as<const char *>());
-		networkSettings.staticIp.dns1 = IPAddress().fromString(json["static_dns1"].as<const char *>());
-		networkSettings.staticIp.dns1 = IPAddress().fromString(json["static_dns2"].as<const char *>());
+	if (json["static"].as<bool>()) {
+		networkSettings.staticIp.addr = json["static_addr"].as<IPAddress>();
+		networkSettings.staticIp.subnet = json["static_subnet"].as<IPAddress>();
+		networkSettings.staticIp.gateway = json["static_gateway"].as<IPAddress>();
+		networkSettings.staticIp.dns1 = json["static_dns1"].as<IPAddress>();
+		networkSettings.staticIp.dns2 = json["static_dns2"].as<IPAddress>();
 	}
 
 	if (!networkSettings.isValid()) {

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -52,7 +52,6 @@ static unsigned long connectStartTimestamp = 0;
 static uint32_t connectionFailedTimestamp = 0;
 
 // state for persistent settings
-static constexpr size_t maxSavedNetworks = 20;
 static constexpr const char *nvsWiFiNamespace = "wifi-settings";
 static constexpr const char *nvsWiFiKey = "wifi-";
 static constexpr const char *nvsWiFiKeyFormat = "wifi-%02u";
@@ -620,7 +619,7 @@ bool Wlan_AddNetworkSettings(const WiFiSettings &settings) {
 	}
 
 	// this is a new entry, find the first unused key
-	for (size_t i = 0; i < maxSavedNetworks; i++) {
+	for (uint8_t i = 0; i < std::numeric_limits<uint8_t>::max(); i++) {
 		char key[NVS_KEY_NAME_MAX_SIZE];
 		snprintf(key, NVS_KEY_NAME_MAX_SIZE, nvsWiFiKeyFormat, i);
 		if (!prefsWifiSettings.isKey(key)) {

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -85,7 +85,7 @@ static WiFiSettings loadWiFiSettingsFromNvs(const char *key) {
 	prefsWifiSettings.getBytes(key, buffer.data(), buffer.size());
 	return WiFiSettings(buffer);
 }
-static WiFiSettings loadWiFiSettingsFromNvs(const String key) {
+[[maybe_unused]] static WiFiSettings loadWiFiSettingsFromNvs(const String &key) {
 	return loadWiFiSettingsFromNvs(key.c_str());
 }
 
@@ -104,7 +104,7 @@ static bool storeWiFiSettingsToNvs(const char *key, const WiFiSettings &s) {
 	}
 	return prefsWifiSettings.putBytes(key, buffer->data(), buffer->size()) == buffer->size();
 }
-static bool storeWiFiSettingsToNvs(const String key, const WiFiSettings &s) {
+[[maybe_unused]] static bool storeWiFiSettingsToNvs(const String &key, const WiFiSettings &s) {
 	return storeWiFiSettingsToNvs(key.c_str(), s);
 }
 

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -31,8 +31,8 @@ uint8_t wifiState = WIFI_STATE_INIT;
 #define RECONNECT_INTERVAL 600000
 
 // AP-WiFi
-IPAddress apIP(192, 168, 4, 1); // Access-point's static IP
-IPAddress apNetmask(255, 255, 255, 0); // Access-point's netmask
+const IPAddress apIP(192, 168, 4, 1); // Access-point's static IP
+const IPAddress apNetmask(255, 255, 255, 0); // Access-point's netmask
 
 bool wifiEnabled; // Current status if wifi is enabled
 
@@ -566,7 +566,7 @@ void accessPointStart(const char *SSID, const char *password, IPAddress ip, IPAd
 	delay(500);
 
 	Log_Println(apReady, LOGLEVEL_NOTICE);
-	Log_Printf(LOGLEVEL_NOTICE, "IP-Adresse: %s", apIP.toString().c_str());
+	Log_Printf(LOGLEVEL_NOTICE, "IP-Adresse: %s", ip.toString().c_str());
 
 	if (!dnsServer) {
 		dnsServer = new DNSServer();

--- a/src/Wlan.h
+++ b/src/Wlan.h
@@ -1,17 +1,109 @@
 #pragma once
 
+#include <WString.h>
 #include <functional>
 
 // be very careful changing this struct, as it is used for NVS storage and will corrupt existing entries
 struct WiFiSettings {
-	char ssid[33];
-	char password[65];
-	bool use_static_ip;
-	uint32_t static_addr;
-	uint32_t static_gateway;
-	uint32_t static_subnet;
-	uint32_t static_dns1;
-	uint32_t static_dns2;
+	struct StaticIp {
+		static constexpr size_t numFields = 5;
+
+		IPAddress addr {INADDR_NONE};
+		IPAddress subnet {INADDR_NONE};
+		IPAddress gateway {INADDR_NONE};
+		IPAddress dns1 {INADDR_NONE};
+		IPAddress dns2 {INADDR_NONE};
+
+		StaticIp() = default;
+		StaticIp(const IPAddress &addr, const IPAddress &subnet, const IPAddress &gateway = INADDR_NONE, const IPAddress &dns1 = INADDR_NONE, const IPAddress &dns2 = INADDR_NONE)
+			: addr {addr}
+			, subnet {subnet}
+			, gateway {gateway}
+			, dns1 {dns1}
+			, dns2 {dns2} {
+			if (dns1 == INADDR_NONE && dns2 != INADDR_NONE) {
+				// swapp dns1 and dns2 if only dns2 is set
+				this->dns1 = this->dns2;
+				this->dns2 = INADDR_NONE;
+			}
+		}
+
+		bool isValid() const { return addr != INADDR_NONE && subnet != INADDR_NONE; }
+
+		void serialize(uint32_t *blob) const {
+			blob[0] = addr;
+			blob[1] = subnet;
+			blob[2] = gateway;
+			blob[3] = dns1;
+			blob[4] = dns2;
+		}
+		void deserialize(const uint32_t *blob) {
+			addr = blob[0];
+			subnet = blob[1];
+			gateway = blob[2];
+			dns1 = blob[3];
+			dns2 = blob[4];
+		}
+	};
+
+	String ssid {String()};
+	String password {String()};
+	StaticIp staticIp;
+
+	WiFiSettings() = default;
+	WiFiSettings(const std::vector<uint8_t> &buffer) { deserialize(buffer); }
+
+	bool isValid() const { return !ssid.isEmpty() && ssid.length() < 33 && password.length() < 65; }
+
+	/**
+	 * @brief Serialize the fields of this instance
+	 * @return std::optional<std::vector<uint8_t>> std::vector with the binary data or std::nullopt if the instance is corrupted
+	 */
+	std::optional<std::vector<uint8_t>> serialize() const;
+
+	/**
+	 * @brief Deserialize data from the supplied NVS key
+	 * @param buffer The buffer with the binary data to be used
+	 */
+	void deserialize(const std::vector<uint8_t> &buffer);
+
+protected:
+	/**
+	 * @brief Serialize a String into a binary buffer. Format: [len:u8] + [len * u8] + '\0'
+	 * @param it iterator to the start of the serialization
+	 * @param s the string to be serialized
+	 */
+	void serializeString(std::vector<uint8_t>::iterator &it, const String &s) const;
+
+	/**
+	 * @brief Return the needed bytes to serialize the String
+	 */
+	size_t serializeStringLen(const String &s) const { return 1 + s.length() + 1; }
+
+	/**
+	 * @brief Deserialize a String from a binary buffer
+	 * @see serializeString for further information
+	 */
+	void deserializeString(std::vector<uint8_t>::const_iterator &it, String &s);
+
+	/**
+	 * @brief Serialize a String into a binary buffer. Format: [bool:u8] + <numFields * u32>
+	 * @warning the ip fields are optional any only present if the network has a static ip config
+	 * @param it iteratot to the start of the serialization
+	 * @param ip the static IP data to be serialized
+	 */
+	void serializeStaticIp(std::vector<uint8_t>::iterator &it, const StaticIp &ip) const;
+
+	/**
+	 * @brief Return the needed bytes to serialize the Static IP config
+	 */
+	size_t serializeStaticIpLen(const StaticIp &ip) const { return 1 + ((ip.isValid()) ? (StaticIp::numFields * sizeof(uint32_t)) : 0); }
+
+	/**
+	 * @brief Deserialize a static IP confgiuration from a binary buffer
+	 * @see serializeStaticIp for further information
+	 */
+	void deserializeStaticIp(std::vector<uint8_t>::const_iterator &it, StaticIp &ip);
 };
 
 void Wlan_Init(void);

--- a/src/Wlan.h
+++ b/src/Wlan.h
@@ -108,7 +108,7 @@ protected:
 
 void Wlan_Init(void);
 void Wlan_Cyclic(void);
-bool Wlan_AddNetworkSettings(WiFiSettings);
+bool Wlan_AddNetworkSettings(const WiFiSettings &);
 uint8_t Wlan_NumSavedNetworks();
 void Wlan_GetSavedNetworks(std::function<void(const WiFiSettings &)>);
 const String Wlan_GetCurrentSSID();


### PR DESCRIPTION
This PR removes the WiFi settings from the RAM entirely. To improve the performance, the NVS storage is modified:
 - own namespace for the settings
 - 1 key / Network

One WiFiSettings entry is serialized the following was:
`[str:ssid] + [str:password] + [binary:static IP]`

Strings use: `[u8:len] + [len*u8:string] + [u8:'\0']`
Static IP use: `[u8:bool]  + <u8 * 20:static IP block>`

This allows to NVS iteration over all entries without the need to load all entries into RAM. Old WiFi settings will be migrated to the new NVS storage structure. 

For discussions see: https://forum.espuino.de/t/pr-diskussion-wifi-settings-ram-reduktion/2763