### PR TITLE
remove convertFilenameToAscii()

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -47,12 +47,6 @@ inline bool endsWith(const char *str, const char *suf) {
 	return b == suf && *a == *b;
 }
 
-inline void convertFilenameToAscii(String utf8String, char *asciiString) {
-	// Arduino >= 2.0.5 filenames are already unicode, copy to result here without UTF-8 decoding
-	strncpy(asciiString, (char *) utf8String.c_str(), utf8String.length() / sizeof(asciiString[0]));
-	asciiString[utf8String.length()] = 0;
-}
-
 inline void convertAsciiToUtf8(String asciiString, char *utf8String) {
 
 	int k = 0;


### PR DESCRIPTION
avoid unnecessary string copies by removing the legacy `convertFilenameToAscii()` function

Fixes memory corruption when working with long file paths (`convertFilenameToAscii()` didn't check the target buffer size).