### PR TITLE
Add fast seek button

### DIFF
--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -290,7 +290,11 @@ static void Button_HandleSinglePress(uint8_t i, unsigned long currentTimestamp) 
 	}
 
 	// Handle volume buttons with repeat functionality
-	if (Cmd_Long == CMD_VOLUMEUP || Cmd_Long == CMD_VOLUMEDOWN) {
+	if (Cmd_Long == CMD_VOLUMEUP || Cmd_Long == CMD_VOLUMEDOWN
+#ifdef BUTTON_SEEK_REPEAT_ENABLE
+		|| Cmd_Long == CMD_SEEK_FORWARDS || Cmd_Long == CMD_SEEK_BACKWARDS
+#endif
+	) {
 		if (pressDuration <= intervalToLongPress) {
 			return;
 		}

--- a/src/settings.h
+++ b/src/settings.h
@@ -49,6 +49,7 @@
 	//#define SHUTDOWN_ON_BAT_CRITICAL      // Whether to turn off on critical battery-level (only used if MEASURE_BATTERY_XXX is active)
 	//#define PLAY_LAST_RFID_AFTER_REBOOT   // When restarting ESPuino, the last RFID that was active before, is recalled and played
 	#define USEROTARY_ENABLE                // If rotary-encoder is used (don't forget to review WAKEUP_BUTTON if you disable this feature!)
+	//#define BUTTON_SEEK_REPEAT_ENABLE       // If enabled, holding seek-buttons (forwards/backwards) will trigger repeated seek-actions after the long-press-interval
 	//#define BLUETOOTH_ENABLE                // If enabled and bluetooth-mode is active, you can stream to your ESPuino or to a headset via bluetooth (a2dp-sink & a2dp-source). Note: This feature consumes a lot of resources and the available flash/ram might not be sufficient.
 	//#define IR_CONTROL_ENABLE             // Enables remote control (https://forum.espuino.de/t/neues-feature-fernsteuerung-per-infrarot-fernbedienung/265)
 	//#define PAUSE_WHEN_RFID_REMOVED       // Playback starts when card is applied and pauses automatically, when card is removed (https://forum.espuino.de/t/neues-feature-pausieren-wenn-rfid-karte-entfernt-wurde/541)


### PR DESCRIPTION
This PR introduces a new configurable feature for button long-press seek behavior. This behaves identically to the volume button auto-repeat.

BUTTON_SEEK_REPEAT_ENABLE in src/settings.h allows users to toggle long-press for seek buttons.