### PR TITLE
Adding MQTT Topics

### DIFF
--- a/src/settings.h
+++ b/src/settings.h
@@ -26,18 +26,18 @@
 	more to come...
 	*/
 	#ifndef HAL             // Will be set by platformio.ini. If using Arduino-IDE you have to set HAL according your needs!
-		#define HAL 1       // HAL 1 = LoLin32, 2 = ESP32-A1S-AudioKit, 3 = Lolin D32, 4 = Lolin D32 pro; ... 99 = custom
+		#define HAL 7       // HAL 1 = LoLin32, 2 = ESP32-A1S-AudioKit, 3 = Lolin D32, 4 = Lolin D32 pro; ... 99 = custom
 	#endif
 
 
 	//########################## MODULES #################################
-	//#define PORT_EXPANDER_ENABLE          // When enabled, buttons can be connected via port-expander PCA9555 (https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306)
+	#define PORT_EXPANDER_ENABLE          // When enabled, buttons can be connected via port-expander PCA9555 (https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306)
 	//#define I2S_COMM_FMT_LSB_ENABLE       // Enables FMT instead of MSB for I2S-communication-format. Used e.g. by PT2811. Don't enable for MAX98357a, AC101 or PCM5102A)
 	#define MDNS_ENABLE                     // When enabled, you don't have to handle with ESPuino's IP-address. If hostname is set to "ESPuino", you can reach it via ESPuino.local
-	//#define MQTT_ENABLE                   // Make sure to configure mqtt-server and (optionally) username+pwd
+	#define MQTT_ENABLE                   // Make sure to configure mqtt-server and (optionally) username+pwd
 	#define FTP_ENABLE                      // Enables FTP-server; DON'T FORGET TO ACTIVATE AFTER BOOT BY PRESSING PAUSE + NEXT-BUTTONS (IN PARALLEL)!
 	#define NEOPIXEL_ENABLE                 // Don't forget configuration of NUM_LEDS if enabled
-	//#define NEOPIXEL_REVERSE_ROTATION     // Some Neopixels are adressed/soldered counter-clockwise. This can be configured here.
+	#define NEOPIXEL_REVERSE_ROTATION     // Some Neopixels are adressed/soldered counter-clockwise. This can be configured here.
 	#define LANGUAGE DE                     // DE = deutsch; EN = english
 	//#define STATIC_IP_ENABLE              // DEPRECATED: Enables static IP-configuration (change static ip-section accordingly)
 	#define HEADPHONE_ADJUST_ENABLE         // Used to adjust (lower) volume for optional headphone-pcb (refer maxVolumeSpeaker / maxVolumeHeadphone) and to enable stereo (if PLAY_MONO_SPEAKER is set)
@@ -123,19 +123,19 @@
 	// *****BUTTON*****        *****ACTION*****
 	#define BUTTON_0_SHORT    CMD_NEXTTRACK
 	#define BUTTON_1_SHORT    CMD_PREVTRACK
-	#define BUTTON_2_SHORT    CMD_PLAYPAUSE
-	#define BUTTON_3_SHORT    CMD_MEASUREBATTERY
-	#define BUTTON_4_SHORT    CMD_SEEK_BACKWARDS
-	#define BUTTON_5_SHORT    CMD_SEEK_FORWARDS
+	#define BUTTON_2_SHORT    CMD_NOTHING
+	#define BUTTON_3_SHORT    CMD_PLAYPAUSE
+	#define BUTTON_4_SHORT    CMD_TELL_IP_ADDRESS
+	#define BUTTON_5_SHORT    CMD_TELL_CURRENT_TIME
 
-	#define BUTTON_0_LONG     CMD_LASTTRACK
-	#define BUTTON_1_LONG     CMD_FIRSTTRACK
+	#define BUTTON_0_LONG     CMD_VIRTUAL_RFID_CARD_01
+	#define BUTTON_1_LONG     CMD_VIRTUAL_RFID_CARD_02
 	#define BUTTON_2_LONG     CMD_PLAYPAUSE
 	#define BUTTON_3_LONG     CMD_SLEEPMODE
 	#define BUTTON_4_LONG     CMD_VOLUMEUP
 	#define BUTTON_5_LONG     CMD_VOLUMEDOWN
 
