### PR TITLE
Feature/track seeking with rotary encoder

### DIFF
--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -87,7 +87,6 @@
 		},
 		"seek": {
 			"title": "Spulen (Drehimpulsgeber)",
-			"enable": "Spulen über Drehimpulsgeber aktivieren",
 			"delay": "Zeitverzug bis zum Sprung (Sek.)",
 			"turns": "Drehimpulsgeber-Umdrehungen pro Titel"
 		}

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -84,6 +84,12 @@
 		"rotary": {
 			"title": "Drehimpulsgeber",
 			"reverse": "Drehrichtung umkehren"
+		},
+		"seek": {
+			"title": "Spulen (Drehimpulsgeber)",
+			"enable": "Spulen über Drehimpulsgeber aktivieren",
+			"delay": "Zeitverzug bis zum Sprung (Sek.)",
+			"turns": "Drehimpulsgeber-Umdrehungen pro Titel"
 		}
 	},
 	"wifi": {
@@ -253,7 +259,8 @@
 					"247": "Spiele virtuelle RFID-Karte 07",
 					"248": "Spiele virtuelle RFID-Karte 08",
 					"249": "Spiele virtuelle RFID-Karte 09",
-					"250": "Spiele virtuelle RFID-Karte 10"
+					"250": "Spiele virtuelle RFID-Karte 10",
+					"186": "Spulen (Drehimpulsgeber)"
 				}
 			}
 		}

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -84,6 +84,12 @@
 		"rotary": {
 			"title": "Rotary encoder",
 			"reverse": "Reverse direction of rotation"
+		},
+		"seek": {
+			"title": "Seek (rotary encoder)",
+			"enable": "Enable seeking via rotary encoder",
+			"delay": "Delay before jumping (s)",
+			"turns": "Encoder turns per track"
 		}
 	},
 	"wifi": {
@@ -253,7 +259,8 @@
 					"247": "Play virtual RFID-card 07",
 					"248": "Play virtual RFID-card 08",
 					"249": "Play virtual RFID-card 09",
-					"250": "Play virtual RFID-card 10"
+					"250": "Play virtual RFID-card 10",
+					"186": "Seek (rotary encoder)"
 				}
 			}
 		}

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -87,7 +87,6 @@
 		},
 		"seek": {
 			"title": "Seek (rotary encoder)",
-			"enable": "Enable seeking via rotary encoder",
 			"delay": "Delay before jumping (s)",
 			"turns": "Encoder turns per track"
 		}

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -84,6 +84,12 @@
 		"rotary": {
 			"title": "Codeur rotatif",
 			"reverse": "Inversion du sens de rotation"
+		},
+		"seek": {
+			"title": "Avance/retour (encodeur)",
+			"enable": "Activer l’avance/retour via l’encodeur",
+			"delay": "Délai avant le saut (s)",
+			"turns": "Tours d’encodeur par piste"
 		}
 	},
 	"wifi": {
@@ -253,7 +259,8 @@
 					"247": "Lire la carte RFID virtuelle 07",
 					"248": "Lire la carte RFID virtuelle 08",
 					"249": "Lire la carte RFID virtuelle 09",
-					"250": "Lire la carte RFID virtuelle 10"
+					"250": "Lire la carte RFID virtuelle 10",
+					"186": "Avance/retour (encodeur)"
 				}
 			}
 		}

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -87,7 +87,6 @@
 		},
 		"seek": {
 			"title": "Avance/retour (encodeur)",
-			"enable": "Activer l’avance/retour via l’encodeur",
 			"delay": "Délai avant le saut (s)",
 			"turns": "Tours d’encodeur par piste"
 		}

--- a/html/management.html
+++ b/html/management.html
@@ -1245,6 +1245,17 @@
 								<label for="rotaryReverse" data-i18n="settingsex.rotary.reverse"></label>
 							</fieldset>
 						</div>
