### PR TITLE
use natural sort

### DIFF
--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -269,6 +269,13 @@
             "criticalShutoff": "Unter dieser Spannung schaltet der ESPuino ab.",
             "high": "Alle LEDs leuchten bei dieser Spannung",
             "measureInterval": "Zeitabstand der Messung (in Minuten)"
+        },
+        "playlist": {
+            "title": "Wiedergabeliste",
+            "sortMode": "Sortierungsmodus für Wiedergabeliste und Dateibrowser",
+            "strcmp": "Standardsortierung",
+            "strnatcmp": "Natürlich: Groß- und Kleinschreibung beachten",
+            "strnatcasecmp": "Natürlich: Groß- und Kleinschreibung ignorieren"
         }
     },
     "tools": {

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -269,6 +269,13 @@
             "criticalShutoff": "Below this voltage, ESPuino turns off.",
             "high": "Voltage, that is indicated by all LEDs",
             "measureInterval": "Interval between measurements (in minutes)"
+        },
+        "playlist": {
+            "title": "Playlist",
+            "sortMode": "Sorting mode for playlist and file browser",
+            "strcmp": "Standard sorting",
+            "strnatcmp": "Natural: case-sensitive",
+            "strnatcasecmp": "Natural: case-insensitive"
         }
     },
     "tools": {

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -271,6 +271,13 @@
             "criticalShutoff": "En dessous de cette tension, ESPuino s'éteint.",
             "high": "Tension indiquée par toutes les LED",
             "measureInterval": "Intervalle entre les mesures (en minutes)"
+        },
+        "playlist": {
+            "title": "Playlist",
+            "sortMode": "Mode de tri pour la liste de lecture et le navigateur de fichiers",
+            "strcmp": "Tri standard",
+            "strnatcmp": "Naturel: sensible à la casse",
+            "strnatcasecmp": "Naturel: insensible à la casse"
         }
     },
     "tools": {

--- a/html/management.html
+++ b/html/management.html
@@ -23,6 +23,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/i18next/23.7.11/i18next.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/i18next-http-backend/2.4.2/i18nextHttpBackend.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/loc-i18next@0.1.6/dist/umd/loc-i18next.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/gh/sourcefrog/natsort@f8a6b0c/natcompare.js"></script>
 	<style type="text/css">
 		.jstree-default .jstree-search {
 			font-style: italic;
@@ -744,7 +745,19 @@
 
 					</fieldset>
 				</div>
-<br>
+				<br>
+				<div class="form-group col-md-12" id="playlistConfig">
+					<fieldset>
+						<legend class="w-auto" data-i18n="general.playlist.title"></legend>
+						<label for="playlistSortMode" data-i18n="[prepend]general.playlist.sortMode">:</label>
+						<select id="playlistSortMode" name="playlistSortMode" class="form-control">
+							<option value="3" selected data-i18n="general.playlist.strnatcasecmp"></option>
+							<option value="2" data-i18n="general.playlist.strnatcmp"></option>
+							<option value="1" data-i18n="general.playlist.strcmp"></option>
+						</select>
+					</fieldset>
+				</div>
+				<br>
 				<div class="text-center">
 				<button type="reset" class="btn btn-secondary" data-i18n="reset" onclick="resetSettings()"></button>&nbsp
 				<button type="submit" class="btn btn-primary" data-i18n="submit"></button>
@@ -1251,20 +1264,41 @@
 		});
 	}
 