-	#define BUTTON_MULTI_01   CMD_NOTHING   //CMD_TOGGLE_WIFI_STATUS (disabled now to prevent children from unwanted WiFi-disable)
+	#define BUTTON_MULTI_01   CMD_TOGGLE_WIFI_STATUS   //CMD_TOGGLE_WIFI_STATUS (disabled now to prevent children from unwanted WiFi-disable)
 	#define BUTTON_MULTI_02   CMD_ENABLE_FTP_SERVER
 	#define BUTTON_MULTI_03   CMD_NOTHING
 	#define BUTTON_MULTI_04   CMD_NOTHING
@@ -267,32 +267,32 @@
 	#ifdef MQTT_ENABLE
 		constexpr uint16_t mqttRetryInterval = 60;                // Try to reconnect to MQTT-server every (n) seconds if connection is broken
 		constexpr uint8_t mqttMaxRetriesPerInterval = 1;          // Number of retries per time-interval (mqttRetryInterval). mqttRetryInterval 60 / mqttMaxRetriesPerInterval 1 => once every 60s
-		#define DEVICE_HOSTNAME "ESP32-ESPuino"         // Name that is used for MQTT
-		constexpr const char topicSleepCmnd[] = "Cmnd/ESPuino/Sleep";
-		constexpr const char topicSleepState[] = "State/ESPuino/Sleep";
-		constexpr const char topicRfidCmnd[] = "Cmnd/ESPuino/Rfid";
-		constexpr const char topicRfidState[] = "State/ESPuino/Rfid";
-		constexpr const char topicTrackState[] = "State/ESPuino/Track";
-		constexpr const char topicTrackControlCmnd[] = "Cmnd/ESPuino/TrackControl";
-		constexpr const char topicCoverChangedState[] = "State/ESPuino/CoverChanged";
-		constexpr const char topicLoudnessCmnd[] = "Cmnd/ESPuino/Loudness";
-		constexpr const char topicLoudnessState[] = "State/ESPuino/Loudness";
-		constexpr const char topicSleepTimerCmnd[] = "Cmnd/ESPuino/SleepTimer";
-		constexpr const char topicSleepTimerState[] = "State/ESPuino/SleepTimer";
-		constexpr const char topicState[] = "State/ESPuino/State";
-		constexpr const char topicCurrentIPv4IP[] = "State/ESPuino/IPv4";
-		constexpr const char topicLockControlsCmnd[] ="Cmnd/ESPuino/LockControls";
-		constexpr const char topicLockControlsState[] ="State/ESPuino/LockControls";
-		constexpr const char topicPlaymodeState[] = "State/ESPuino/Playmode";
-		constexpr const char topicRepeatModeCmnd[] = "Cmnd/ESPuino/RepeatMode";
-		constexpr const char topicRepeatModeState[] = "State/ESPuino/RepeatMode";
-		constexpr const char topicLedBrightnessCmnd[] = "Cmnd/ESPuino/LedBrightness";
-		constexpr const char topicLedBrightnessState[] = "State/ESPuino/LedBrightness";
-		constexpr const char topicWiFiRssiState[] = "State/ESPuino/WifiRssi";
-		constexpr const char topicSRevisionState[] = "State/ESPuino/SoftwareRevision";
+		#define DEVICE_HOSTNAME "ESP32-ESPuino1"         // Name that is used for MQTT. Make sure this is unique for each device if you use this method.
+		constexpr const char topicSleepCmnd[] = "Cmnd/" DEVICE_HOSTNAME "/Sleep";
+		constexpr const char topicSleepState[] = "State/" DEVICE_HOSTNAME "/Sleep";
+		constexpr const char topicRfidCmnd[] = "Cmnd/" DEVICE_HOSTNAME "/Rfid";
+		constexpr const char topicRfidState[] = "State/" DEVICE_HOSTNAME "/Rfid";
+		constexpr const char topicTrackState[] = "State/" DEVICE_HOSTNAME "/Track";
+		constexpr const char topicTrackControlCmnd[] = "Cmnd/" DEVICE_HOSTNAME "/TrackControl";
+		constexpr const char topicCoverChangedState[] = "State/" DEVICE_HOSTNAME "/CoverChanged";
+		constexpr const char topicLoudnessCmnd[] = "Cmnd/" DEVICE_HOSTNAME "/Loudness";
+		constexpr const char topicLoudnessState[] = "State/" DEVICE_HOSTNAME "/Loudness";
+		constexpr const char topicSleepTimerCmnd[] = "Cmnd/" DEVICE_HOSTNAME "/SleepTimer";
+		constexpr const char topicSleepTimerState[] = "State/" DEVICE_HOSTNAME "/SleepTimer";
+		constexpr const char topicState[] = "State/" DEVICE_HOSTNAME "/State";
+		constexpr const char topicCurrentIPv4IP[] = "State/" DEVICE_HOSTNAME "/IPv4";
+		constexpr const char topicLockControlsCmnd[] ="Cmnd/" DEVICE_HOSTNAME "/LockControls";
+		constexpr const char topicLockControlsState[] ="State/" DEVICE_HOSTNAME "/LockControls";
+		constexpr const char topicPlaymodeState[] = "State/" DEVICE_HOSTNAME "/Playmode";
+		constexpr const char topicRepeatModeCmnd[] = "Cmnd/" DEVICE_HOSTNAME "/RepeatMode";
+		constexpr const char topicRepeatModeState[] = "State/" DEVICE_HOSTNAME "/RepeatMode";
+		constexpr const char topicLedBrightnessCmnd[] = "Cmnd/" DEVICE_HOSTNAME "/LedBrightness";
+		constexpr const char topicLedBrightnessState[] = "State/" DEVICE_HOSTNAME "/LedBrightness";
+		constexpr const char topicWiFiRssiState[] = "State/" DEVICE_HOSTNAME "/WifiRssi";
+		constexpr const char topicSRevisionState[] = "State/" DEVICE_HOSTNAME "/SoftwareRevision";
 		#ifdef BATTERY_MEASURE_ENABLE
