### PR TITLE
set title and navbar heading to hostname

### DIFF
--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -3,7 +3,7 @@
     "restart": "Neustart",
     "reset": "Reset",
 	"execute": "Ausführen",
-    "title": "ESPuino-Konfiguration",
+    "title": "ESPuino",
     "shutdown": "Ausschalten",
     "log": "Log",
     "info": "Info",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -3,7 +3,7 @@
     "restart": "Restart",
     "reset": "Reset",
     "execute": "Execute",
-    "title": "ESPuino-Settings",
+    "title": "ESPuino",
     "shutdown": "Shutdown",
     "log": "Log",
     "info": "Info",

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -3,7 +3,7 @@
     "restart": "Redémarrer",
     "reset": "Réinitialiser",
     "execute": "Exécuter",
-    "title": "Paramètres ESPuino",
+    "title": "ESPuino",
     "shutdown": "Éteindre",
     "log": "Journal",
     "info": "Info",

--- a/html/management.html
+++ b/html/management.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-	<title data-i18n="title">ESPuino-Settings</title>
+	<title data-i18n="title">ESPuino</title>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="preconnect" href="https://cdnjs.cloudflare.com">
@@ -161,7 +161,7 @@
 	<a class="float-left navbar-brand">
 		<img src="/logo"
 			 width="35" height="35" class="d-inline-block align-top" alt=""/>
-		ESPuino
+		<span id="navbar-heading">ESPuino</span>
 	</a>
 	<a class="reboot float-right nav-link openPopupRestart" href="javascript:void(0);"><i class="fas fa-redo"></i> <span data-i18n="restart">Restart</span></a>
 	<a class="reboot float-right nav-link openPopupShutdown" href="javascript:void(0);"><i class="fas fa-power-off"></i> <span data-i18n="shutdown">Shutdown</span></a>
@@ -1682,6 +1682,9 @@
 		if (wifiSettings) {
 			document.getElementById("hostname").value = wifiSettings.hostname;
 			document.getElementById("scan_wifi_on_start").checked = wifiSettings.scanOnStart;
+			
+			// set title to hostname
+			setTitle(wifiSettings.hostname);
 		}
 		// ssids
 		let ssidSettings = settings.ssids;
@@ -2096,6 +2099,9 @@
 			hostname: hostname,
 			scanOnStart: scanWifi
 		};
+
+		// set title to hostname
+		setTitle(hostname);
 		
 		await fetch("/wificonfig", {
 			method: "POST",
@@ -2257,6 +2263,11 @@
 	async function fetchLog() {
 		let logtext = await (await fetch("/log")).text();
 		$('#modalLogContent').text(logtext);
+	}
+
+	function setTitle(newTitle) {
+		$('title').text(newTitle);
+		$('#navbar-heading').text(newTitle);
 	}
 
 	$(document).ready(function () {


### PR DESCRIPTION
With this PR the html title and the text "ESPuino" in the navbar will be changed to the hostname for easier identification (in case you'er working with multiple ESPuinos).

I also changed the default title from "ESPuino-Settings" to just "ESPuino".