+						<div class="col-md-12 mb-4" id="seekPreviewConfig" style="display:none"> <!-- Eigene Änderung für Spulen -->
+							<fieldset> <!-- Eigene Änderung für Spulen -->
+								<legend class="w-auto" data-i18n="settingsex.seek.title"></legend><br> <!-- Eigene Änderung für Spulen -->
+								<label for="seekDelay" data-i18n="settingsex.seek.delay"></label>: <br> <!-- Eigene Änderung für Spulen -->
+								<input id="seekDelay" data-provide="slider" type="number" data-slider-min="0" data-slider-max="3"
+									data-slider-step="0.5" class="form-control" name="seekDelay" data-slider-value="2" value="2"><br> <!-- Eigene Änderung für Spulen -->
+								<label for="seekTurns" data-i18n="settingsex.seek.turns"></label>: <br> <!-- Eigene Änderung für Spulen -->
+								<input id="seekTurns" data-provide="slider" type="number" data-slider-min="1" data-slider-max="5"
+									data-slider-step="1" class="form-control" name="seekTurns" data-slider-value="2" value="2"><br> <!-- Eigene Änderung für Spulen -->
+							</fieldset> <!-- Eigene Änderung für Spulen -->
+						</div> <!-- Eigene Änderung für Spulen -->
 						<div class="col-md-12 mb-4" id="settingsExConfig">
 							<fieldset>
 								<legend class="w-auto" data-i18n="settingsex.led.title"></legend><br>
@@ -2587,6 +2598,13 @@
 				document.getElementById("rotaryConfig").style.display = null;
 				$('#rotaryReverse').prop('checked', rotarySettings.reverse);
 			}
+			// seek preview (spooling) via rotary encoder
+			let seekSettings = settings.seek;
+			if (seekSettings) {
+				document.getElementById("seekPreviewConfig").style.display = null;
+				$('#seekDelay').bootstrapSlider('setValue', seekSettings.delay);
+				$('#seekTurns').bootstrapSlider('setValue', seekSettings.turns);
+			}
 			// buttons
 			let buttonSettings = settings.buttons;
 			if (buttonSettings) {
@@ -2993,6 +3011,10 @@
 				},
 				"rotary": {
 					reverse: $('#rotaryReverse').prop('checked')
+				},
+				"seek": {
+					delay: Number($('#seekDelay').val()),
+					turns: Number($('#seekTurns').val())
 				}
 			};
 			// fill LED control colors
@@ -3667,7 +3689,7 @@
 			const cmdElem = document.createElement('select');
 			const cmdNothing = addOption(cmdElem, 0);
 			cmdNothing.setAttribute('data-i18n', "settingsex.buttons.noaction");
