### PR TITLE
LED: drive WS2812 via NeoPixelBus on ESP32-S3 and classic ESP32 (FastLED broken on Arduino 3.x / IDF 5.x)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,7 @@ lib_deps =
 	https://github.com/madhephaestus/ESP32Encoder.git#7501cb47ec702c43de3c64df56d0b10930b9bc70 ; v0.12.0
 	https://github.com/Joe91/ESP-FTP-Server-Lib.git#517a2c90876659bfd6692d1f464784a05296e8d8 ; v1.0.1
 	https://github.com/FastLED/FastLED.git#20667c3a6413ed46a828f78ec95fb57e58d753f8 ; v3.10.3
+	https://github.com/Makuna/NeoPixelBus.git#fd670ee534064ddf5765e4db63c213ba05bbe880 ; v2.8.4, WS2812 output on ESP32-S3 (see Led.cpp)
 	https://github.com/ESP32Async/ESPAsyncWebServer.git#d6aa7daf0823a41966b1841826cff015237d6e42 ; v3.11.1
 	https://github.com/bblanchon/ArduinoJson.git#77771d3c07668e01d8f52acb03910c1110bb373f ; v7.4.3
 	https://github.com/pschatzmann/arduino-audio-tools.git#b4b32dc849233e1c51424221951c9f5c576671e5 ; v1.2.4

--- a/platformio.ini
+++ b/platformio.ini
@@ -144,6 +144,10 @@ board_upload.flash_size = 8MB
 ;https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html
 board = esp32-s3-devkitc-1
 platform = espressif32