-		constexpr const char topicBatteryVoltage[] = "State/ESPuino/Voltage";
-		constexpr const char topicBatterySOC[]     = "State/ESPuino/Battery";
+		constexpr const char topicBatteryVoltage[] = "State/" DEVICE_HOSTNAME "/Voltage";
+		constexpr const char topicBatterySOC[]     = "State/" DEVICE_HOSTNAME "/Battery";
 		#endif
 	#endif
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -26,18 +26,18 @@
 	more to come...
 	*/
 	#ifndef HAL             // Will be set by platformio.ini. If using Arduino-IDE you have to set HAL according your needs!
-		#define HAL 7       // HAL 1 = LoLin32, 2 = ESP32-A1S-AudioKit, 3 = Lolin D32, 4 = Lolin D32 pro; ... 99 = custom
+		#define HAL 1       // HAL 1 = LoLin32, 2 = ESP32-A1S-AudioKit, 3 = Lolin D32, 4 = Lolin D32 pro; ... 99 = custom
 	#endif
 
 
 	//########################## MODULES #################################
-	#define PORT_EXPANDER_ENABLE          // When enabled, buttons can be connected via port-expander PCA9555 (https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306)
+	//#define PORT_EXPANDER_ENABLE          // When enabled, buttons can be connected via port-expander PCA9555 (https://forum.espuino.de/t/einsatz-des-port-expanders-pca9555/306)
 	//#define I2S_COMM_FMT_LSB_ENABLE       // Enables FMT instead of MSB for I2S-communication-format. Used e.g. by PT2811. Don't enable for MAX98357a, AC101 or PCM5102A)
 	#define MDNS_ENABLE                     // When enabled, you don't have to handle with ESPuino's IP-address. If hostname is set to "ESPuino", you can reach it via ESPuino.local
-	#define MQTT_ENABLE                   // Make sure to configure mqtt-server and (optionally) username+pwd
+	//#define MQTT_ENABLE                   // Make sure to configure mqtt-server and (optionally) username+pwd
 	#define FTP_ENABLE                      // Enables FTP-server; DON'T FORGET TO ACTIVATE AFTER BOOT BY PRESSING PAUSE + NEXT-BUTTONS (IN PARALLEL)!
 	#define NEOPIXEL_ENABLE                 // Don't forget configuration of NUM_LEDS if enabled
