### PR TITLE
add button to expand/shrink file list

### DIFF
--- a/html/management.html
+++ b/html/management.html
@@ -32,9 +32,11 @@
 		}
 		.filetree {
 			border: 1px solid black;
-			height: 200px;
 			margin: 0em 0em 1em 0em;
 			overflow-y: scroll;
+		}
+		.filetree-size {
+			height: 200px;
 		}
 		.slider.slider-horizontal {
 			width: 60%;
@@ -495,13 +497,14 @@
 				<legend id="fileslegend" data-i18n="files.title">Files</legend>
 				<div class="filetree-container">
 				<div id="filebrowser">
-					<div class="filetree demo" id="explorerTree"></div>
+					<div class="filetree filetree-size" id="explorerTree"></div>
 				</div>
 				<div class="input-group input-focus">
 					<div class="input-group-prepend">
 					  <span class="input-group-text bg-white"><i class="fas fa-search"></i></span>
 					</div>
 					<input type="search" id="filetreesearch" data-i18n="[placeholder]files.search.placeholder" class="form-control border-left-0" onsearch="searchFiles($(this).val())" onkeyup="searchFiles($(this).val())">
+					&nbsp;<button id="expandfilelist" class="btn btn-primary" onclick="resizeFileList(true)"><span class="fas fa-expand-alt"></span></button><button id="shrinkfilelist" class="btn btn-primary" onclick="resizeFileList(false)" style="display: none;"><span class="fas fa-compress-alt"></span></button>
 				</div>
 				<div>
 				<br>
@@ -2254,6 +2257,19 @@
 		};
 		var myJSON = JSON.stringify(myObj);
 		socket.send(myJSON);
+	}
+	function resizeFileList(expand) {
+		const el = document.querySelector(".filetree-size");
+		if (expand) {
+			el.setAttribute("style", "height: auto");
+			$('#expandfilelist').hide();
+			$('#shrinkfilelist').show();
+		}
+		else {
+			el.setAttribute("style", "height: 200px");
+			$('#shrinkfilelist').hide();
+			$('#expandfilelist').show();
+		}
 	}
 	function sendVolume(vol) {
 		var myObj = {


### PR DESCRIPTION
This PR adds a button to expand/shrink file list. This is useful if the list gets longer. In expanded mode, the list is always as large as needed.

@tueddy Please habe a look. It also works well on a smart phone webbrowser.

# Normal
![grafik](https://github.com/biologist79/ESPuino/assets/1783586/f59b54e1-193d-4106-b2e3-b2154496eae2)

# Expanded
![grafik](https://github.com/biologist79/ESPuino/assets/1783586/a147f7bb-62c7-4b11-9f86-626d4fe4bb22)