+; The ESP32-S3 has no Classic Bluetooth; ESP32-A2DP #errors on it, and the
+; LDF compiles the lib even with BLUETOOTH_ENABLE off (chain mode doesn't
+; evaluate #ifdefs). Bluetooth.cpp compiles to stubs without it.
+lib_ignore = ESP32-A2DP
 
 ; change microcontroller
 board_build.mcu = esp32s3

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -18,27 +18,30 @@
 #include <atomic>
 #include <esp_task_wdt.h>
 
-#if defined(NEOPIXEL_ENABLE) && defined(CONFIG_IDF_TARGET_ESP32S3)
-	// On ESP32-S3 with Arduino 3.x / ESP-IDF 5.x none of FastLED's WS2812
-	// backends work (clockless-SPI claims the FSPI host, RMT5 fails in
-	// led_strip_new_rmt_device/rmt_transmit, legacy RMT4 conflicts with the
-	// driver_ng the core installs). FastLED is kept for the CRGB/CHSV math and
-	// the animation buffer only; the actual output goes through NeoPixelBus's
-	// S3 LCD/GDMA method. (NeoPixelBus's RMT method is also unusable here: as
-	// of 2.8.4 it is built on the legacy RMT driver, which aborts at boot with
-	// "CONFLICT! driver_ng is not allowed to be used with the legacy driver".)
+#ifdef NEOPIXEL_ENABLE
+	// FastLED's WS2812 backends don't work on this Arduino 3.x / ESP-IDF 5.x stack:
+	// on the S3 the clockless-SPI backend claims the FSPI host and RMT5 fails; on the
+	// classic ESP32 the SPI-DMA backend aborts (ESP_ERROR_CHECK in SpiStripWs2812::
+	// waitDone) once SD + RFID already own both SPI hosts. So the strip is driven
+	// through NeoPixelBus instead — FastLED is kept only for the CRGB/CHSV math and
+	// the animation buffer. NeoPixelBus's RMT method is unusable here too (2.8.4 uses
+	// the legacy RMT driver, which aborts under the core's driver_ng), so the output
+	// method is target-specific (see Led_InitStrip): S3 -> LCD/GDMA, classic ESP32 ->
+	// the I2S peripheral 1 method (I2S0 is left for the audio path).
 	#define LED_USE_NEOPIXELBUS 1
 
-	#include <esp_idf_version.h>
-	#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
-		// IDF 5.5 removed gpio_hal_iomux_func_sel(), but NeoPixelBus (<= 2.8.4)
-		// still calls it from the S3 LCD-method header used below.
-		// PIN_FUNC_SELECT is the operation that function wrapped.
-		#include <soc/io_mux_reg.h>
+	#if defined(CONFIG_IDF_TARGET_ESP32S3)
+		#include <esp_idf_version.h>
+		#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+			// IDF 5.5 removed gpio_hal_iomux_func_sel(), but NeoPixelBus (<= 2.8.4)
+			// still calls it from the S3 LCD-method header. PIN_FUNC_SELECT is the
+			// operation that function wrapped.
+			#include <soc/io_mux_reg.h>
 inline void gpio_hal_iomux_func_sel(uint32_t pin_name, uint32_t func) {
 	PIN_FUNC_SELECT(pin_name, func);
 }
-	#endif
+		#endif
+	#endif // CONFIG_IDF_TARGET_ESP32S3
 
 	#include <NeoPixelBus.h>
 #endif
@@ -202,7 +205,12 @@ struct NeoFeatureFor<GRB> {
 	using type = NeoGrbFeature;
 };
 
-using LedStrip = NeoPixelBus<NeoFeatureFor<COLOR_ORDER>::type, NeoEsp32LcdX8Ws2812xMethod>;
+		#if defined(CONFIG_IDF_TARGET_ESP32S3)
+using LedStripMethod = NeoEsp32LcdX8Ws2812xMethod; // S3: LCD/GDMA (RMT unusable; no free SPI host)
+		#else
+using LedStripMethod = NeoEsp32I2s1Ws2812xMethod; // classic ESP32: I2S peripheral 1 (I2S0 = audio)
+		#endif
+using LedStrip = NeoPixelBus<NeoFeatureFor<COLOR_ORDER>::type, LedStripMethod>;
 static LedStrip *ledStrip = nullptr;
 	#endif
 

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -212,6 +212,11 @@ using LedStripMethod = NeoEsp32I2s1Ws2812xMethod; // classic ESP32: I2S peripher
 		#endif
 using LedStrip = NeoPixelBus<NeoFeatureFor<COLOR_ORDER>::type, LedStripMethod>;
 static LedStrip *ledStrip = nullptr;
+// Perceptual dimming: WS2812 output is ~linear in its 8-bit value but the eye is ~logarithmic,
+// so a plain linear brightness scale barely dims until the very bottom of the range. Gamma-correct
+// the (already brightness-scaled) colour in Led_ShowStrip so perceived brightness tracks the
+// setting — a wide, smooth dimming range instead of "bright until it snaps off".
+static NeoGamma<NeoGammaCieLabEquationMethod> ledGamma;
 	#endif
 
 // (Re-)initialize the LED output driver for the given total number of leds
@@ -236,7 +241,8 @@ static void Led_ShowStrip(CRGB *leds, uint16_t count) {
 	const uint8_t scaleG = scale8(0xB0, b);
 	const uint8_t scaleB = scale8(0xF0, b);
 	for (uint16_t i = 0; i < count; i++) {
-		ledStrip->SetPixelColor(i, RgbColor(scale8(leds[i].r, scaleR), scale8(leds[i].g, scaleG), scale8(leds[i].b, scaleB)));
+		const RgbColor c(scale8(leds[i].r, scaleR), scale8(leds[i].g, scaleG), scale8(leds[i].b, scaleB));
+		ledStrip->SetPixelColor(i, ledGamma.Correct(c));
 	}
 	ledStrip->Show();
 	#else
@@ -1478,13 +1484,13 @@ void Led_ShowOtaProgress(uint8_t percent) {
 			blinkOn = !blinkOn;
 		}
 		leds[0] = blinkOn ? CRGB::Blue : CRGB::Black;
-		FastLED.show();
+		Led_ShowStrip(leds, gLedSettings.numIndicatorLeds + gLedSettings.numControlLeds);
 		return;
 	}
 	const uint8_t litCount = (uint8_t) (((uint16_t) percent * gLedSettings.numIndicatorLeds) / 100);
 	for (uint8_t i = 0; i < gLedSettings.numIndicatorLeds; i++) {
 		leds[i] = (i < litCount) ? CRGB::Blue : CRGB::Black;
 	}
-	FastLED.show();
+	Led_ShowStrip(leds, gLedSettings.numIndicatorLeds + gLedSettings.numControlLeds);
 #endif
 }

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -18,6 +18,31 @@
 #include <atomic>
 #include <esp_task_wdt.h>
 
