### PR TITLE
Added virtual RFID-Cards

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -274,7 +274,7 @@ void Audio_setTitle(const char *format, ...) {
 	va_end(args);
 
 	// notify web ui and mqtt
-	Web_SendWebsocketData(0, 30);
+	Web_SendWebsocketData(0, WebsocketCodeType::TrackInfo);
 #ifdef MQTT_ENABLE
 	publishMqtt(topicTrackState, gPlayProperties.title, false);
 #endif
@@ -413,7 +413,7 @@ void AudioPlayer_Task(void *parameter) {
 		if (xQueueReceive(gVolumeQueue, &currentVolume, 0) == pdPASS) {
 			Log_Printf(LOGLEVEL_INFO, newLoudnessReceivedQueue, currentVolume);
 			audio->setVolume(currentVolume, VOLUMECURVE);
-			Web_SendWebsocketData(0, 50);
+			Web_SendWebsocketData(0, WebsocketCodeType::Volume);
 #ifdef MQTT_ENABLE
 			publishMqtt(topicLoudnessState, currentVolume, false);
 #endif
@@ -540,7 +540,7 @@ void AudioPlayer_Task(void *parameter) {
 						AudioPlayer_NvsRfidWriteWrapper(gPlayProperties.playRfidTag, gPlayProperties.playlist->at(gPlayProperties.currentTrackNumber), audio->getFilePos() - audio->inBufferFilled(), gPlayProperties.playMode, gPlayProperties.currentTrackNumber, gPlayProperties.playlist->size());
 					}
 					gPlayProperties.pausePlay = !gPlayProperties.pausePlay;
-					Web_SendWebsocketData(0, 30);
+					Web_SendWebsocketData(0, WebsocketCodeType::TrackInfo);
 					continue;
 
 				case NEXTTRACK:
@@ -1290,7 +1290,7 @@ void AudioPlayer_ClearCover(void) {
 	gPlayProperties.coverFilePos = 0;
 	AudioPlayer_StationLogoUrl = "";
 	// websocket and mqtt notify cover image has changed
-	Web_SendWebsocketData(0, 40);
+	Web_SendWebsocketData(0, WebsocketCodeType::CoverImg);
 #ifdef MQTT_ENABLE
 	publishMqtt(topicCoverChangedState, "", false);
 #endif
@@ -1301,7 +1301,7 @@ void audio_info(const char *info) {
 	Log_Printf(LOGLEVEL_INFO, "info        : %s", info);
 	if (startsWith((char *) info, "slow stream, dropouts")) {
 		// websocket notify for slow stream
-		Web_SendWebsocketData(0, 3);
+		Web_SendWebsocketData(0, WebsocketCodeType::Dropout);
 	}
 }
 
@@ -1358,7 +1358,7 @@ void audio_icyurl(const char *info) { // homepage
 		// has station homepage, get favicon url
 		AudioPlayer_StationLogoUrl = "https://www.google.com/s2/favicons?sz=256&domain_url=" + String(info);
 		// websocket and mqtt notify station logo has changed
-		Web_SendWebsocketData(0, 40);
+		Web_SendWebsocketData(0, WebsocketCodeType::CoverImg);
 	}
 }
 
@@ -1367,7 +1367,7 @@ void audio_icylogo(const char *info) { // logo
 	if (String(info) != "") {
 		AudioPlayer_StationLogoUrl = info;
 		// websocket and mqtt notify station logo has changed
-		Web_SendWebsocketData(0, 40);
+		Web_SendWebsocketData(0, WebsocketCodeType::CoverImg);
 	}
 }
 
@@ -1381,7 +1381,7 @@ void audio_id3image(File &file, const size_t pos, const size_t size) {
 	gPlayProperties.coverFilePos = pos;
 	gPlayProperties.coverFileSize = size;
 	// websocket and mqtt notify cover image has changed
-	Web_SendWebsocketData(0, 40);
+	Web_SendWebsocketData(0, WebsocketCodeType::CoverImg);
 #ifdef MQTT_ENABLE
 	publishMqtt(topicCoverChangedState, "", false);
 #endif
@@ -1444,7 +1444,7 @@ void audio_oggimage(File &file, std::vector<uint32_t> v) {
 	}
 	gPlayProperties.coverFilePos = 1; // flacMarker gives 4 Bytes before METADATA_BLOCK_PICTURE, whereas for flac files audioI2S points 3 Bytes before METADATA_BLOCK_PICTURE, so gPlayProperties.coverFilePos has to be set to 4-3=1
 	// websocket and mqtt notify cover image has changed
-	Web_SendWebsocketData(0, 40);
+	Web_SendWebsocketData(0, WebsocketCodeType::CoverImg);
 #ifdef MQTT_ENABLE
 	publishMqtt(topicCoverChangedState, "", false);
 #endif

--- a/src/Cmd.cpp
+++ b/src/Cmd.cpp
@@ -10,6 +10,7 @@
 #include "Led.h"
 #include "Log.h"
 #include "Mqtt.h"
+#include "Queues.h"
 #include "System.h"
 #include "Wlan.h"
 
@@ -364,6 +365,56 @@ void Cmd_Action(const uint16_t mod) {
 
 		case CMD_STOP: {
 			AudioPlayer_TrackControlToQueueSender(STOP);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_01: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_01, 0);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_02: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_02, 0);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_03: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_03, 0);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_04: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_04, 0);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_05: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_05, 0);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_06: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_06, 0);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_07: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_07, 0);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_08: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_08, 0);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_09: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_09, 0);
+			break;
+		}
+
+		case CMD_VIRTUAL_RFID_CARD_10: {
+			xQueueSend(gRfidCardQueue, VIRTUAL_RFID_CARD_10, 0);
 			break;
 		}
 

