### PR TITLE
Embed swagger UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ sdkconfig.*
 src/settings-override.h
 src/settings-custom-override.h
 node_modules/
+html/REST_API.yaml

--- a/REST-API.yaml
+++ b/REST-API.yaml
@@ -5,6 +5,8 @@ info:
   description: API for the ESPuino, a DIY Smart Speaker project. ESPuino is a DIY Smart Speaker that uses software-based audio decoding, supports various music sources, and offers a user-friendly web interface. It simplifies audio processing and enhances user feedback with Neopixel rings.
 
 servers:
+  - url: /
+    description: Local Device
   - url: http://espuino.local/
     description: Development ESPuino
 

--- a/html/js/swaggerInitializer.js
+++ b/html/js/swaggerInitializer.js
@@ -1,6 +1,4 @@
 window.onload = function() {
-  //<editor-fold desc="Changeable Configuration Block">
-
   window.ui = SwaggerUIBundle({
     url: "../REST_API.yaml",
     dom_id: '#swagger-ui',
@@ -14,6 +12,4 @@ window.onload = function() {
     ],
     layout: "StandaloneLayout"
   });
-
-  //</editor-fold>
 };

--- a/html/js/swaggerInitializer.js
+++ b/html/js/swaggerInitializer.js
@@ -1,0 +1,19 @@
+window.onload = function() {
+  //<editor-fold desc="Changeable Configuration Block">
+
+  window.ui = SwaggerUIBundle({
+    url: "../REST_API.yaml",
+    dom_id: '#swagger-ui',
+    deepLinking: true,
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [
+      SwaggerUIBundle.plugins.DownloadUrl
+    ],
+    layout: "StandaloneLayout"
+  });
+
+  //</editor-fold>
+};

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -27,7 +27,7 @@
         "bluetooth": "Bluetooth",
         "general": "Allgemein",
         "tools": "Tools",
-        "forum": "Forum"
+        "help": "Hilfe"
     },
     "wifi": {
         "title": "WLAN-Einstellungen",
@@ -305,9 +305,15 @@
             "desc": "Hier kann ein Firmware-Update durchgeführt werden."
         }
     },
-    "forum": {
-        "title": "Forum",
-        "desc": "Du hast Probleme mit ESPuino oder bist an einem Erfahrungsaustausch interessiert?<br />Dann schaue doch mal im <a href=\"https://forum.espuino.de\" target=\"_blank\">ESPuino-Forum</a> vorbei! Insbesondere gibt es dort auch einen<br /><a href=\"https://forum.espuino.de/c/dokumentation/anleitungen/10\" target=\"_blank\">Bereich</a>, in dem reichlich Dokumentation hinterlegt ist. Wir freuen uns auf deinen Besuch!"
+    "help": {
+        "forum": {
+            "title": "Forum",
+            "desc": "Du hast Probleme mit ESPuino oder bist an einem Erfahrungsaustausch interessiert?<br />Dann schaue doch mal im <a href=\"https://forum.espuino.de\" target=\"_blank\">ESPuino-Forum</a> vorbei! Insbesondere gibt es dort auch einen<br /><a href=\"https://forum.espuino.de/c/dokumentation/anleitungen/10\" target=\"_blank\">Bereich</a>, in dem reichlich Dokumentation hinterlegt ist. Wir freuen uns auf deinen Besuch!"
+        },
+        "swagger": {
+            "title": "Swagger",
+            "desc": "Dokumentation der REST API: <a href=\"swagger.html\" target=\"_blank\">Swagger</a>."
+        }
     },
     "datetime": {
         "day": "Tag",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -27,7 +27,7 @@
         "bluetooth": "Bluetooth",
         "general": "General",
         "tools": "Tools",
-        "forum": "Forum"
+        "help": "Help"
     },
     "wifi": {
         "title": "WiFi-configuration",
@@ -305,9 +305,15 @@
             "desc": "Firmware can be updated right here."
         }
     },
