### PR TITLE
use saved SSID as LAST_SSID, when no successfull connection was possible

### DIFF
--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -271,6 +271,12 @@ void Wlan_Init(void) {
 			ipMode = buffer;
 		}
 		Log_Printf(LOGLEVEL_DEBUG, "SSID: %s, Password: %s, %s", s.ssid.c_str(), (s.password.length()) ? "yes" : "no", ipMode);
+		
+	    if (gPrefsSettings.isKey("LAST_SSID") == false) {
+			gPrefsSettings.putString("LAST_SSID", s.ssid);
+			Log_Println("Warn: using saved SSID as LAST_SSID", LOGLEVEL_NOTICE);
+		}
+		
 		return true;
 	});
 


### PR DESCRIPTION
I observed when no successfull conecction was possible (e.g. when mac filter on fritz box is active) after reboot no connection was made. In the patch we use the saved SSID as LAST_SSID 