### PR TITLE
Playlist fixes

### DIFF
--- a/src/LogMessages_DE.cpp
+++ b/src/LogMessages_DE.cpp
@@ -27,6 +27,7 @@ const char dirOrFileDoesNotExist[] = "Datei oder Verzeichnis existiert nicht: %s
 const char unableToAllocateMemForPlaylist[] = "Speicher für Playlist konnte nicht allokiert werden!";
 const char unableToAllocateMem[] = "Speicher konnte nicht allokiert werden!";
 const char fileModeDetected[] = "Dateimodus erkannt.";
+const char fileInvalid[] = "Ungültige Datei: %s";
 const char nameOfFileFound[] = "Gefundenes File: %s";
 const char reallocCalled[] = "Speicher reallokiert.";
 const char unableToAllocateMemForLinearPlaylist[] = "Speicher für lineare Playlist konnte nicht allokiert werden!";

--- a/src/LogMessages_EN.cpp
+++ b/src/LogMessages_EN.cpp
@@ -27,6 +27,7 @@ const char dirOrFileDoesNotExist[] = "File of directory does not exist: %s";
 const char unableToAllocateMemForPlaylist[] = "Unable to allocate memory for playlist!";
 const char unableToAllocateMem[] = "Unable to allocate memory!";
 const char fileModeDetected[] = "File-mode detected.";
+const char fileInvalid[] = "Invalid file: %s";
 const char nameOfFileFound[] = "File found: %s";
 const char reallocCalled[] = "Reallocated memory.";
 const char unableToAllocateMemForLinearPlaylist[] = "Unable to allocate memory for linear playlist!";

--- a/src/LogMessages_FR.cpp
+++ b/src/LogMessages_FR.cpp
@@ -26,6 +26,7 @@ const char dirOrFileDoesNotExist[] = "Le fichier ou le répertoire n'existe pas 
 const char unableToAllocateMemForPlaylist[] = "Impossible d'allouer de la mémoire pour la liste de lecture !";
 const char unableToAllocateMem[] = "Impossible d'allouer de la mémoire !";
 const char fileModeDetected[] = "Mode fichier détecté.";
+const char fileInvalid[] = "Fichier non valide: %s";
 const char nameOfFileFound[] = "Fichier trouvé : %s";
 const char reallocCalled[] = "Mémoire réallouée.";
 const char unableToAllocateMemForLinearPlaylist[] = "Impossible d'allouer de la mémoire pour la liste de lecture linéaire !";

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -311,7 +311,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 	// Don't read from m3u-file. Means: read filenames from SD and make playlist of it
 	if (!enablePlaylistFromM3u) {
 		Log_Println(playlistGen, LOGLEVEL_NOTICE);
-		char fileNameBuf[255];
+		const char *fileNameBuf;
 		// File-mode
 		if (!fileOrDirectory.isDirectory()) {
 			files = (char **) x_malloc(sizeof(char *) * 2);
@@ -321,7 +321,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 				return nullptr;
 			}
 			Log_Println(fileModeDetected, LOGLEVEL_INFO);
-			strncpy(fileNameBuf, fileOrDirectory.path(), sizeof(fileNameBuf) / sizeof(fileNameBuf[0]));
+			fileNameBuf = fileOrDirectory.path();
 			if (fileValid(fileNameBuf)) {
 				files[1] = x_strdup(fileNameBuf);
 				files[0] = x_strdup("1"); // Number of files is always 1 in file-mode
@@ -350,7 +350,7 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 			if (isDir) {
 				continue;
 			} else {
-				strncpy(fileNameBuf, MyfileName.c_str(), sizeof(fileNameBuf) / sizeof(fileNameBuf[0]));
+				fileNameBuf = MyfileName.c_str();
 				// Don't support filenames that start with "." and only allow .mp3 and other supported audio file formats
 				if (fileValid(fileNameBuf)) {
 					// Log_Printf(LOGLEVEL_INFO, "%s: %s", nameOfFileFound), fileNameBuf);

--- a/src/SdCard.cpp
+++ b/src/SdCard.cpp
@@ -324,8 +324,11 @@ char **SdCard_ReturnPlaylist(const char *fileName, const uint32_t _playMode) {
 			strncpy(fileNameBuf, fileOrDirectory.path(), sizeof(fileNameBuf) / sizeof(fileNameBuf[0]));
 			if (fileValid(fileNameBuf)) {
 				files[1] = x_strdup(fileNameBuf);
+				files[0] = x_strdup("1"); // Number of files is always 1 in file-mode
+			} else {
+				files[0] = x_strdup("0"); // empty playlist
+				Log_Printf(LOGLEVEL_ERROR, fileInvalid, fileNameBuf);
 			}
-			files[0] = x_strdup("1"); // Number of files is always 1 in file-mode
 
 			return &(files[1]);
 		}

--- a/src/logmessages.h
+++ b/src/logmessages.h
@@ -23,6 +23,7 @@ extern const char dirOrFileDoesNotExist[];
 extern const char unableToAllocateMemForPlaylist[];
 extern const char unableToAllocateMem[];
 extern const char fileModeDetected[];
+extern const char fileInvalid[];
 extern const char nameOfFileFound[];
 extern const char reallocCalled[];
 extern const char unableToAllocateMemForLinearPlaylist[];


### PR DESCRIPTION
fix a crash when trying to play an "invalid" file (playlist with length 1 was created but without an actual item)

Avoid unecessary string copy during playlist generation