-    "forum": {
-        "title": "Forum",
-        "desc": "Having problems or aim to discuss about ESPuino?<br /> Join us at <a href=\"https://forum.espuino.de\" target=\"_blank\">ESPuino-Forum</a>! Especially there's a lot of (german)<br /><a href=\"https://forum.espuino.de/c/dokumentation/anleitungen/10\" target=\"_blank\">documentation</a> online!"
+    "help": {
+        "forum": {
+            "title": "Forum",
+            "desc": "Having problems or aim to discuss about ESPuino?<br /> Join us at <a href=\"https://forum.espuino.de\" target=\"_blank\">ESPuino-Forum</a>! Especially there's a lot of (german)<br /><a href=\"https://forum.espuino.de/c/dokumentation/anleitungen/10\" target=\"_blank\">documentation</a> online!"
+        },
+        "swagger": {
+            "title": "Swagger",
+            "desc": "Documentation of the REST API: <a href=\"swagger.html\" target=\"_blank\">Swagger</a>."
+        }
     },
     "datetime": {
         "day": "day",

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -27,7 +27,7 @@
         "bluetooth": "Bluetooth",
         "general": "Général",
         "tools": "Outils",
-        "forum": "Forum"
+        "help": "Aide"
     },
     "wifi": {
         "title": "Configuration WiFi",
@@ -307,10 +307,16 @@
             "desc": "La mise à jour du micrologiciel peut être effectuée ici."
         }
     },