-			const cmds = [170, 171, 172, 173, 174, 184, 185, 175, 176, 177, 178, 179, 180, 181, 182, 183, 199, 130, 140, 141, 142, 150, 151, 152, 153, 120, 100, 101, 102, 103, 104, 105, 106, 107, 110, 111, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250];
+			const cmds = [170, 171, 172, 173, 174, 184, 185, 186, 175, 176, 177, 178, 179, 180, 181, 182, 183, 199, 130, 140, 141, 142, 150, 151, 152, 153, 120, 100, 101, 102, 103, 104, 105, 106, 107, 110, 111, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250];
 			for (const cmd of cmds) {
 				const opt = addOption(cmdElem, cmd);
 				if ([140, 141, 142].includes(cmd)) {
@@ -3679,9 +3701,16 @@
 			/* fill settingsex button commands */
 			document.querySelectorAll('[id*=cmdselect_]').forEach(e => replaceCommandSelect(e, cmdElem));
 
+			/* hide long-only commands (e.g. seek preview) in short-press selectors */
+			document.querySelectorAll('[id*=cmdselect_short_]').forEach(select => {
+				select.querySelectorAll('option[value="186"]').forEach(option => {
+					option.style.display = 'none';
+				});
+			});
+
 			/* The <select /> that houses all commands for the modification selectors */
 			const modElem = document.createElement('select');
-			const mods = [100, 179, 101, 102, 103, 104, 105, 106, 110, 111, 120, 130, 140, 141, 142, 150, 151, 152, 153, 0, 170, 171, 172, 173, 174, 184, 185, 180, 181, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250];
+			const mods = [100, 179, 101, 102, 103, 104, 105, 106, 110, 111, 120, 130, 140, 141, 142, 150, 151, 152, 153, 0, 170, 171, 172, 173, 174, 184, 185, 186, 180, 181, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250];
 			for (const mod of mods) {
 				const opt = addOption(modElem, mod);
 				if ([140, 141, 142].includes(mod)) {

--- a/html/management.html
+++ b/html/management.html
@@ -1245,17 +1245,17 @@
 								<label for="rotaryReverse" data-i18n="settingsex.rotary.reverse"></label>
 							</fieldset>
 						</div>
-						<div class="col-md-12 mb-4" id="seekPreviewConfig" style="display:none"> <!-- Eigene Änderung für Spulen -->
-							<fieldset> <!-- Eigene Änderung für Spulen -->
-								<legend class="w-auto" data-i18n="settingsex.seek.title"></legend><br> <!-- Eigene Änderung für Spulen -->
-								<label for="seekDelay" data-i18n="settingsex.seek.delay"></label>: <br> <!-- Eigene Änderung für Spulen -->
+						<div class="col-md-12 mb-4" id="seekPreviewConfig" style="display:none"> 
+							<fieldset> 
+								<legend class="w-auto" data-i18n="settingsex.seek.title"></legend><br> 
+								<label for="seekDelay" data-i18n="settingsex.seek.delay"></label>: <br> 
 								<input id="seekDelay" data-provide="slider" type="number" data-slider-min="0" data-slider-max="3"
-									data-slider-step="0.5" class="form-control" name="seekDelay" data-slider-value="2" value="2"><br> <!-- Eigene Änderung für Spulen -->
-								<label for="seekTurns" data-i18n="settingsex.seek.turns"></label>: <br> <!-- Eigene Änderung für Spulen -->
+									data-slider-step="0.5" class="form-control" name="seekDelay" data-slider-value="2" value="2"><br> 
+								<label for="seekTurns" data-i18n="settingsex.seek.turns"></label>: <br> 
 								<input id="seekTurns" data-provide="slider" type="number" data-slider-min="1" data-slider-max="5"
-									data-slider-step="1" class="form-control" name="seekTurns" data-slider-value="2" value="2"><br> <!-- Eigene Änderung für Spulen -->
-							</fieldset> <!-- Eigene Änderung für Spulen -->
-						</div> <!-- Eigene Änderung für Spulen -->
+									data-slider-step="1" class="form-control" name="seekTurns" data-slider-value="2" value="2"><br> 
+							</fieldset> 
+						</div> 
 						<div class="col-md-12 mb-4" id="settingsExConfig">
 							<fieldset>
 								<legend class="w-auto" data-i18n="settingsex.led.title"></legend><br>

--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -24,12 +24,124 @@
 #include "main.h"
 #include "strnatcmp.h"
 
+#include <algorithm>
+#include <cmath>
 #include <esp_task_wdt.h>
 #include <freertos/task.h>
 #include <random>
 
 // Allocate gPlayProperties in PSRAM if available
 EXT_RAM_BSS_ATTR playProps gPlayProperties;
+
+// ---------------------------------------------------------------------
+// Seek preview (spooling) mode
+// ---------------------------------------------------------------------
+// Requirements:
+// - only for local music files (no webstream)
+// - enter via long-press on configurable button (handled in Button.cpp)
+// - while active: rotary encoder selects a target position
+// - if no rotary movement for configured delay: jump to target position
+// - scaling: configurable turns from start to end
+//
+// Note: rotary encoder driver reports steps as "impulses" (see RotaryEncoder.cpp: encoderValue / 2).
+static bool s_seekPreviewActive = false;
+static double s_seekPreviewTargetRelPos = 0.0; // 0..100
+static uint32_t s_seekPreviewLastInputMs = 0;
+static bool s_seekPreviewPendingJump = false;
+
+static constexpr int32_t SEEKPREVIEW_IMPULSES_PER_TURN = 20;
+
+// Config from NVS (advanced settings, web UI)
+// - delay: 0..3 s in 0.5 s steps (stored as float seconds)
+// - turns: 1..5 turns for full range (start..end)
+static inline uint32_t SeekPreview_GetJumpDelayMs(void) {
+	float s = gPrefsSettings.getFloat("seekDelay", 2.0f);
+	if (s < 0.0f) {
+		s = 0.0f;
+	}
+	if (s > 3.0f) {
+		s = 3.0f;
+	}
+	const int32_t halfSeconds = (int32_t) lroundf(s * 2.0f);
+	return (uint32_t) halfSeconds * 500u;
+}
+
+static inline int32_t SeekPreview_GetTotalImpulses(void) {
+	uint8_t turns = gPrefsSettings.getUChar("seekTurns", 2);
+	if (turns < 1) {
+		turns = 1;
+	}
+	if (turns > 5) {
+		turns = 5;
+	}
+	return (int32_t) SEEKPREVIEW_IMPULSES_PER_TURN * (int32_t) turns;
+}
+
+bool AudioPlayer_SeekPreviewIsActive(void) {
+	return s_seekPreviewActive;
+}
+
+double AudioPlayer_SeekPreviewGetTargetRelPos(void) {
+	return s_seekPreviewTargetRelPos;
+}
+
+void AudioPlayer_SeekPreviewEnter(void) {
+	if (gPlayProperties.playMode == NO_PLAYLIST || gPlayProperties.playMode == BUSY) {
+		System_IndicateError();
+		return;
+	}
+	if (gPlayProperties.playMode == WEBSTREAM || (gPlayProperties.playMode == LOCAL_M3U && gPlayProperties.isWebstream)) {
+		System_IndicateError();
+		return;
+	}
+	if (gPlayProperties.isWebstream || gPlayProperties.audioFileDuration == 0 || gPlayProperties.playlistFinished) {
+		System_IndicateError();
+		return;
+	}
+	s_seekPreviewActive = true;
+	s_seekPreviewTargetRelPos = std::clamp<double>(gPlayProperties.currentRelPos, 0.0, 100.0);
+	s_seekPreviewLastInputMs = millis();
+	s_seekPreviewPendingJump = false;
+}
+
+void AudioPlayer_SeekPreviewExit(void) {
+	s_seekPreviewActive = false;
+	s_seekPreviewPendingJump = false;
+}
+
+void AudioPlayer_SeekPreviewAdjustByImpulses(int32_t deltaImpulses) {
+	if (!s_seekPreviewActive) {
+		return;
+	}
+	if (gPlayProperties.isWebstream || gPlayProperties.audioFileDuration == 0) {
+		return;
+	}
+	const int32_t totalImpulses = SeekPreview_GetTotalImpulses();
+	if (totalImpulses <= 0) {
+		return;
+	}
+	const double percentPerImpulse = 100.0 / (double) totalImpulses;
+	s_seekPreviewTargetRelPos = std::clamp<double>(s_seekPreviewTargetRelPos + (double) deltaImpulses * percentPerImpulse, 0.0, 100.0);
+	s_seekPreviewLastInputMs = millis();
+	s_seekPreviewPendingJump = true;
+}
+
+static void AudioPlayer_SeekPreviewProcess(void) {
+	if (!s_seekPreviewActive || !s_seekPreviewPendingJump) {
+		return;
+	}
+	if (gPlayProperties.isWebstream || gPlayProperties.audioFileDuration == 0) {
+		s_seekPreviewPendingJump = false;
+		return;
+	}
+	if (millis() - s_seekPreviewLastInputMs < SeekPreview_GetJumpDelayMs()) {
+		return;
+	}
+	gPlayProperties.currentRelPos = s_seekPreviewTargetRelPos;
+	gPlayProperties.seekmode = SEEK_POS_PERCENT;
+	s_seekPreviewPendingJump = false;
+	s_seekPreviewLastInputMs = millis();
+}
 
 // Playlist
 static playlistSortMode AudioPlayer_PlaylistSortMode = AUDIOPLAYER_PLAYLIST_SORT_MODE_DEFAULT;
@@ -426,6 +538,9 @@ void AudioPlayer_Cyclic(void) {
 		lastPlayingTimestamp = millis();
 		playTimeSecSinceStart += 1;
 	}
+
+	// Seek preview (spooling) delayed jump
+	AudioPlayer_SeekPreviewProcess();
 
 	// Actual loop stuff
 	AudioPlayer_Loop();

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -94,3 +94,10 @@ time_t AudioPlayer_GetPlayTimeAllTime(void);
 uint32_t AudioPlayer_GetCurrentTime(void);
 uint32_t AudioPlayer_GetFileDuration(void);
 String AudioPlayer_GetStationLogoUrl(void);
+
+// Seek preview (spooling) mode: hold configured button + use rotary encoder to pick a new position
+bool AudioPlayer_SeekPreviewIsActive(void);
+double AudioPlayer_SeekPreviewGetTargetRelPos(void); // 0..100
+void AudioPlayer_SeekPreviewEnter(void);
+void AudioPlayer_SeekPreviewExit(void);
+void AudioPlayer_SeekPreviewAdjustByImpulses(int32_t deltaImpulses); // encoder impulses (+/-)

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -3,6 +3,7 @@
 
 #include "Button.h"
 
+#include "AudioPlayer.h"
 #include "Cmd.h"
 #include "Log.h"
 #include "Port.h"
@@ -50,6 +51,9 @@ bool gButtonInitComplete = false;
 EXT_RAM_BSS_ATTR t_button gButtons[7]; // next + prev + pplay + rotEnc + button4 + button5 + dummy-button
 uint8_t gShutdownButton = 99; // Helper used for Neopixel: stores button-number of shutdown-button
 uint16_t gLongPressTime = 0;
+
+// Long-press seek preview (spooling) bookkeeping per button
+static bool s_seekPreviewTriggered[7] = {false, false, false, false, false, false, false};
 
 #ifdef PORT_EXPANDER_ENABLE
 extern bool Port_AllowReadFromPortExpander;
@@ -242,13 +246,43 @@ static const struct {
 
 // Check for multi-button combinations and execute corresponding action
 static bool Button_HandleMultiButtonPress(void) {
+	static bool s_multiSeekActive = false;
+	static uint8_t s_multiSeekBtn1 = 0xFF;
+	static uint8_t s_multiSeekBtn2 = 0xFF;
+	auto physPressed = [](uint8_t idx) -> bool {
+		return !gButtons[idx].currentState;
+	};
+	if (s_multiSeekActive) {
+		if (!(physPressed(s_multiSeekBtn1) && physPressed(s_multiSeekBtn2))) {
+			AudioPlayer_SeekPreviewExit();
+			s_multiSeekActive = false;
+			s_multiSeekBtn1 = 0xFF;
+			s_multiSeekBtn2 = 0xFF;
+		}
+		return true;
+	}
 	for (const auto &combo : multiButtonCombos) {
-		if (gButtons[combo.btn1].isPressed && gButtons[combo.btn2].isPressed) {
-			gButtons[combo.btn1].isPressed = false;
-			gButtons[combo.btn2].isPressed = false;
-			Cmd_Action(gPrefsSettings.getUChar(combo.prefsKey, combo.defaultCmd));
+		const bool bothPressed = physPressed(combo.btn1) && physPressed(combo.btn2);
+		const bool justPressed = gButtons[combo.btn1].isPressed || gButtons[combo.btn2].isPressed;
+		if (!bothPressed || !justPressed) {
+			continue;
+		}
+		uint8_t const cmd = gPrefsSettings.getUChar(combo.prefsKey, combo.defaultCmd);
+		if (cmd == CMD_SEEK_PREVIEW) {
+			AudioPlayer_SeekPreviewEnter();
+			s_multiSeekActive = AudioPlayer_SeekPreviewIsActive();
+			if (s_multiSeekActive) {
+				s_multiSeekBtn1 = combo.btn1;
+				s_multiSeekBtn2 = combo.btn2;
+				gButtons[combo.btn1].isPressed = false;
+				gButtons[combo.btn2].isPressed = false;
+			}
 			return true;
 		}
+		gButtons[combo.btn1].isPressed = false;
+		gButtons[combo.btn2].isPressed = false;
+		Cmd_Action(cmd);
+		return true;
 	}
 	return false;
 }
@@ -282,12 +316,27 @@ static void Button_HandleSinglePress(uint8_t i, unsigned long currentTimestamp) 
 
 		if (wasShortPress) {
 			Cmd_Action(Cmd_Short);
-		} else if (Cmd_Long == CMD_SLEEPMODE) {
-			// Sleep-mode only triggers on release to prevent immediate wake-up
-			Cmd_Action(Cmd_Long);
+		} else {
+			if (Cmd_Long == CMD_SLEEPMODE) {
+				Cmd_Action(Cmd_Long);
+			} else if (Cmd_Long == CMD_SEEK_PREVIEW) {
+				AudioPlayer_SeekPreviewExit();
+				s_seekPreviewTriggered[i] = false;
+			}
 		}
-
 		gButtons[i].isPressed = false;
+		return;
+	}
+
+	// Seek preview (spooling): enter after long-press threshold and stay active while button is held
+	if (Cmd_Long == CMD_SEEK_PREVIEW) {
+		if (pressDuration <= intervalToLongPress) {
+			return;
+		}
+		if (!s_seekPreviewTriggered[i]) {
+			AudioPlayer_SeekPreviewEnter();
+			s_seekPreviewTriggered[i] = true;
+		}
 		return;
 	}
 

--- a/src/Cmd.cpp
+++ b/src/Cmd.cpp
@@ -378,6 +378,15 @@ void Cmd_Action(const uint16_t mod) {
 			break;
 		}
 
+		case CMD_SEEK_PREVIEW: {
+			if (AudioPlayer_SeekPreviewIsActive()) {
+				AudioPlayer_SeekPreviewExit();
+			} else {
+				AudioPlayer_SeekPreviewEnter();
+			}
+			break;
+		}
+
 		case CMD_STOP: {
 			AudioPlayer_SetTrackControl(STOP);
 			break;

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -1031,13 +1031,23 @@ AnimationReturnType Animation_Progress(const bool startNewAnimation, CRGBSet &le
 	// return values
 	int32_t animationDelay = 0;
 	// static values
-	static double lastPos = 0.0f;
-
-	if (gPlayProperties.currentRelPos != lastPos || startNewAnimation) {
+	static double lastPos = -1.0;
+	static double lastTarget = -1.0;
+	static bool lastSeekPreview = false;
+	const bool seekPreviewActive = AudioPlayer_SeekPreviewIsActive();
+	const double targetRelPos = seekPreviewActive ? AudioPlayer_SeekPreviewGetTargetRelPos() : 0.0;
+	const bool refreshNeeded = startNewAnimation || (gPlayProperties.currentRelPos != lastPos) || (seekPreviewActive != lastSeekPreview) || (seekPreviewActive && (targetRelPos != lastTarget));
+	if (refreshNeeded) {
 		lastPos = gPlayProperties.currentRelPos;
+		lastSeekPreview = seekPreviewActive;
+		lastTarget = targetRelPos;
 		leds = CRGB::Black;
 		if (gLedSettings.numIndicatorLeds == 1) {
+			if (seekPreviewActive) {
+				leds[0] = CRGB::Yellow;
+			} else {
 			leds[0].setHue((uint8_t) (85 - ((double) 90 / 100) * gPlayProperties.currentRelPos));
+			}
 		} else {
 			const uint32_t ledValue = std::clamp<uint32_t>(map(gPlayProperties.currentRelPos, 0, 98, 0, leds.size() * gLedSettings.dimmableStates), 0, leds.size() * gLedSettings.dimmableStates);
 			const uint8_t fullLeds = ledValue / gLedSettings.dimmableStates;
@@ -1046,16 +1056,35 @@ AnimationReturnType Animation_Progress(const bool startNewAnimation, CRGBSet &le
 				if (System_AreControlsLocked()) {
 					leds[Led_Address(led)] = CRGB::Red;
 				} else if (!gPlayProperties.pausePlay) { // Hue-rainbow
+					if (seekPreviewActive) {
+						leds[Led_Address(led)] = CRGB::Yellow;
+					} else {
 					leds[Led_Address(led)].setHue((uint8_t) (((float) gLedSettings.progressHueEnd - (float) gLedSettings.progressHueStart) / (leds.size() - 1) * led + gLedSettings.progressHueStart));
+					}
 				}
 			}
 			if (lastLed > 0) {
 				if (System_AreControlsLocked()) {
 					leds[Led_Address(fullLeds)] = CRGB::Red;
 				} else {
+					if (seekPreviewActive) {
+						leds[Led_Address(fullLeds)] = CRGB::Yellow;
+					} else {
 					leds[Led_Address(fullLeds)].setHue((uint8_t) (((float) gLedSettings.progressHueEnd - (float) gLedSettings.progressHueStart) / (leds.size() - 1) * fullLeds + gLedSettings.progressHueStart));
+					}
 				}
 				leds[Led_Address(fullLeds)] = Led_DimColor(leds[Led_Address(fullLeds)], lastLed);
+			}
+			if (seekPreviewActive && !System_AreControlsLocked()) {
+				static constexpr uint8_t cursorStates = 4;
+				const uint32_t cursorTotal = (uint32_t) leds.size() * cursorStates;
+				const uint32_t cursorValue = std::clamp<uint32_t>(map((uint32_t) targetRelPos, 0, 100, 0, cursorTotal - 1), 0, cursorTotal - 1);
+				const uint8_t cursorLed = cursorValue / cursorStates;
+				const uint8_t cursorSub = cursorValue % cursorStates;
+				const uint8_t level = cursorSub + 1;
+				CRGB c = CRGB::Blue;
+				c.nscale8_video((uint8_t) ((255u * level) / cursorStates));
+				leds[Led_Address(cursorLed)] = c;
 			}
 		}
 		animationDelay = 10;

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -1046,7 +1046,7 @@ AnimationReturnType Animation_Progress(const bool startNewAnimation, CRGBSet &le
 			if (seekPreviewActive) {
 				leds[0] = CRGB::Yellow;
 			} else {
-			leds[0].setHue((uint8_t) (85 - ((double) 90 / 100) * gPlayProperties.currentRelPos));
+				leds[0].setHue((uint8_t) (85 - ((double) 90 / 100) * gPlayProperties.currentRelPos));
 			}
 		} else {
 			const uint32_t ledValue = std::clamp<uint32_t>(map(gPlayProperties.currentRelPos, 0, 98, 0, leds.size() * gLedSettings.dimmableStates), 0, leds.size() * gLedSettings.dimmableStates);
@@ -1059,7 +1059,7 @@ AnimationReturnType Animation_Progress(const bool startNewAnimation, CRGBSet &le
 					if (seekPreviewActive) {
 						leds[Led_Address(led)] = CRGB::Yellow;
 					} else {
-					leds[Led_Address(led)].setHue((uint8_t) (((float) gLedSettings.progressHueEnd - (float) gLedSettings.progressHueStart) / (leds.size() - 1) * led + gLedSettings.progressHueStart));
+						leds[Led_Address(led)].setHue((uint8_t) (((float) gLedSettings.progressHueEnd - (float) gLedSettings.progressHueStart) / (leds.size() - 1) * led + gLedSettings.progressHueStart));
 					}
 				}
 			}
@@ -1070,7 +1070,7 @@ AnimationReturnType Animation_Progress(const bool startNewAnimation, CRGBSet &le
 					if (seekPreviewActive) {
 						leds[Led_Address(fullLeds)] = CRGB::Yellow;
 					} else {
-					leds[Led_Address(fullLeds)].setHue((uint8_t) (((float) gLedSettings.progressHueEnd - (float) gLedSettings.progressHueStart) / (leds.size() - 1) * fullLeds + gLedSettings.progressHueStart));
+						leds[Led_Address(fullLeds)].setHue((uint8_t) (((float) gLedSettings.progressHueEnd - (float) gLedSettings.progressHueStart) / (leds.size() - 1) * fullLeds + gLedSettings.progressHueStart));
 					}
 				}
 				leds[Led_Address(fullLeds)] = Led_DimColor(leds[Led_Address(fullLeds)], lastLed);

--- a/src/RotaryEncoder.cpp
+++ b/src/RotaryEncoder.cpp
@@ -55,14 +55,17 @@ void RotaryEncoder_Cyclic(void) {
 	// Only if initial run or value has changed. And only after "full step" of rotary encoder
 	if ((encoderValue != 0) && (encoderValue % 2 == 0)) {
 		System_UpdateActivityTimer(); // Set inactivity back if rotary encoder was used
-		// just reset the encoder here, so we get a new delta next time
+		const int32_t deltaImpulses = (encoderValue / 2);
 		encoder.clearCount();
-
+		if (AudioPlayer_SeekPreviewIsActive()) {
+			AudioPlayer_SeekPreviewAdjustByImpulses(deltaImpulses);
+			return;
+		}
 		if ((OPMODE_NORMAL == System_GetOperationMode()) || (OPMODE_BLUETOOTH_SOURCE == System_GetOperationMode())) {
-			auto newVol = AudioPlayer_GetCurrentVolume() + (encoderValue / 2);
+			auto newVol = AudioPlayer_GetCurrentVolume() + deltaImpulses;
 			AudioPlayer_SetVolume(newVol);
 		} else {
-			auto newVol = Bluetooth_GetCurrentVolume() + (encoderValue / 2);
+			auto newVol = Bluetooth_GetCurrentVolume() + deltaImpulses;
 			Bluetooth_SetVolume(newVol);
 		}
 		return;

--- a/src/RotaryEncoder.cpp
+++ b/src/RotaryEncoder.cpp
@@ -56,6 +56,7 @@ void RotaryEncoder_Cyclic(void) {
 	if ((encoderValue != 0) && (encoderValue % 2 == 0)) {
 		System_UpdateActivityTimer(); // Set inactivity back if rotary encoder was used
 		const int32_t deltaImpulses = (encoderValue / 2);
+		// just reset the encoder here, so we get a new delta next time
 		encoder.clearCount();
 		if (AudioPlayer_SeekPreviewIsActive()) {
 			AudioPlayer_SeekPreviewAdjustByImpulses(deltaImpulses);

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -816,6 +816,29 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 		}
 		RotaryEncoder_Init();
 	}
+	if (doc["seek"].is<JsonObject>()) {
+		JsonObject seekObj = doc["seek"];
+		float delaySec = seekObj["delay"].as<float>();
+		uint8_t turns = seekObj["turns"].as<uint8_t>();
+		if (delaySec < 0.0f) {
+			delaySec = 0.0f;
+		}
+		if (delaySec > 3.0f) {
+			delaySec = 3.0f;
+		}
+		if (turns < 1) {
+			turns = 1;
+		}
+		if (turns > 5) {
+			turns = 5;
+		}
+		bool success = (gPrefsSettings.putFloat("seekDelay", delaySec) != 0);
+		success = success && (gPrefsSettings.putUChar("seekTurns", turns) != 0);
+		if (!success) {
+			Log_Printf(LOGLEVEL_ERROR, webSaveSettingsError, "seek");
+			return WebsocketCodeType::Error;
+		}
+	}
 	if (doc["battery"].is<JsonObject>()) {
 		// Battery settings
 		if (gPrefsSettings.putFloat("wLowVoltage", doc["battery"]["warnLowVoltage"].as<float>()) == 0 || gPrefsSettings.putFloat("vIndicatorLow", doc["battery"]["indicatorLow"].as<float>()) == 0 || gPrefsSettings.putFloat("vIndicatorHigh", doc["battery"]["indicatorHi"].as<float>()) == 0 || gPrefsSettings.putFloat("wCritVoltage", doc["battery"]["criticalVoltage"].as<float>()) == 0 || gPrefsSettings.putUInt("vCheckIntv", doc["battery"]["voltageCheckInterval"].as<uint8_t>()) == 0) {
@@ -1135,6 +1158,11 @@ static void settingsToJSON(JsonObject obj, const String section) {
 		// Rotary encoder
 		JsonObject rotaryObj = obj["rotary"].to<JsonObject>();
 		rotaryObj["reverse"].set(gPrefsSettings.getBool("rotaryReverse", false));
+	}
+	if ((section == "") || (section == "seek")) {
+		JsonObject seekObj = obj["seek"].to<JsonObject>();
+		seekObj["delay"].set(gPrefsSettings.getFloat("seekDelay", 2.0f));
+		seekObj["turns"].set(gPrefsSettings.getUChar("seekTurns", 2));
 	}
 	// playlist
 	if ((section == "") || (section == "playlist")) {

--- a/src/values.h
+++ b/src/values.h
@@ -75,6 +75,7 @@
 #define CMD_RESTARTSYSTEM  183 // Command: restart System
 #define CMD_NEXTFOLDER	   184 // Command: jump forwards to next folder (only applicable for recursive playmodes)
 #define CMD_PREVFOLDER	   185 // Command: jump forwards to previous folder (only applicable for recursive playmodes)
+#define CMD_SEEK_PREVIEW   186 // Command: Spooling/seek preview mode (hold button + use rotary encoder to select position)
 
 #define CMD_VIRTUAL_RFID_CARD_01 241 // Command: Virtual RFID-Card 900000000001
 #define CMD_VIRTUAL_RFID_CARD_02 242 // Command: Virtual RFID-Card 900000000002


### PR DESCRIPTION
### Add rotary encoder seek feature

Adds a seek mode controlled by the rotary encoder.  
When seek mode is triggered via the configured button action, encoder rotation adjusts the current playback position forward or backward.

The feature adds configurable seek behavior through the management interface:

- seek delay before playback resumes
- encoder turn threshold for seek steps

This improves navigation in long audio tracks such as audiobooks or radio plays without adding a separate playback command.