--- a/src/RfidCommon.cpp
+++ b/src/RfidCommon.cpp
@@ -38,7 +38,7 @@ void Rfid_PreferenceLookupHandler(void) {
 		System_UpdateActivityTimer();
 		strncpy(gCurrentRfidTagId, rfidTagId, cardIdStringSize - 1);
 		Log_Printf(LOGLEVEL_INFO, "%s: %s", rfidTagReceived, gCurrentRfidTagId);
-		Web_SendWebsocketData(0, 10); // Push new rfidTagId to all websocket-clients
+		Web_SendWebsocketData(0, WebsocketCodeType::CurrentRfid); // Push new rfidTagId to all websocket-clients
 		String s = "-1";
 		if (gPrefsRfid.isKey(gCurrentRfidTagId)) {
 			s = gPrefsRfid.getString(gCurrentRfidTagId, "-1"); // Try to lookup rfidId in NVS

--- a/src/Web.h
+++ b/src/Web.h
@@ -1,19 +1,18 @@
 #pragma once
 
 typedef enum class WebsocketCode {
-    Ok,
-    Error,
-    Dropout,
-    CurrentRfid,
-    Pong,
-    TrackInfo,
-    CoverImg,
-    Volume,
-    Settings,
-    Ssid,
-    TrackProgress
+	Ok = 0,
+	Error,
+	Dropout,
+	CurrentRfid,
+	Pong,
+	TrackInfo,
+	CoverImg,
+	Volume,
+	Settings,
+	Ssid,
+	TrackProgress
 } WebsocketCodeType;
-
 
 void Web_Cyclic(void);
 void Web_SendWebsocketData(uint32_t client, WebsocketCodeType code);

--- a/src/Web.h
+++ b/src/Web.h
@@ -1,4 +1,19 @@
 #pragma once
 
+typedef enum class WebsocketCode {
+    Ok,
+    Error,
+    Dropout,
+    CurrentRfid,
+    Pong,
+    TrackInfo,
+    CoverImg,
+    Volume,
+    Settings,
+    Ssid,
+    TrackProgress
+} WebsocketCodeType;
+
+
 void Web_Cyclic(void);
-void Web_SendWebsocketData(uint32_t client, uint8_t code);
+void Web_SendWebsocketData(uint32_t client, WebsocketCodeType code);

--- a/src/values.h
+++ b/src/values.h
@@ -68,6 +68,17 @@
 #define CMD_STOP		   182 // Command: stops playback
 #define CMD_RESTARTSYSTEM  183 // Command: restart System
 
+#define CMD_VIRTUAL_RFID_CARD_01 241 // Command: Virtual RFID-Card 900000000001
+#define CMD_VIRTUAL_RFID_CARD_02 242 // Command: Virtual RFID-Card 900000000002
+#define CMD_VIRTUAL_RFID_CARD_03 243 // Command: Virtual RFID-Card 900000000003
+#define CMD_VIRTUAL_RFID_CARD_04 244 // Command: Virtual RFID-Card 900000000004
+#define CMD_VIRTUAL_RFID_CARD_05 245 // Command: Virtual RFID-Card 900000000005
+#define CMD_VIRTUAL_RFID_CARD_06 246 // Command: Virtual RFID-Card 900000000006
+#define CMD_VIRTUAL_RFID_CARD_07 247 // Command: Virtual RFID-Card 900000000007
+#define CMD_VIRTUAL_RFID_CARD_08 248 // Command: Virtual RFID-Card 900000000008
+#define CMD_VIRTUAL_RFID_CARD_09 249 // Command: Virtual RFID-Card 900000000009
+#define CMD_VIRTUAL_RFID_CARD_10 250 // Command: Virtual RFID-Card 900000000010
+
 // Repeat-Modes
 #define NO_REPEAT		 0 // No repeat
 #define TRACK			 1 // Repeat current track (infinite loop)
@@ -89,6 +100,18 @@
 #define DE 1
 #define EN 2
 #define FR 3
+
+// Virtual RFID Cards
+#define VIRTUAL_RFID_CARD_01 "900000000001"
+#define VIRTUAL_RFID_CARD_02 "900000000002"
+#define VIRTUAL_RFID_CARD_03 "900000000003"
+#define VIRTUAL_RFID_CARD_04 "900000000004"
+#define VIRTUAL_RFID_CARD_05 "900000000005"
+#define VIRTUAL_RFID_CARD_06 "900000000006"
+#define VIRTUAL_RFID_CARD_07 "900000000007"
+#define VIRTUAL_RFID_CARD_08 "900000000008"
+#define VIRTUAL_RFID_CARD_09 "900000000009"
+#define VIRTUAL_RFID_CARD_10 "900000000010"
 
 // Debug
 #define PRINT_TASK_STATS 199 // Prints task stats for debugging, needs CONFIG_FREERTOS_USE_TRACE_FACILITY=y and CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y in sdkconfig.defaults


### PR DESCRIPTION
This PR is a replacement for https://github.com/biologist79/ESPuino/pull/315 and adds 10 virtual RFID-Cards.

It is based on the concept in https://forum.espuino.de/t/webradio-station-auf-eine-taste-legen/1343:

1. In `settings.h` assign any button action to one of the virtual RFID-Card cmds `CMD_VIRTUAL_RFID_CARD_0{1..10}`
2. In the WebUI, use the corresponding virtual RFIDs `90000000000{1..10}` as the RFID number. Alternatively just press the configured key shortcut and the corresponding RFID gets filled in.

Note that I also replaced the magic numbers für the code in the `Web_SendWebsocketData()` with an enum.