-	#define NEOPIXEL_REVERSE_ROTATION     // Some Neopixels are adressed/soldered counter-clockwise. This can be configured here.
+	//#define NEOPIXEL_REVERSE_ROTATION     // Some Neopixels are adressed/soldered counter-clockwise. This can be configured here.
 	#define LANGUAGE DE                     // DE = deutsch; EN = english
 	//#define STATIC_IP_ENABLE              // DEPRECATED: Enables static IP-configuration (change static ip-section accordingly)
 	#define HEADPHONE_ADJUST_ENABLE         // Used to adjust (lower) volume for optional headphone-pcb (refer maxVolumeSpeaker / maxVolumeHeadphone) and to enable stereo (if PLAY_MONO_SPEAKER is set)
@@ -123,19 +123,19 @@
 	// *****BUTTON*****        *****ACTION*****
 	#define BUTTON_0_SHORT    CMD_NEXTTRACK
 	#define BUTTON_1_SHORT    CMD_PREVTRACK
-	#define BUTTON_2_SHORT    CMD_NOTHING
-	#define BUTTON_3_SHORT    CMD_PLAYPAUSE
-	#define BUTTON_4_SHORT    CMD_TELL_IP_ADDRESS
-	#define BUTTON_5_SHORT    CMD_TELL_CURRENT_TIME
+	#define BUTTON_2_SHORT    CMD_PLAYPAUSE
+	#define BUTTON_3_SHORT    CMD_MEASUREBATTERY
+	#define BUTTON_4_SHORT    CMD_SEEK_BACKWARDS
+	#define BUTTON_5_SHORT    CMD_SEEK_FORWARDS
 
-	#define BUTTON_0_LONG     CMD_VIRTUAL_RFID_CARD_01
-	#define BUTTON_1_LONG     CMD_VIRTUAL_RFID_CARD_02
+	#define BUTTON_0_LONG     CMD_LASTTRACK
+	#define BUTTON_1_LONG     CMD_FIRSTTRACK
 	#define BUTTON_2_LONG     CMD_PLAYPAUSE
 	#define BUTTON_3_LONG     CMD_SLEEPMODE
 	#define BUTTON_4_LONG     CMD_VOLUMEUP
 	#define BUTTON_5_LONG     CMD_VOLUMEDOWN
 
-	#define BUTTON_MULTI_01   CMD_TOGGLE_WIFI_STATUS   //CMD_TOGGLE_WIFI_STATUS (disabled now to prevent children from unwanted WiFi-disable)
+	#define BUTTON_MULTI_01   CMD_NOTHING   //CMD_TOGGLE_WIFI_STATUS (disabled now to prevent children from unwanted WiFi-disable)
 	#define BUTTON_MULTI_02   CMD_ENABLE_FTP_SERVER
 	#define BUTTON_MULTI_03   CMD_NOTHING
 	#define BUTTON_MULTI_04   CMD_NOTHING
@@ -267,7 +267,7 @@
 	#ifdef MQTT_ENABLE
 		constexpr uint16_t mqttRetryInterval = 60;                // Try to reconnect to MQTT-server every (n) seconds if connection is broken
 		constexpr uint8_t mqttMaxRetriesPerInterval = 1;          // Number of retries per time-interval (mqttRetryInterval). mqttRetryInterval 60 / mqttMaxRetriesPerInterval 1 => once every 60s
-		#define DEVICE_HOSTNAME "ESP32-ESPuino1"         // Name that is used for MQTT. Make sure this is unique for each device if you use this method.
+		#define DEVICE_HOSTNAME "ESP32-ESPuino"         // Name that is used for MQTT. Make sure this is unique for each device if you use this method.
 		constexpr const char topicSleepCmnd[] = "Cmnd/" DEVICE_HOSTNAME "/Sleep";
 		constexpr const char topicSleepState[] = "State/" DEVICE_HOSTNAME "/Sleep";
 		constexpr const char topicRfidCmnd[] = "Cmnd/" DEVICE_HOSTNAME "/Rfid";


### PR DESCRIPTION
Adjusted MQTT settings for easier integration of multiple ESPuino devices in a household.
The default setting #define DEVICE_HOSTNAME "ESP32-ESPuino" is now used as the MQTT-specific device name. This hostname is also utilized in the MQTT topics. As a result, integration with Home Assistant is now simpler and more streamlined.