+    "help": {
         "forum": {
                 "title": "Forum",
                 "desc": "Rencontrez-vous des problèmes ou souhaitez-vous discuter à propos d'ESPuino ?<br /> Rejoignez-nous sur le <a href=\"https://forum.espuino.de\" target=\"_blank\">Forum ESPuino</a> ! Surtout, il y a beaucoup de <a href=\"https://forum.espuino.de/c/dokumentation/anleitungen/10\" target=\"_blank\">documentation</a> en ligne !"
             },
+        "swagger": {
+            "title": "Swagger",
+            "desc": "Documentation de l'API REST: <a href=\"swagger.html\" target=\"_blank\">Swagger</a>."
+        }
+    },
             "datetime": {
                 "day": "jour",
                 "days": "jours",

--- a/html/management.html
+++ b/html/management.html
@@ -333,7 +333,7 @@
 			<a class="nav-item nav-link" id="nav-bt-tab" data-visible="false" data-toggle="tab" href="#nav-bt" role="tab" aria-controls="nav-bt" aria-selected="false"><i class="fab fa-bluetooth"></i><span data-i18n="nav.bluetooth">Bluetooth</span></a>
 			<a class="nav-item nav-link" id="nav-general-tab" data-toggle="tab" href="#nav-general" role="tab" aria-controls="nav-general" aria-selected="false"><i class="fas fa-sliders-h"></i><span data-i18n="nav.general">General</span></a>
 			<a class="nav-item nav-link" id="nav-tools-tab" data-toggle="tab" href="#nav-tools" role="tab" aria-controls="nav-tools" aria-selected="false"><i class="fas fa-wrench"></i><span data-i18n="nav.tools">Tools</span></a>
-			<a class="nav-item nav-link" id="nav-forum-tab" data-toggle="tab" href="#nav-forum" role="tab" aria-controls="nav-forum" aria-selected="false"><i class="fas fa-comment"></i><span class=".d-sm-none .d-md-block"><span data-i18n="nav.forum">Forum</span></span></a>
+			<a class="nav-item nav-link" id="nav-help-tab" data-toggle="tab" href="#nav-help" role="tab" aria-controls="nav-help" aria-selected="false"><i class="fas fa-comment"></i><span class=".d-sm-none .d-md-block"><span data-i18n="nav.help">Help</span></span></a>
 		</div>
 	</nav>
 <br>
@@ -877,10 +877,14 @@
 	</div>
 	<br />
 	<br />
-	<div class="tab-pane fade" id="nav-forum" role="tabpanel" aria-labelledby="nav-forum-tab">
-		<div class="container" id="forum">
-			<legend data-i18n="forum.title"></legend>
-			<p data-i18n="[html]forum.desc"></p>
+	<div class="tab-pane fade" id="nav-help" role="tabpanel" aria-labelledby="nav-help-tab">
+		<div class="container" id="divForum">
+			<legend data-i18n="help.forum.title"></legend>
+			<p data-i18n="[html]help.forum.desc"></p>
+		</div>
+		<div class="container" id="divSwagger">
+			<legend data-i18n="help.swagger.title"></legend>
+			<p data-i18n="[html]help.swagger.desc"></p>
 		</div>
 	</div>
 </div>

--- a/html/swagger.html
+++ b/html/swagger.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.15.1/swagger-ui.css" />
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.15.1/swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.15.1/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+    <script src="./js/swaggerInitializer.js" charset="UTF-8"> </script>
+  </body>
+</html>

--- a/processHtml.py
+++ b/processHtml.py
@@ -6,6 +6,7 @@ Use this script for creating binary header files from html files.
 
 from pathlib import Path
 import os
+import shutil
 import mimetypes
 import gzip
 Import("env")  # pylint: disable=undefined-variable
@@ -26,12 +27,15 @@ HTML_DIR = Path("html").absolute()
 # List of files, which will only be minifed but not compressed (f.e. html files with templates)
 WWW_FILES = []
 # list of all files, which shall be compressed before embedding
-# files with ".json" ending will be minifed before compression, ".js" will not be changed!
+# files with ".json" ending will be minifed before compression, ".js" and ".yaml" will not be changed!
 BINARY_FILES =[
     Path("management.html"),
     Path("accesspoint.html"),
     Path("js/i18next.min.js"),
     Path("js/i18nextHttpBackend.min.js"),
+    Path("REST_API.yaml"),
+    Path("swagger.html"),
+    Path("js/swaggerInitializer.js"),
     Path("js/loc_i18next.min.js"),
     Path("locales/de.json"),
     Path("locales/en.json"),
@@ -114,6 +118,9 @@ class HtmlHeaderProcessor:
             print(f"  {HTML_DIR / html_file} -> {OUTPUT_DIR / header_file}")
             cls._process_header_file(HTML_DIR / html_file, OUTPUT_DIR / header_file)
         binary_header = OUTPUT_DIR / "HTMLbinary.h"
+
+        shutil.copyfile('REST-API.yaml', 'html/REST_API.yaml')
+
         if binary_header.exists():
             os.remove(binary_header)    # remove file if it exists, since we are appending to it
 
@@ -124,7 +131,10 @@ class HtmlHeaderProcessor:
 
             info = dict()   # the dict entry for this file
             info["uri"] = "/" + filePath.relative_to(HTML_DIR).as_posix()
-            info["mimeType"] = mimetypes.types_map[filePath.suffix]
+            if filePath.suffix == ".yaml":
+                info["mimeType"] = "application/yaml" # mimetypes does not yet know yaml, see https://datatracker.ietf.org/doc/rfc9512/
+            else:
+                info["mimeType"] = mimetypes.types_map[filePath.suffix]
             info = cls._process_binary_file(HTML_DIR / binary_file, binary_header, info)
             fileList.append(info)
 

--- a/processHtml.py
+++ b/processHtml.py
@@ -119,7 +119,7 @@ class HtmlHeaderProcessor:
             cls._process_header_file(HTML_DIR / html_file, OUTPUT_DIR / header_file)
         binary_header = OUTPUT_DIR / "HTMLbinary.h"
 
-        shutil.copyfile('REST-API.yaml', 'html/REST_API.yaml')
+        shutil.copy2('REST-API.yaml', 'html/REST_API.yaml')  # Copy and rename the file with keeping the mtime
 
         if binary_header.exists():
             os.remove(binary_header)    # remove file if it exists, since we are appending to it


### PR DESCRIPTION
This PR embeds the Swagger UI into the Web Interface. To keep the additionally required flash usage low, most files get pulled from a CDN.

I also renamed the last tab `Forum` to `Help` and extended the tab with a section for the REST API documentation.
The great advantage for an embedded Swagger UI is to be able to directly send the cmds to the device.

# Updated UI
![grafik](https://github.com/biologist79/ESPuino/assets/1783586/e8fa14a2-6903-4c1d-80f6-2f17ad63ad39)

# Swagger UI
![grafik](https://github.com/biologist79/ESPuino/assets/1783586/906b5110-8565-4d60-8a07-e244003ac904)

# Direct calls to the device
![grafik](https://github.com/biologist79/ESPuino/assets/1783586/7f59aca6-2305-4d4f-862e-b10ff315fa3b)