-	function fileNameSort( a, b ) {
-		if ( a.dir && !b.dir ) {
-			return -1
+	// returns the string comparison function based on the sortMode
+	function fileNameSortHelper(sortMode) {
+		return function(a, b) {
+			// Make sure directories are always listed first
+			if ( a.dir && !b.dir ) {
+				return -1
+			}
+			if ( !a.dir && b.dir ) {
+				return 1
+			}
+
+			switch (sortMode) {
+				case 1: // strcmp - standard string comparison
+					if (a.name < b.name) {
+						return -1;
+					}
+					if (a.name > b.name) {
+						return 1;
+					}
+					return 0;
+				case 2: // strnatcmp - natural case-sensitive
+					return natcompare(a.name, b.name);
+					break;
+				case 3: // strnatcasecmp - natural case-insensitive
+				default:
+					return natcompare(a.name.toLowerCase(), b.name.toLowerCase());
+					break;
+			}
 		}
-		if ( !a.dir && b.dir ) {
-			return 1
-		}
-		if ( a.name < b.name ){
-			return -1;
-		}
-		if ( a.name > b.name ){
-			return 1;
-		}
-		return 0;
+	}
+
+	function sortData(data) {
+		const sortMode = window?.settings?.playlist?.sortMode;
+		const fileNameSort = fileNameSortHelper(sortMode);
+		data.sort(fileNameSort);
 	}
 
 	function createChild(nodeId, data) {
@@ -1338,7 +1372,7 @@
 
 	function addFileDirectory(parent, data) {
 
-		data.sort( fileNameSort );
+		sortData(data);
 		var ref = $('#explorerTree').jstree(true);
 
 		for (var i=0; i<data.length; i++) {
@@ -1489,7 +1523,7 @@
 			/* We now have data! */
 			$('#explorerTree').jstree(true).settings.core.data.children = [];
 
-			data.sort( fileNameSort );
+			sortData(data);
 
 
 			for (var i=0; i<data.length; i++) {
@@ -1609,6 +1643,10 @@
 		if (!settings) { 
 			return false 
 		}
+
+		// update global settings
+		window.settings = { ...window.settings, ...settings };
+
 		// general
 		let genSettings = settings.general;
 		if (genSettings) {
@@ -1637,6 +1675,7 @@
 			$('#voltageIndicatorHigh').bootstrapSlider('setValue', defSettings.indicatorHi);
 			$('#voltageCheckInterval').bootstrapSlider('setValue', defSettings.voltageCheckInterval);
 			$('#criticalVoltage').bootstrapSlider('setValue', defSettings.criticalVoltage);
+			$("#playlistSortMode").val(defSettings.sortMode).change();
 		}
 		// wifi
 		let wifiSettings = settings.wifi;
@@ -1655,6 +1694,11 @@
 			document.getElementById('neopixelConfig').setAttribute('data-visible', true);
 			$('#initBrightness').bootstrapSlider('setValue', ledSettings.initBrightness);
 			$('#nightBrightness').bootstrapSlider('setValue', ledSettings.nightBrightness);
+		}
+		// playlist
+		let playlistSettings = settings.playlist;
+		if (playlistSettings) {
+			$("#playlistSortMode").val(playlistSettings.sortMode).change();
 		}
 		// battery
 		let batSettings = settings.battery;
@@ -1945,9 +1989,14 @@
 				indicatorHi: document.getElementById('voltageIndicatorHigh').value,
 				criticalVoltage: document.getElementById('criticalVoltage').value,
 				voltageCheckInterval: document.getElementById('voltageCheckInterval').value
+			},
+			"playlist": {
+				sortMode: +document.getElementById('playlistSortMode').value
 			}
 		};
 		var myJSON = JSON.stringify(myObj);
+		// update global settings
+		window.settings = { ...window.settings, ...myObj };
 		socket.send(myJSON);
 	}
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,6 +46,7 @@ lib_deps =
 	https://github.com/tuniii/LogRingBuffer.git#89d7d3e
 	https://github.com/tueddy/PN5180-Library.git#6838d0b
 	https://github.com/SZenglein/Arduino-MAX17055_Driver#75cdfcf
+    https://github.com/sourcefrog/natsort.git#f8a6b0c
 build_flags =
     -DCONFIG_ASYNC_TCP_RUNNING_CORE=1
     -DCONFIG_ASYNC_TCP_USE_WDT=1

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -1,5 +1,15 @@
 #pragma once
 
+#ifndef AUDIOPLAYER_PLAYLIST_SORT_MODE_DEFAULT
+	#define AUDIOPLAYER_PLAYLIST_SORT_MODE_DEFAULT playlistSortMode::STRNATCASECMP
+#endif
+
+enum class playlistSortMode : uint8_t {
+	STRCMP = 1,
+	STRNATCMP = 2,
+	STRNATCASECMP = 3,
+};
+
 typedef struct { // Bit field
 	uint8_t playMode : 4; // playMode
 	char **playlist; // playlist
@@ -42,6 +52,9 @@ void AudioPlayer_TrackQueueDispatcher(const char *_itemToPlay, const uint32_t _l
 void AudioPlayer_TrackControlToQueueSender(const uint8_t trackCommand);
 void AudioPlayer_PauseOnMinVolume(const uint8_t oldVolume, const uint8_t newVolume);
 
+playlistSortMode AudioPlayer_GetPlaylistSortMode(void);
+bool AudioPlayer_SetPlaylistSortMode(playlistSortMode value);
+bool AudioPlayer_SetPlaylistSortMode(uint8_t value);
 uint8_t AudioPlayer_GetCurrentVolume(void);
 void AudioPlayer_SetCurrentVolume(uint8_t value);
 uint8_t AudioPlayer_GetMaxVolume(void);

--- a/src/EnumUtils.h
+++ b/src/EnumUtils.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <type_traits>
+
+/*
+helper for converting to/from enum classes
+Example:
+
+	enum class ExampleEnum : int {
+		a = 1,
+		b = 3,
+		c = 5
+	};
+
+	constexpr int a = EnumUtils::underlying_value(ExampleEnum::c); // a = 5
+	constexpr ExampleEnum b = EnumUtils::to_enum<ExampleEnum>(a); // b = ExampleEnum::c
+	constexpr int c = EnumUtils::underlying_value(b); // c = 5
+*/
+namespace EnumUtils {
+namespace details {
+template <typename E>
+using enable_enum_t = typename std::enable_if<std::is_enum<E>::value, typename std::underlying_type<E>::type>::type;
+}
+
+template <typename E>
+constexpr inline details::enable_enum_t<E> underlying_value(E e) noexcept {
+	return static_cast<typename std::underlying_type<E>::type>(e);
+}
+
+template <typename E, typename T>
+constexpr inline typename std::enable_if<std::is_enum<E>::value && std::is_integral<T>::value, E>::type to_enum(T value) noexcept {
+	return static_cast<E>(value);
+}
+} // namespace EnumUtils


### PR DESCRIPTION
Currently media with >= 10 files won't be played in the correct order unless the filenames contain leading zeros.
This changes the playlist generation and the explorer file list sorting to natural sort.
It makes sure that the names containing numeric values are sorted by their actual value (1 < 2 < 10) instead of a basic string comparison (1 < 10 < 2).