### PR TITLE
RfidMfrc522: deterministic WUPA presence poll for pauseIfRfidRemoved

### DIFF
--- a/docs/rfid-presence-detection.md
+++ b/docs/rfid-presence-detection.md
@@ -1,0 +1,133 @@
+# RC522 constant-presence detection: root cause & fix
+
+Context: In `pauseIfRfidRemoved` mode, playback would flap (pause/resume) while a
+card sat perfectly still on the reader, and card-removal detection was unreliable
+on RC522 clones. During debugging we first tried papering over this with a growing
+"consecutive misses" debounce (3 → 8 cycles ≈ 400 ms). That treats the symptom.
+This note records the actual root cause and the fix.
+
+## Root cause: REQA never reliably re-detects a stationary card
+
+The old presence loop polled with `PICC_IsNewCardPresent()`. Under the hood that
+sends **REQA (`0x26`)**. From the MFRC522 library's own header:
+
+| Command | Opcode | Wakes cards in state… |
+|---------|--------|-----------------------|
+| `REQA`  | `0x26` | **IDLE only** ("Sleeping cards in state HALT are ignored") |
+| `WUPA`  | `0x52` | **IDLE and HALT** |
+| `HLTA`  | `0x50` | moves an ACTIVE card → HALT |
+
+The ISO-14443A state machine is: `IDLE → (REQA/WUPA) → READY → (Select) → ACTIVE → (HLTA) → HALT`.
+
+In `pauseIfRfidRemoved` mode the old code deliberately did **not** `HaltA()` after
+reading the card (`RfidMfrc522.cpp`, the `if (!gPlayProperties.pauseIfRfidRemoved)`
+guard around `PICC_HaltA()`). So the card was left in the **ACTIVE** state — and an
+ACTIVE card does not answer REQA. The loop then relied on a block of "voodoo"
+(from miguelbalboa/rfid issue #188) that re-ran `PICC_ReadCardSerial()`
+(anticollision + Select) on retries and checked for a magic `control == 13 || 14`.
+
+Whether that re-Select succeeds on any given poll depends on which state the card
+(and a sloppy clone's state machine) happens to be in at that instant. That is the
+coin-flip we were seeing. Requiring N consecutive misses only hides dropped polls,
+at the cost of N × ~50 ms of removal latency — it can never make the underlying
+poll deterministic.
+
+## The fix: keep the card in HALT, poll with WUPA
+
+Park the card in a **known** state (HALT) after every read, and poll with the one
+command that wakes a HALTed card. Each poll becomes a clean yes/no.
+
+```cpp
+template <typename Reader>
+static bool RfidMfrc522_CardStillPresent(Reader &reader) {
+    byte bufferATQA[2];
+    byte bufferSize = sizeof(bufferATQA);
+    // mirror PICC_IsNewCardPresent()'s register reset; some readers need it
+    reader.PCD_WriteRegister(Reader::TxModeReg, 0x00);
+    reader.PCD_WriteRegister(Reader::RxModeReg, 0x00);
+    reader.PCD_WriteRegister(Reader::ModWidthReg, 0x26);
+    auto result = reader.PICC_WakeupA(bufferATQA, &bufferSize); // WUPA wakes HALT
+    reader.PICC_HaltA();                                        // straight back to HALT
+    return (result == Reader::STATUS_OK || result == Reader::STATUS_COLLISION);
+}
+```
+
+Companion change: in `pauseIfRfidRemoved` mode we now `PICC_HaltA()` immediately
+after the initial read, so the card enters the poll loop already in HALT. The
+`control`/voodoo block and the 8-cycle debounce are gone; the loop is just:
+
+```cpp
+while (RfidMfrc522_CardStillPresent(reader) || ++misses < removalDebounceCycles) { … }
+```
+
+`removalDebounceCycles` is kept at **2** (≈100 ms) purely to swallow the rare
+genuinely-dropped poll from RF noise. Because each WUPA poll is now deterministic,
+this can be dropped to **1** to test raw reliability with zero miss tolerance.
+
+### Template note (both reader types)
+
+`RfidMfrc522_TaskImpl` is instantiated for both the SPI `MFRC522` class and the
+I2C `MFRC522_I2C` class. Those two libraries differ in ways that matter here:
+
+- Register addresses: SPI values are `<< 1` shifted (`TxModeReg = 0x24`), I2C are
+  raw (`TxModeReg = 0x12`).
+- `StatusCode`: SPI `STATUS_OK = 0`, I2C `STATUS_OK = 1`.
+- `PICC_WakeupA` returns `MFRC522::StatusCode` (SPI) vs `byte` (I2C).
+
+Using `Reader::TxModeReg` / `Reader::STATUS_OK` and `auto result` lets the compiler
+pick the correct constants and types per instantiation, so one helper serves both.
+
+## Verified
+
+`pio run -e esp32-s3-devkitc-1` — recompiles `RfidMfrc522.cpp` and links the full
+firmware **SUCCESS**. That env defines `RFID_READER_TYPE_RUNTIME` and
+`I2C_2_ENABLE`, so both the SPI and I2C template instantiations are exercised.
+
+(Note: `-e lolin_d32_pro_sdmmc_pe`, the repo default env, fails to build on the
+current machine for **unrelated, pre-existing** reasons — a FastLED
+`addLeds<CHIPSET, LED_PIN, COLOR_ORDER>` version mismatch in `Led.cpp` and
+undeclared `I2S_BCLK/LRC/DOUT` pins in `AudioPlayer.cpp`, i.e. that env's per-user
+pin config isn't present here. Neither involves `RfidMfrc522.cpp`.)
+
+## If it's still unreliable after this — secondary avenues
+
+These are hardware/tuning, in rough order of effort-to-payoff:
+
+1. **Antenna gain is at max (`mfrc522Gain` default `0x07`, ~48 dB).** For a card
+   sitting *directly* on the coil, max gain can saturate the receiver and garble
+   the ATQA. Counterintuitively, try `0x04`–`0x05`. Quick test via the `mfrc522Gain`
+   NVS pref.
+2. **Power decoupling.** RC522 clones brown out on the RF transmit burst. Add a
+   10–100 µF cap across the module's 3V3/GND and make sure the 3.3 V rail is solid.
+   Many "random" dropped polls are actually supply dips.
+3. **Hardware swap — PN532.** If the clone is simply bad, no firmware saves it. The
+   PN532 has proper in-field target detection (vs. repeated REQA/WUPA polling) and
+   is the reliable choice for continuous-presence use; several Tonuino/Toniebox-style
+   builds moved to it for exactly this reason.
+
+## Live test results (2026-07-05, ESP32-S3 + RC522 clone, SPI, version reg 0x82)
+
+Bench-tested for ~2 h on real hardware in `pauseIfRfidRemoved` mode with an
+audiobook playlist and multiple Mifare cards:
+
+- **Protocol fix confirmed.** No pause/resume flapping while a card sits
+  stationary on the reader; verified stretches of 38+ s continuous presence
+  with playback progressing. Genuine removals are detected in 100–400 ms
+  (2-cycle debounce) — down from the 400 ms+ the old 8-cycle debounce needed
+  just to stay stable.
+- **Secondary avenue #1 (antenna gain) also confirmed.** With the default
+  `mfrc522Gain` (7 = 48 dB max), a card lying *directly on* the reader coil
+  got a phantom removal 100–400 ms after every detect (receiver saturation) —
+  log signature: `RFID-tag removed` → immediate pause at position 0. The same
+  card at ~3 cm was rock solid. Setting `mfrc522Gain = 5` fixed contact
+  distance completely. Reminder: the pref is only read in `RfidMfrc522_Init`,
+  so it needs a reboot to apply.
+- Side effect worth knowing: with max gain those phantom removals paused
+  playback instantly after a card was applied, which presents as "the box
+  doesn't start playing" — an audio-looking symptom whose actual cause is RF.
+
+## Optional hardening (not yet done)
+
+`WUPA` confirms *a* card is present, not that it's the *same* UID — a card swapped
+during playback would read as "still present". If that matters, change the poll to
+`WUPA → PICC_Select → compare UID → HaltA`. Slightly slower, still deterministic.

--- a/src/Rfid.h
+++ b/src/Rfid.h
@@ -6,6 +6,9 @@ constexpr uint8_t cardIdStringSize = (cardIdSize * 3u) + 1u;
 extern char gCurrentRfidTagId[cardIdStringSize];
 
 void Rfid_ResetOldRfid(void);
+void Rfid_ResetLastTag(void);
+// Reader-task internal: returns true once after Rfid_ResetLastTag() was called.
+bool Rfid_ConsumeLastTagReset(void);
 void Rfid_Init(void);
 void Rfid_WakeupHandling(void);
 void Rfid_StartTask(void);

--- a/src/RfidCommon.cpp
+++ b/src/RfidCommon.cpp
@@ -13,6 +13,8 @@
 #include "System.h"
 #include "Web.h"
 
+#include <atomic>
+
 unsigned long Rfid_LastRfidCheckTimestamp = 0;
 char gCurrentRfidTagId[cardIdStringSize] = ""; // No crap here as otherwise it could be shown in GUI
 char gOldRfidTagId[cardIdStringSize] = "X"; // Init with crap
@@ -109,6 +111,28 @@ void Rfid_PreferenceLookupHandler(void) {
 
 void Rfid_ResetOldRfid() {
 	strncpy(gOldRfidTagId, "X", cardIdStringSize - 1);
+}
+
+// Set by Rfid_ResetLastTag(), consumed by the reader task. The reader's "same card re-applied"
+// buffer is task-local, so it can only be cleared from within the task itself.
+static std::atomic<bool> gResetLastTagRequested {false};
+
+// Forget the tag that was last seen/accepted, in both places that remember it: gOldRfidTagId (the
+// dontAcceptRfidTwice dedup) and the reader task's own last-card buffer (the pauseIfRfidRemoved dedup).
+// Call this whenever something *other than the reader* changes what a tag means -- an assignment being
+// written, deleted or restored, or playback being started from the web UI.
+//
+// Without this, re-applying a tag whose assignment just changed is short-circuited before the NVS lookup
+// ever happens: in pauseIfRfidRemoved-mode the reader turns it into a play/pause toggle on the playlist
+// that is still loaded, so the *old* book resumes. Both dedups live only in RAM, which is why a reboot or
+// a deep-sleep cycle appears to "fix" it.
+void Rfid_ResetLastTag() {
+	Rfid_ResetOldRfid();
+	gResetLastTagRequested.store(true, std::memory_order_relaxed);
+}
+
+bool Rfid_ConsumeLastTagReset() {
+	return gResetLastTagRequested.exchange(false, std::memory_order_relaxed);
 }
 
 #if defined(RFID_READER_TYPE_RUNTIME)

--- a/src/RfidMfrc522.cpp
+++ b/src/RfidMfrc522.cpp
@@ -113,6 +113,12 @@ static void RfidMfrc522_TaskImpl(Reader &reader) {
 		} else {
 			vTaskDelay(portTICK_PERIOD_MS * 20);
 		}
+		if (Rfid_ConsumeLastTagReset()) {
+			// An assignment changed (or the web UI started playback): the card on/near the reader may now
+			// mean something else, so it must not be treated as "same card re-applied" any more.
+			memset(lastValidcardId, 0, sizeof(lastValidcardId));
+		}
+
 		byte cardId[cardIdSize];
 		String cardIdString;
 		bool sameCardReapplied = false;

--- a/src/RfidMfrc522.cpp
+++ b/src/RfidMfrc522.cpp
@@ -76,9 +76,36 @@ void RfidMfrc522_TaskReset(void) {
 	Rfid_LastRfidCheckTimestamp = millis();
 }
 
+// Deterministic "is a card still on the antenna?" poll used by pauseIfRfidRemoved
+// mode. The card is kept parked in the ISO-14443 HALT state between polls; WUPA
+// (PICC_WakeupA, 0x52) is the only REQ-family command that wakes a HALTed card,
+// so each poll is a clean yes/no. This replaces the old REQA-based detection
+// (PICC_IsNewCardPresent sends REQA, 0x26, which only invites cards in the IDLE
+// state) whose non-deterministic misses on a perfectly stationary card forced an
+// ever-growing miss debounce. Templated because Reader is either the SPI MFRC522
+// or the I2C MFRC522_I2C class; the Reader:: register/status constants and the
+// PICC_WakeupA return type both differ between the two libraries, so we let the
+// compiler pick the right ones per instantiation.
+template <typename Reader>
+static bool RfidMfrc522_CardStillPresent(Reader &reader) {
+	byte bufferATQA[2];
+	byte bufferSize = sizeof(bufferATQA);
+	// Reset baud-rate / modulation-width registers exactly like
+	// PICC_IsNewCardPresent() does internally; some readers won't answer WUPA
+	// reliably otherwise. Reader::* resolves to the correct (SPI-shifted vs I2C)
+	// register addresses for whichever library this is instantiated with.
+	reader.PCD_WriteRegister(Reader::TxModeReg, 0x00);
+	reader.PCD_WriteRegister(Reader::RxModeReg, 0x00);
+	reader.PCD_WriteRegister(Reader::ModWidthReg, 0x26);
+	auto result = reader.PICC_WakeupA(bufferATQA, &bufferSize);
+	// Immediately park the card back in HALT so the next WUPA is meaningful.
+	reader.PICC_HaltA();
+	return (result == Reader::STATUS_OK || result == Reader::STATUS_COLLISION);
+}
+
 template <typename Reader>
 static void RfidMfrc522_TaskImpl(Reader &reader) {
-	uint8_t control = 0x00;
+	byte lastValidcardId[cardIdSize] = {0}; // must outlive loop iterations: "same card reapplied" is decided by comparing against it
 
 	for (;;) {
 		if (RFID_SCAN_INTERVAL / 2 >= 20) {
@@ -88,7 +115,6 @@ static void RfidMfrc522_TaskImpl(Reader &reader) {
 		}
 		byte cardId[cardIdSize];
 		String cardIdString;
-		byte lastValidcardId[cardIdSize];
 		bool sameCardReapplied = false;
 		if ((millis() - Rfid_LastRfidCheckTimestamp) >= RFID_SCAN_INTERVAL) {
 			// Log_Printf(LOGLEVEL_DEBUG, "%u", uxTaskGetStackHighWaterMark(NULL));
@@ -153,30 +179,29 @@ static void RfidMfrc522_TaskImpl(Reader &reader) {
 			}
 
 			if (gPlayProperties.pauseIfRfidRemoved) {
-				// https://github.com/miguelbalboa/rfid/issues/188; voodoo! :-)
+				// Park the freshly-selected card in the HALT state so the WUPA-based
+				// presence poll below can wake it deterministically. Without this the
+				// card is left ACTIVE and only REQA (which ignores ACTIVE/HALT cards)
+				// was available, causing the notorious pause/resume flap on stationary
+				// cards. See RfidMfrc522_CardStillPresent().
+				reader.PICC_HaltA();
+				reader.PCD_StopCrypto1();
+
+				// Poll until the card is physically removed. Each WUPA poll is a clean
+				// yes/no, so a small debounce is enough to swallow the rare genuinely
+				// dropped poll (RF noise) without the old REQA "voodoo". Set to 1 to
+				// test raw WUPA reliability with zero tolerance for a missed poll.
+				constexpr uint8_t removalDebounceCycles = 2;
+				uint8_t consecutiveMisses = 0;
 				while (true) {
 					if (RFID_SCAN_INTERVAL / 2 >= 20) {
 						vTaskDelay(portTICK_PERIOD_MS * (RFID_SCAN_INTERVAL / 2));
 					} else {
 						vTaskDelay(portTICK_PERIOD_MS * 20);
 					}
-					control = 0;
-					for (uint8_t i = 0u; i < 3; i++) {
-						if (!reader.PICC_IsNewCardPresent()) {
-							if (reader.PICC_ReadCardSerial()) {
-								control |= 0x16;
-							}
-							if (reader.PICC_ReadCardSerial()) {
-								control |= 0x16;
-							}
-							control += 0x1;
-						}
-						control += 0x4;
-					}
-
-					if (control == 13 || control == 14) {
-						// card is still there
-					} else {
+					if (RfidMfrc522_CardStillPresent(reader)) {
+						consecutiveMisses = 0;
+					} else if (++consecutiveMisses >= removalDebounceCycles) {
 						break;
 					}
 				}

--- a/src/RfidPn5180.cpp
+++ b/src/RfidPn5180.cpp
@@ -137,7 +137,7 @@ void RfidPn5180_Task(void *parameter) {
 	uint32_t lastTimeDetected14443 = 0;
 	uint32_t lastTimeDetected15693 = 0;
 	const uint16_t debounceMs = gPrefsRfid.getUShort("pn5180Debounce", 500);
-	byte lastValidcardId[cardIdSize];
+	byte lastValidcardId[cardIdSize] = {0}; // "same card reapplied" is decided by comparing against it
 	bool cardAppliedCurrentRun = false;
 	bool cardAppliedLastRun = false;
 	static byte cardId[cardIdSize], lastCardId[cardIdSize];
@@ -152,6 +152,11 @@ void RfidPn5180_Task(void *parameter) {
 
 	for (;;) {
 		vTaskDelay(portTICK_PERIOD_MS * 10u);
+		if (Rfid_ConsumeLastTagReset()) {
+			// An assignment changed (or the web UI started playback): the card on/near the reader may now
+			// mean something else, so it must not be treated as "same card re-applied" any more.
+			memset(lastValidcardId, 0, sizeof(lastValidcardId));
+		}
 		if (Rfid_Pn5180LpcdEnabled() && Rfid_GetLpcdShutdownStatus()) {
 			Rfid_EnableLpcd();
 			Rfid_SetLpcdShutdownStatus(false); // give feedback that execution is complete

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -584,6 +584,7 @@ void webserverStart(void) {
 			// make a backup first
 			Web_DumpNvsToSd("rfidTags", backupFile);
 			if (gPrefsRfid.clear()) {
+				Rfid_ResetLastTag(); // Every tag means something else now (namely: nothing)
 				request->send(200);
 			} else {
 				request->send(500);
@@ -997,6 +998,7 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 				return WebsocketCodeType::Error;
 			}
 		}
+		Rfid_ResetLastTag(); // The tag means something else now: make sure re-applying it is not deduped away
 		Web_DumpNvsToSd("rfidTags", backupFile); // Store backup-file every time when a new rfid-tag is programmed
 	} else if (doc["rfidAssign"].is<JsonObject>()) {
 		const char *_rfidIdAssinId = doc["rfidAssign"]["rfidIdMusic"];
@@ -1009,9 +1011,7 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 		char rfidString[275];
 		snprintf(rfidString, sizeof(rfidString) / sizeof(rfidString[0]), "%s%s%s0%s%u%s0", stringDelimiter, _fileOrUrlAscii, stringDelimiter, stringDelimiter, _playMode, stringDelimiter);
 		gPrefsRfid.putString(_rfidIdAssinId, rfidString);
-		if (gPlayProperties.dontAcceptRfidTwice) {
-			Rfid_ResetOldRfid(); // Set old rfid-id to crap in order to allow to re-apply a new assigned rfid-tag exactly once
-		}
+		Rfid_ResetLastTag(); // The tag means something else now: make sure re-applying it is not deduped away
 
 		String s = gPrefsRfid.getString(_rfidIdAssinId, "-1");
 		if (s.compareTo(rfidString)) {
@@ -2198,9 +2198,7 @@ void explorerHandleAudioRequest(AsyncWebServerRequest *request) {
 		playModeString = param->value();
 
 		playMode = atoi(playModeString.c_str());
-		if (gPlayProperties.dontAcceptRfidTwice) {
-			Rfid_ResetOldRfid();
-		}
+		Rfid_ResetLastTag(); // Another playlist is loaded now: re-applying the last tag must reload it, not toggle pause
 		AudioPlayer_SetPlaylist(filePath, 0, playMode, 0);
 	} else {
 		Log_Println("AUDIO: No path variable set", LOGLEVEL_ERROR);
@@ -2582,6 +2580,7 @@ static void handlePostRFIDRequest(AsyncWebServerRequest *request, JsonVariant &j
 	char rfidString[275];
 	snprintf(rfidString, sizeof(rfidString) / sizeof(rfidString[0]), "%s%s%s0%s%u%s0", stringDelimiter, _fileOrUrlAscii, stringDelimiter, stringDelimiter, _playModeOrModId, stringDelimiter);
 	gPrefsRfid.putString(tagId.c_str(), rfidString);
+	Rfid_ResetLastTag(); // The tag means something else now: make sure re-applying it is not deduped away
 
 	String s = gPrefsRfid.getString(tagId.c_str(), "-1");
 	if (s.compareTo(rfidString)) {
@@ -2613,6 +2612,7 @@ static void handleDeleteRFIDRequest(AsyncWebServerRequest *request) {
 			Cmd_Action(CMD_STOP);
 		}
 		if (gPrefsRfid.remove(tagId.c_str())) {
+			Rfid_ResetLastTag(); // The tag means nothing now: make sure re-applying it is not deduped away
 			Log_Printf(LOGLEVEL_INFO, "/rfid (DELETE): tag %s removed successfuly", tagId);
 			request->send(200, "text/plain; charset=utf-8", tagId + " removed successfuly");
 		} else {
@@ -2722,6 +2722,7 @@ void Web_DumpSdToNvs(const char *_filename) {
 	}
 
 	Led_SetPause(false);
+	Rfid_ResetLastTag(); // Tags may mean something else now: make sure re-applying one is not deduped away
 	Log_Printf(LOGLEVEL_NOTICE, importCountNokNvs, invalidCount);
 	tmpFile.close();
 	gFSystem.remove(_filename);


### PR DESCRIPTION
I've rebased onto current `dev` (`d4cffb0`) and added a second commit — plus captured hard before/after evidence on a classic ESP32 (LOLIN D32 Pro) + RC522 clone. All timestamped serial traces below; each opens with the boot banner so the firmware revision is verifiable per run.

## A/B evidence, card sitting perfectly still for 10 minutes, `pauseIfRfidRemoved` on

| Firmware | `mfrc522Gain` | Spurious "RFID-tag removed" / 10 min |
|---|---|---|
| stock `dev` @ `d4cffb0` | 7 (default) | **20** — continuous pause/resume flapping for ~50 s, sub-second cycles |
| stock `dev` @ `d4cffb0` | 5 | 0 |
| this PR @ `8074410` | 7 (default) | **1** (single phantom at initial card contact — receiver saturation, see the tuning note in `docs/rfid-presence-detection.md`) |
| this PR @ `8074410` | 5 | **0** — plus 5/5 deliberate removal cycles all detected cleanly, pause on lift / resume on re-apply |

Two knock-on effects of the stock flapping worth highlighting, both in the traces:

1. **Flash wear** — every flap writes the play position to NVS (one
   `Write '#...' to NVS` per spurious removal).
2. **The box deep-sleeps itself mid-playback** — the pause/resume races desync
   the play/pause state, the inactivity timer arms while audio is audibly
   playing, and 10 minutes later: `Going to deepsleep due to inactivity-timer...`
   mid-track. On a kids' audiobook box this is "it turned itself off mid-story".

## Why the second commit (`Rfid: forget the last-seen tag when its assignment changes`) is part of this PR

The first commit fixes `lastValidcardId`'s lifetime (stock declares it inside
the task loop — uninitialised each iteration, so the "same card re-applied"
dedup effectively never fired). With the dedup *working*, a latent bug becomes
visible: re-assigning a tag in the web UI has no effect until reboot — the
re-applied card is short-circuited into play/pause and NVS is never re-read.
The existing guard (`Rfid_ResetOldRfid` on the assign path) is gated behind
`dontAcceptRfidTwice`, which `AudioPlayer.cpp` force-disables whenever
`pauseIfRfidRemoved` is on — i.e. unreachable in exactly the mode that needs it.

The second commit invalidates the reader's cache from every path that changes
what a tag means (WS + REST assign, mod-card, delete, NVS erase/restore, web-UI
play). Verified live in the same session, no reboot: card playing book A →
lifted → reassigned via `POST /rfid` to book B → re-applied → book B plays
immediately (`RFID-tag received` in the trace shows it reached the queue
instead of being deduped away).

Shipping the first commit without the second would hand every
`pauseIfRfidRemoved` user the reassign bug, so they travel together.


[trace-baseline-dev-d4cffb0.log](https://github.com/user-attachments/files/30085842/trace-baseline-dev-d4cffb0.log)
[trace-stock-dev-gain7.log](https://github.com/user-attachments/files/30085843/trace-stock-dev-gain7.log)
[trace-wupa-gain5.log](https://github.com/user-attachments/files/30085844/trace-wupa-gain5.log)
[trace-wupa-gain7.log](https://github.com/user-attachments/files/30085847/trace-wupa-gain7.log)