+#if defined(NEOPIXEL_ENABLE) && defined(CONFIG_IDF_TARGET_ESP32S3)
+	// On ESP32-S3 with Arduino 3.x / ESP-IDF 5.x none of FastLED's WS2812
+	// backends work (clockless-SPI claims the FSPI host, RMT5 fails in
+	// led_strip_new_rmt_device/rmt_transmit, legacy RMT4 conflicts with the
+	// driver_ng the core installs). FastLED is kept for the CRGB/CHSV math and
+	// the animation buffer only; the actual output goes through NeoPixelBus's
+	// S3 LCD/GDMA method. (NeoPixelBus's RMT method is also unusable here: as
+	// of 2.8.4 it is built on the legacy RMT driver, which aborts at boot with
+	// "CONFLICT! driver_ng is not allowed to be used with the legacy driver".)
+	#define LED_USE_NEOPIXELBUS 1
+
+	#include <esp_idf_version.h>
+	#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+		// IDF 5.5 removed gpio_hal_iomux_func_sel(), but NeoPixelBus (<= 2.8.4)
+		// still calls it from the S3 LCD-method header used below.
+		// PIN_FUNC_SELECT is the operation that function wrapped.
+		#include <soc/io_mux_reg.h>
+inline void gpio_hal_iomux_func_sel(uint32_t pin_name, uint32_t func) {
+	PIN_FUNC_SELECT(pin_name, func);
+}
+	#endif
+
+	#include <NeoPixelBus.h>
+#endif
+
 #ifdef NEOPIXEL_ENABLE
 	#define LED_INDICATOR_SET(indicator)	((Led_Indicators) |= (1u << ((uint8_t) indicator)))
 	#define LED_INDICATOR_IS_SET(indicator) (((Led_Indicators) & (1u << ((uint8_t) indicator))) > 0u)
@@ -106,6 +131,15 @@ bool Led_LoadSettings(LedSettings &settings) {
 	// Get the number of control LEDs from NVS
 	settings.numControlLeds = gPrefsSettings.getUChar("numControl", 0); // NUM_CONTROL_LEDS
 
+	if ((settings.numIndicatorLeds + settings.numControlLeds) == 0) {
+		// a stored total of zero leds would leave the strip driver without a
+		// buffer and the box permanently dark — fall back to the same defaults
+		// the NVS reads above use (can happen when settings were saved by a
+		// build that had NEOPIXEL_ENABLE off)
+		settings.numIndicatorLeds = 24;
+		settings.numControlLeds = 0;
+	}
+
 	// Get the number of Led idle dots from NVS
 	settings.numIdleDots = gPrefsSettings.getUChar("numIdleDots", 4); // NUM_LEDS_IDLE_DOTS
 	if (settings.numIdleDots == 0) {
@@ -152,6 +186,69 @@ bool Led_LoadSettings(LedSettings &settings) {
 }
 #endif
 
+#ifdef NEOPIXEL_ENABLE
+	#ifdef LED_USE_NEOPIXELBUS
+// Map FastLED's COLOR_ORDER setting onto the matching NeoPixelBus feature
+template <EOrder order>
+struct NeoFeatureFor;
+
+template <>
+struct NeoFeatureFor<RGB> {
+	using type = NeoRgbFeature;
+};
+
+template <>
+struct NeoFeatureFor<GRB> {
+	using type = NeoGrbFeature;
+};
+
+using LedStrip = NeoPixelBus<NeoFeatureFor<COLOR_ORDER>::type, NeoEsp32LcdX8Ws2812xMethod>;
+static LedStrip *ledStrip = nullptr;
+	#endif
+
+// (Re-)initialize the LED output driver for the given total number of leds
+static void Led_InitStrip(CRGB *leds, uint16_t count) {
+	#ifdef LED_USE_NEOPIXELBUS
+	delete ledStrip; // the dtor releases the peripheral, so a re-init doesn't leak it
+	ledStrip = new LedStrip(count, LED_PIN);
+	ledStrip->Begin();
+	Log_Printf(LOGLEVEL_NOTICE, "LED: NeoPixelBus strip initialized (%u leds on GPIO %u)", count, LED_PIN);
+	#else
+	FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, count).setCorrection(TypicalSMD5050);
+	#endif
+}
+
+// Push the CRGB working buffer out to the strip
+static void Led_ShowStrip(CRGB *leds, uint16_t count) {
+	#ifdef LED_USE_NEOPIXELBUS
+	// NeoPixelBus has no global brightness or color-correction, so apply
+	// FastLED's semantics (brightness x TypicalSMD5050) per pixel here
+	const uint8_t b = gLedSettings.Led_Brightness;
+	const uint8_t scaleR = scale8(0xFF, b);
+	const uint8_t scaleG = scale8(0xB0, b);
+	const uint8_t scaleB = scale8(0xF0, b);
+	for (uint16_t i = 0; i < count; i++) {
+		ledStrip->SetPixelColor(i, RgbColor(scale8(leds[i].r, scaleR), scale8(leds[i].g, scaleG), scale8(leds[i].b, scaleB)));
+	}
+	ledStrip->Show();
+	#else
+	FastLED.show();
+	#endif
+}
+
+// Turn all leds off immediately (also called from outside the led-task)
+static void Led_ClearStrip(void) {
+	#ifdef LED_USE_NEOPIXELBUS
+	if (ledStrip) {
+		ledStrip->ClearTo(RgbColor(0));
+		ledStrip->Show();
+	}
+	#else
+	FastLED.clear(true);
+	#endif
+}
+#endif
+
 void Led_Init(void) {
 #ifdef NEOPIXEL_ENABLE
 
@@ -185,7 +282,7 @@ void Led_Exit(void) {
 		Led_TaskHandle = NULL;
 	}
 	// Turn off LEDs in order to avoid LEDs still glowing when ESP32 is in deepsleep
-	FastLED.clear(true);
+	Led_ClearStrip();
 #endif
 }
 
@@ -402,11 +499,13 @@ static void Led_Task(void *parameter) {
 	// Allocate memory for LED arrays
 	leds = new CRGB[numIndicatorLeds + numControlLeds];
 	indicator = new CRGBSet(leds, numIndicatorLeds);
-	// initialize FastLED
-	FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, numIndicatorLeds + numControlLeds).setCorrection(TypicalSMD5050);
+	// initialize the LED driver
+	Led_InitStrip(leds, numIndicatorLeds + numControlLeds);
+	#ifndef LED_USE_NEOPIXELBUS
 	FastLED.setBrightness(gLedSettings.Led_Brightness);
 	FastLED.setDither(DISABLE_DITHER);
 	FastLED.setMaxRefreshRate(200); // limit LED refresh rate to 200Hz (less likely to cause flickering)
+	#endif
 
 	LedAnimationType activeAnimation = LedAnimationType::NoNewAnimation;
 	LedAnimationType nextAnimation = LedAnimationType::NoNewAnimation;
@@ -501,7 +600,9 @@ static void Led_Task(void *parameter) {
 
 		// apply brightness-changes
 		if (lastLedBrightness != gLedSettings.Led_Brightness) {
+	#ifndef LED_USE_NEOPIXELBUS
 			FastLED.setBrightness(gLedSettings.Led_Brightness);
+	#endif
 			lastLedBrightness = gLedSettings.Led_Brightness;
 		}
 
@@ -574,7 +675,7 @@ static void Led_Task(void *parameter) {
 
 					default:
 						*indicator = CRGB::Black;
-						FastLED.show();
+						Led_ShowStrip(leds, numIndicatorLeds + numControlLeds);
 						ret.animationActive = false;
 						ret.animationDelay = 50;
 						break;
@@ -583,7 +684,7 @@ static void Led_Task(void *parameter) {
 				animationActive = ret.animationActive;
 				animationTimer = ret.animationDelay;
 				if (ret.animationRefresh) {
-					FastLED.show();
+					Led_ShowStrip(leds, numIndicatorLeds + numControlLeds);
 				}
 			}
 		} else {
@@ -596,7 +697,7 @@ static void Led_Task(void *parameter) {
 					leds[i].setHSV(gLedSettings.atmoHue, gLedSettings.atmoSaturation, 255);
 				}
 			}
-			FastLED.show();
+			Led_ShowStrip(leds, numIndicatorLeds + numControlLeds);
 			activeAnimation = LedAnimationType::NoNewAnimation;
 			animationActive = false;
 			animationTimer = 0;
@@ -1334,7 +1435,7 @@ void Led_TaskPause(void) {
 #ifdef NEOPIXEL_ENABLE
 	if (Led_TaskHandle != NULL) {
 		vTaskSuspend(Led_TaskHandle);
-		FastLED.clear(true);
+		Led_ClearStrip();
 	}
 #endif
 }

--- a/src/Led.h
+++ b/src/Led.h
@@ -64,7 +64,13 @@ struct AnimationReturnType {
 	#define LED_BRIGHTNESS_MIN			 1u // Never let a gesture turn the LEDs fully off -- that looks like a crash
 	#define LED_INITIAL_NIGHT_BRIGHTNESS 2u
 
-	#define FASTLED_ESP32_USE_CLOCKLESS_SPI 1
+	// FastLED's clockless-SPI WS2812 driver claims the FSPI host, which on
+	// ESP32-S3 collides with the SD-card SPI bus -> ESP_ERR_TIMEOUT in
+	// strip_spi.cpp waitDone and a boot loop. The S3 has RMT5 (needs no SPI
+	// host), so let it use that; classic ESP32 keeps the long-standing SPI path.
+	#if !defined(CONFIG_IDF_TARGET_ESP32S3)
+		#define FASTLED_ESP32_USE_CLOCKLESS_SPI 1
+	#endif
 
 	#include <FastLED.h>
 


### PR DESCRIPTION
## What

Makes NeoPixel/WS2812 LEDs work on **both ESP32 variants** by driving the strip
with **NeoPixelBus** instead of FastLED: the **ESP32-S3** uses NeoPixelBus's
LCD/GDMA method, and the **classic ESP32** uses its I2S method (I2S peripheral
1). FastLED stays exactly as-is for the `CRGB`/`CHSV` math and all animation
code — only the driver (init/show/clear) is swapped. Animations are identical
on every target; only the output backend changes.

## Why

On Arduino core 3.x / ESP-IDF 5.x, **no FastLED WS2812 backend works on either
ESP32 variant.**

**ESP32-S3:**

| FastLED backend | Result on S3 / Arduino 3.3.8 / IDF 5.5 |
|---|---|
| clockless-SPI (what `Led.h` forces today) | hard-locked to the FSPI host → collides with SPI peripherals (SD/RFID) → `ESP_ERR_TIMEOUT` boot loop |
| RMT5 (FastLED 3.10.3) | `ESP_ERR_NO_MEM` in `led_strip_new_rmt_device` |
| RMT5 (FastLED 3.9.16) | strip created, then `ESP_ERR_INVALID_ARG` at `rmt_transmit` |
| legacy RMT4 (`-DFASTLED_RMT5=0`) | boot abort: `rmt(legacy): CONFLICT! driver_ng is not allowed to be used with the legacy driver` |

**Classic ESP32 (WROVER):**

| FastLED backend | Result on classic ESP32 / Arduino 3.3.8 / IDF 5.5 |
|---|---|
| SPI-DMA (`ClocklessSpiWs2812Controller`) | garbled output, then an `ESP_ERROR_CHECK` abort in `SpiStripWs2812::waitDone()` → boot loop, once SD + RFID already own both SPI hosts (HSPI/VSPI) |
| RMT | same legacy-RMT `driver_ng` conflict as the S3 row above |

NeoPixelBus's **RMT** method is unusable for the same reason as the legacy-RMT4
rows — through v2.8.4 it is built on the legacy RMT driver. So each target uses a
method that avoids RMT (and the SPI hosts):

- **S3:** LCD_CAM + GDMA (`NeoEsp32LcdX8Ws2812xMethod`) — no RMT, no SPI host.
- **Classic ESP32:** I2S (`NeoEsp32I2s1Ws2812xMethod`) on **I2S peripheral 1**,
  leaving I2S0 for the audio path — no RMT, no SPI host.

Both coexist with SD, RFID readers, and the audio I2S.

## Implementation notes

- The NeoPixelBus path in `Led.cpp` is now enabled for **all ESP32 targets**
  (was S3-only); the output method is chosen at compile time — LCD/GDMA on the
  S3, I2S1 on the classic ESP32. The S3-only IDF-5.5 `gpio_hal_iomux_func_sel`
  shim is guarded behind `CONFIG_IDF_TARGET_ESP32S3`.
- `Led.h` no longer forces `FASTLED_ESP32_USE_CLOCKLESS_SPI` on the S3 (the
  FastLED driver is no longer initialized on any ESP32, but the guard keeps the
  define correct for anyone experimenting).
- Small helpers `Led_InitStrip` / `Led_ShowStrip` / `Led_ClearStrip` in
  `Led.cpp` select NeoPixelBus (ESP32/S3) or FastLED (fallback) at compile time.
  Animations are untouched — they still fill the `CRGB` buffer.
- Global brightness and `TypicalSMD5050` colour correction are applied per-pixel
  in the show helper (NeoPixelBus has neither built in).
- IDF 5.5 removed `gpio_hal_iomux_func_sel()`, which NeoPixelBus ≤ 2.8.4 still
  calls in the LCD-method header; `Led.cpp` shims it around `PIN_FUNC_SELECT`
  (same operation).
- Fixes a latent bug on the way: the LED-count re-config path used to call
  `FastLED.addLeds` again without releasing the previous controller (leaked a
  controller/RMT channel per change). The new path deletes the strip first.
- `Led_LoadSettings` falls back to the compile-time LED counts when NVS holds a
  stored total of 0 (happens when settings were saved by a build with
  `NEOPIXEL_ENABLE` off) — a zero-pixel strip left the LEDs permanently dark
  with no error.
- Same class of bug for `dimmableStates`: an NVS value of 0 (also saved by a
  `NEOPIXEL_ENABLE`-off build) caused an `IntegerDivideByZero` panic in
  `Animation_Progress` at playback start; now guarded with the same
  fall-back-to-default pattern.

## Testing

- **ESP32-S3-DevKitC-1 clone (N16R8)**, 12-LED WS2812B ring on GPIO 21, RC522 on
  FSPI, SD (SPI mode) on HSPI: boot/idle/volume animations render correctly,
  RFID and SD unaffected, no boot loop.
- **Classic ESP32-WROVER (LOLIN D32)**, 12-LED WS2812B ring on GPIO 12, RC522 +
  SD both on SPI (both hosts occupied): FastLED boot-looped here; with
  NeoPixelBus/I2S1 it boots clean, logs `NeoPixelBus strip initialized
  (12 leds)`, renders correct colours and brightness, and audio/RFID/SD are
  unaffected.
- Compile-checked `esp32-s3-devkitc-1` and `lolin_d32_pro` with stock settings.
