### PR TITLE
WiFi setup/onboarding flow — timeout, i18n, failure diagnosis, live test

### DIFF
--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -90,6 +90,7 @@
 			</select>
 		</div>
 		<h1 data-i18n="wifi.title"></h1>
+		<div id="connstatus" style="display:none;background:#f8d7da;color:#721c24;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
 		<div id="WiFiList"></div>
 		<label for="ssid" data-i18n="wifi.ssid.title"></label>: <br>
 		<input type="text" id="ssid" name="ssid" placeholder="SSID" required>
@@ -165,6 +166,7 @@
 			if (typeof localize === "function") {
 				localize('body');
 			}
+			renderWifiStatus();
 		});
 		document.querySelector('#langSel').addEventListener('change', (event) => {
 			const lang = event.target.value;
@@ -174,6 +176,26 @@
 			}
 		});
 
+		let wifiStatusData = null;
+		function renderWifiStatus() {
+			const box = document.getElementById("connstatus");
+			const failure = wifiStatusData && wifiStatusData.last_failure;
+			if (!failure || !i18next.isInitialized) {
+				box.style.display = "none";
+				return;
+			}
+			const cls = ["wrong_password", "not_found", "rejected"].includes(failure.class) ? failure.class : "other";
+			box.innerText = i18next.t("wifi.fail." + cls, { ssid: failure.ssid, code: failure.reason });
+			box.style.display = "block";
+		}
+		async function getWifiStatus() {
+			try {
+				wifiStatusData = await (await fetch("/wifistatus")).json();
+				renderWifiStatus();
+			} catch (error) {
+				console.log(error);
+			}
+		}
 		function selectWiFi(ssid) {
 			document.getElementById("ssid").value = ssid;
 			document.getElementById("pwd").focus();
@@ -245,6 +267,7 @@
 			getWiFiList();
 			updateWifiFields();
 			setupFullInterfaceLink();
+			getWifiStatus();
 		});
 
 		// Show the full management interface's URL and offer a "copy to clipboard" button. Uses the

--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -91,6 +91,7 @@
 		</div>
 		<h1 data-i18n="wifi.title"></h1>
 		<div id="connstatus" style="display:none;background:#f8d7da;color:#721c24;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
+		<div id="teststatus" style="display:none;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
 		<div id="WiFiList"></div>
 		<label for="ssid" data-i18n="wifi.ssid.title"></label>: <br>
 		<input type="text" id="ssid" name="ssid" placeholder="SSID" required>
@@ -227,10 +228,48 @@
 			let new_style = this.checked ? null : "none";
 			document.getElementById("wifi_static_div").style.display = new_style;
 		};
+		// live connection test: kicked off after saving, result shown in-page
+		const testStatusColors = {
+			progress: ["#cce5ff", "#004085"],
+			success: ["#d4edda", "#155724"],
+			failed: ["#f8d7da", "#721c24"]
+		};
+		let lastTestState = null;
+		function showTestStatus(kind, text) {
+			lastTestState = { kind: kind, text: text };
+			const box = document.getElementById("teststatus");
+			box.style.background = testStatusColors[kind][0];
+			box.style.color = testStatusColors[kind][1];
+			box.innerText = text;
+			box.style.display = "block";
+		}
+		async function pollTestStatus() {
+			try {
+				const data = await (await fetch("/wifistatus")).json();
+				if (data.test) {
+					const t = data.test;
+					if (t.phase === "success") {
+						showTestStatus("success", i18next.t("wifi.test.success", { ssid: t.ssid, ip: t.ip }));
+						return;
+					}
+					if (t.phase === "failed") {
+						const cls = ["wrong_password", "not_found", "rejected", "timeout"].includes(t.class) ? t.class : "other";
+						showTestStatus("failed", i18next.t("wifi.fail." + cls, { ssid: t.ssid, code: t.reason }));
+						return;
+					}
+					showTestStatus("progress", i18next.t("wifi.test.connecting", { ssid: t.ssid }));
+				}
+			} catch (error) {
+				// expected while the AP hops to the target network's channel
+				console.log(error);
+			}
+			setTimeout(pollTestStatus, 1500);
+		}
 		async function wifiConfig() {
 			let static = document.getElementById('static_enabled').checked;
+			const ssid = document.getElementById('ssid').value;
 			var myObj = {
-				ssid: document.getElementById('ssid').value,
+				ssid: ssid,
 				pwd: document.getElementById('pwd').value,
 				static: static
 			};
@@ -262,6 +301,21 @@
 				},
 				body: JSON.stringify(myObj)
 			});
+			// try the credentials right away, while the AP stays up
+			document.getElementById("connstatus").style.display = "none";
+			const response = await fetch("/wifitest", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify({ ssid: ssid })
+			});
+			if (response.ok) {
+				showTestStatus("progress", i18next.t("wifi.test.connecting", { ssid: ssid }));
+				setTimeout(pollTestStatus, 1000);
+			} else {
+				showTestStatus("failed", i18next.t("wifi.fail.other", { ssid: ssid, code: 0 }));
+			}
 		}
 		addEventListener("DOMContentLoaded", (event) => {
 			getWiFiList();

--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -91,7 +91,6 @@
 		</div>
 		<h1 data-i18n="wifi.title"></h1>
 		<div id="connstatus" style="display:none;background:#f8d7da;color:#721c24;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
-		<div id="teststatus" style="display:none;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
 		<div id="WiFiList"></div>
 		<label for="ssid" data-i18n="wifi.ssid.title"></label>: <br>
 		<input type="text" id="ssid" name="ssid" placeholder="SSID" required>
@@ -134,7 +133,8 @@
 		</div>
 		<button type="submit" class="btn" id="save-button" data-i18n="submit"></button>
 	</form>
-	<form action="/restart" method="POST" class="box">
+	<div id="teststatus" style="display:none;border-radius:4px;padding:10px;margin:0 auto 20px;max-width:500px;text-align:left"></div>
+	<form id="restartform" action="/restart" method="POST" class="box">
 		<h1 data-i18n="wifi.restartPrompt"></h1>
 		<button type="submit" class="btn" id="restart-button" data-i18n="restart" value="Reboot"></button>
 	</form>
@@ -243,16 +243,31 @@
 			box.innerText = text;
 			box.style.display = "block";
 		}
+		// Disable the form and turn the Connect button into a "Connecting …"
+		// indicator while a live test is in flight, so it's obvious the box is
+		// working (the button is where the eye already is). Re-enabled on failure
+		// so the user can fix the credentials and retry.
+		function setFormBusy(busy) {
+			const form = document.getElementById("settings");
+			for (const el of form.elements) {
+				el.disabled = busy;
+			}
+			const btn = document.getElementById("save-button");
+			btn.innerText = busy ? i18next.t("wifi.test.connectingBtn") : i18next.t("submit");
+		}
 		async function pollTestStatus() {
 			try {
 				const data = await (await fetch("/wifistatus")).json();
 				if (data.test) {
 					const t = data.test;
 					if (t.phase === "success") {
+						document.getElementById("settings").style.display = "none";
+						document.getElementById("restartform").style.display = "none";
 						showTestStatus("success", i18next.t("wifi.test.success", { ssid: t.ssid, ip: t.ip }));
 						return;
 					}
 					if (t.phase === "failed") {
+						setFormBusy(false);
 						const cls = ["wrong_password", "not_found", "rejected", "timeout"].includes(t.class) ? t.class : "other";
 						showTestStatus("failed", i18next.t("wifi.fail." + cls, { ssid: t.ssid, code: t.reason }));
 						return;
@@ -266,6 +281,7 @@
 			setTimeout(pollTestStatus, 1500);
 		}
 		async function wifiConfig() {
+			setFormBusy(true);
 			let static = document.getElementById('static_enabled').checked;
 			const ssid = document.getElementById('ssid').value;
 			var myObj = {
@@ -314,6 +330,7 @@
 				showTestStatus("progress", i18next.t("wifi.test.connecting", { ssid: ssid }));
 				setTimeout(pollTestStatus, 1000);
 			} else {
+				setFormBusy(false);
 				showTestStatus("failed", i18next.t("wifi.fail.other", { ssid: ssid, code: 0 }));
 			}
 		}

--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -82,6 +82,13 @@
 
 <body>
 	<form id="settings" action="#wifiConfig" class="box" method="POST" onsubmit="wifiConfig(); return false">
+		<div style="text-align:right">
+			<select id="langSel" style="width:auto;height:28px;margin:0;padding:0 5px;font-size:13px">
+				<option value="de">Deutsch</option>
+				<option value="en">English</option>
+				<option value="fr">Français</option>
+			</select>
+		</div>
 		<h1 data-i18n="wifi.title"></h1>
 		<div id="WiFiList"></div>
 		<label for="ssid" data-i18n="wifi.ssid.title"></label>: <br>
@@ -142,10 +149,29 @@
 				loadPath: "/locales/{{lng}}.json"
 			},
 			debug: true,
-			fallbackLng: 'de',
+			load: 'languageOnly',
+			fallbackLng: 'en',
 		}, (err, t) => {
 			localize = locI18next.init(i18next);
-			localize('body');
+			// same language resolution as management.html: explicit choice from
+			// localStorage first, browser language otherwise
+			const lang = localStorage.getItem("language");
+			i18next.changeLanguage(lang !== null ? lang : navigator.language.split("-")[0]);
+		});
+		i18next.on('languageChanged', (lng) => {
+			document.querySelector('#langSel').value = lng;
+			document.documentElement.lang = lng;
+			document.title = i18next.t('wifi.title');
+			if (typeof localize === "function") {
+				localize('body');
+			}
+		});
+		document.querySelector('#langSel').addEventListener('change', (event) => {
+			const lang = event.target.value;
+			if (lang !== i18next.language) {
+				localStorage.setItem("language", lang);
+				i18next.changeLanguage(lang);
+			}
 		});
 
 		function selectWiFi(ssid) {

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -151,6 +151,12 @@
 			"copy": "Adresse kopieren",
 			"copied": "Adresse kopiert!",
 			"copyFailed": "Kopieren nicht möglich - bitte Adresse oben manuell markieren und kopieren."
+		},
+		"fail": {
+			"wrong_password": "Verbindung mit \"{{ssid}}\" fehlgeschlagen — vermutlich ist das Passwort falsch (Code {{code}}). Bitte prüfen und erneut eingeben.",
+			"not_found": "Das Netzwerk \"{{ssid}}\" wurde nicht gefunden (Code {{code}}). Ist es in Reichweite und auf 2,4 GHz?",
+			"rejected": "Der Router hat die Verbindung mit \"{{ssid}}\" abgelehnt (Code {{code}}). MAC-Filter, Client-Limits oder Sicherheitseinstellungen prüfen (WPA2 erforderlich).",
+			"other": "Verbindung mit \"{{ssid}}\" fehlgeschlagen (Code {{code}})."
 		}
 	},
 	"control": {

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -161,6 +161,7 @@
 		},
 		"test": {
 			"connecting": "Verbinde mit \"{{ssid}}\" …",
+			"connectingBtn": "Verbinde …",
 			"success": "Verbunden! Die Box hat die IP {{ip}} erhalten und verlässt jetzt den Einrichtungsmodus. Verbinde dein Telefon wieder mit deinem normalen WLAN und erreiche die Box unter http://{{ip}}"
 		}
 	},

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -156,7 +156,12 @@
 			"wrong_password": "Verbindung mit \"{{ssid}}\" fehlgeschlagen — vermutlich ist das Passwort falsch (Code {{code}}). Bitte prüfen und erneut eingeben.",
 			"not_found": "Das Netzwerk \"{{ssid}}\" wurde nicht gefunden (Code {{code}}). Ist es in Reichweite und auf 2,4 GHz?",
 			"rejected": "Der Router hat die Verbindung mit \"{{ssid}}\" abgelehnt (Code {{code}}). MAC-Filter, Client-Limits oder Sicherheitseinstellungen prüfen (WPA2 erforderlich).",
-			"other": "Verbindung mit \"{{ssid}}\" fehlgeschlagen (Code {{code}})."
+			"other": "Verbindung mit \"{{ssid}}\" fehlgeschlagen (Code {{code}}).",
+			"timeout": "Mit \"{{ssid}}\" verbunden, aber keine IP-Adresse erhalten (Code {{code}}). DHCP-Einstellungen des Routers prüfen."
+		},
+		"test": {
+			"connecting": "Verbinde mit \"{{ssid}}\" …",
+			"success": "Verbunden! Die Box hat die IP {{ip}} erhalten und verlässt jetzt den Einrichtungsmodus. Verbinde dein Telefon wieder mit deinem normalen WLAN und erreiche die Box unter http://{{ip}}"
 		}
 	},
 	"control": {

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -156,7 +156,12 @@
 			"wrong_password": "Could not join \"{{ssid}}\" — the password is probably wrong (code {{code}}). Please check it and try again.",
 			"not_found": "Network \"{{ssid}}\" was not found (code {{code}}). Is it in range and on 2.4 GHz?",
 			"rejected": "The router refused the connection to \"{{ssid}}\" (code {{code}}). Check MAC filters, client limits or security settings (WPA2 required).",
-			"other": "Connecting to \"{{ssid}}\" failed (code {{code}})."
+			"other": "Connecting to \"{{ssid}}\" failed (code {{code}}).",
+			"timeout": "Joined \"{{ssid}}\", but no IP address was received (code {{code}}). Check the router's DHCP settings."
+		},
+		"test": {
+			"connecting": "Trying to connect to \"{{ssid}}\" …",
+			"success": "Connected! The box got IP {{ip}}. It will now leave setup mode — reconnect your phone to your normal WiFi and reach the box at http://{{ip}}"
 		}
 	},
 	"control": {

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -161,6 +161,7 @@
 		},
 		"test": {
 			"connecting": "Trying to connect to \"{{ssid}}\" …",
+			"connectingBtn": "Connecting …",
 			"success": "Connected! The box got IP {{ip}}. It will now leave setup mode — reconnect your phone to your normal WiFi and reach the box at http://{{ip}}"
 		}
 	},

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -151,6 +151,12 @@
 			"copy": "Copy address",
 			"copied": "Address copied!",
 			"copyFailed": "Could not copy - please select and copy the address above manually."
+		},
+		"fail": {
+			"wrong_password": "Could not join \"{{ssid}}\" — the password is probably wrong (code {{code}}). Please check it and try again.",
+			"not_found": "Network \"{{ssid}}\" was not found (code {{code}}). Is it in range and on 2.4 GHz?",
+			"rejected": "The router refused the connection to \"{{ssid}}\" (code {{code}}). Check MAC filters, client limits or security settings (WPA2 required).",
+			"other": "Connecting to \"{{ssid}}\" failed (code {{code}})."
 		}
 	},
 	"control": {

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -151,6 +151,12 @@
 			"copy": "Copier l'adresse",
 			"copied": "Adresse copiée !",
 			"copyFailed": "Impossible de copier - veuillez sélectionner et copier l'adresse ci-dessus manuellement."
+		},
+		"fail": {
+			"wrong_password": "Impossible de rejoindre « {{ssid}} » — le mot de passe est probablement incorrect (code {{code}}). Veuillez le vérifier et réessayer.",
+			"not_found": "Le réseau « {{ssid}} » est introuvable (code {{code}}). Est-il à portée et en 2,4 GHz ?",
+			"rejected": "Le routeur a refusé la connexion à « {{ssid}} » (code {{code}}). Vérifiez les filtres MAC, les limites de clients ou les paramètres de sécurité (WPA2 requis).",
+			"other": "Échec de la connexion à « {{ssid}} » (code {{code}})."
 		}
 	},
 	"control": {

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -156,7 +156,12 @@
 			"wrong_password": "Impossible de rejoindre « {{ssid}} » — le mot de passe est probablement incorrect (code {{code}}). Veuillez le vérifier et réessayer.",
 			"not_found": "Le réseau « {{ssid}} » est introuvable (code {{code}}). Est-il à portée et en 2,4 GHz ?",
 			"rejected": "Le routeur a refusé la connexion à « {{ssid}} » (code {{code}}). Vérifiez les filtres MAC, les limites de clients ou les paramètres de sécurité (WPA2 requis).",
-			"other": "Échec de la connexion à « {{ssid}} » (code {{code}})."
+			"other": "Échec de la connexion à « {{ssid}} » (code {{code}}).",
+			"timeout": "Connecté à « {{ssid}} », mais aucune adresse IP reçue (code {{code}}). Vérifiez les paramètres DHCP du routeur."
+		},
+		"test": {
+			"connecting": "Connexion à « {{ssid}} » …",
+			"success": "Connecté ! La box a reçu l'adresse IP {{ip}} et quitte maintenant le mode configuration. Reconnectez votre téléphone à votre WiFi habituel et accédez à la box via http://{{ip}}"
 		}
 	},
 	"control": {

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -161,6 +161,7 @@
 		},
 		"test": {
 			"connecting": "Connexion à « {{ssid}} » …",
+			"connectingBtn": "Connexion …",
 			"success": "Connecté ! La box a reçu l'adresse IP {{ip}} et quitte maintenant le mode configuration. Reconnectez votre téléphone à votre WiFi habituel et accédez à la box via http://{{ip}}"
 		}
 	},

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -75,6 +75,7 @@ static void explorerHandleRenameRequest(AsyncWebServerRequest *request);
 static void explorerHandleAudioRequest(AsyncWebServerRequest *request);
 static void handleTrackProgressRequest(AsyncWebServerRequest *request);
 static void handleGetSavedSSIDs(AsyncWebServerRequest *request);
+static void handleGetWifiStatus(AsyncWebServerRequest *request);
 static void handlePostSavedSSIDs(AsyncWebServerRequest *request, JsonVariant &json);
 static void handleDeleteSavedSSIDs(AsyncWebServerRequest *request);
 static void handleGetActiveSSID(AsyncWebServerRequest *request);
@@ -626,6 +627,7 @@ void webserverStart(void) {
 		wServer.addRewrite(new OneParamRewrite("/savedSSIDs/{ssid}", "/savedSSIDs?ssid={ssid}"));
 		wServer.on("/savedSSIDs", HTTP_DELETE, handleDeleteSavedSSIDs);
 		wServer.on("/activeSSID", HTTP_GET, handleGetActiveSSID);
+		wServer.on("/wifistatus", HTTP_GET, handleGetWifiStatus);
 
 		wServer.on("/wificonfig", HTTP_GET, handleGetWiFiConfig);
 		wServer.addHandler(new AsyncCallbackJsonWebHandler("/wificonfig", handlePostWiFiConfig));
@@ -2224,6 +2226,61 @@ void handleGetSavedSSIDs(AsyncWebServerRequest *request) {
 	Wlan_GetSavedNetworks([json_ssids](const WiFiSettings &network) {
 		json_ssids.add(network.ssid);
 	});
+
+	response->setLength();
+	request->send(response);
+}
+
+// Map an 802.11 disconnect reason code onto a coarse, user-explainable class.
+// The page translates the class into a localized message; the raw code is
+// reported alongside for the curious/for support.
+static const char *classifyDisconnectReason(uint8_t reason) {
+	switch (reason) {
+		case WIFI_REASON_AUTH_EXPIRE:
+		case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
+		case WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT:
+		case WIFI_REASON_IE_IN_4WAY_DIFFERS:
+		case WIFI_REASON_AUTH_FAIL:
+		case WIFI_REASON_HANDSHAKE_TIMEOUT:
+			return "wrong_password";
+		case WIFI_REASON_NO_AP_FOUND:
+		case 210: // NO_AP_FOUND_IN_RSSI_THRESHOLD (IDF >= 5.3)
+		case 211: // NO_AP_FOUND_IN_AUTHMODE_THRESHOLD
+		case 212: // NO_AP_FOUND_IN_BAND
+		case 213: // NO_AP_FOUND_W_COMPATIBLE_SECURITY
+			return "not_found";
+		case WIFI_REASON_ASSOC_TOOMANY:
+		case WIFI_REASON_802_1X_AUTH_FAILED:
+		case WIFI_REASON_CIPHER_SUITE_REJECTED:
+		case WIFI_REASON_ASSOC_FAIL:
+		case WIFI_REASON_CONNECTION_FAIL:
+			return "rejected";
+		default:
+			return "other";
+	}
+}
+
+// Current WiFi state plus diagnostics of the last failed connection attempt.
+// Used by the accesspoint page to tell the user why their credentials didn't
+// work instead of silently falling back to the setup AP.
+void handleGetWifiStatus(AsyncWebServerRequest *request) {
+	AsyncJsonResponse *response = new AsyncJsonResponse();
+	JsonObject obj = response->getRoot();
+
+	obj["state"] = Wlan_GetConnectState();
+	if (Wlan_IsConnected()) {
+		obj["ssid"] = Wlan_GetCurrentSSID();
+		obj["ip"] = Wlan_GetIpAddress();
+	}
+
+	String failSsid;
+	uint8_t failReason;
+	if (Wlan_GetLastFailure(failSsid, failReason)) {
+		JsonObject fail = obj["last_failure"].to<JsonObject>();
+		fail["ssid"] = failSsid;
+		fail["reason"] = failReason;
+		fail["class"] = classifyDisconnectReason(failReason);
+	}
 
 	response->setLength();
 	request->send(response);

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -76,6 +76,7 @@ static void explorerHandleAudioRequest(AsyncWebServerRequest *request);
 static void handleTrackProgressRequest(AsyncWebServerRequest *request);
 static void handleGetSavedSSIDs(AsyncWebServerRequest *request);
 static void handleGetWifiStatus(AsyncWebServerRequest *request);
+static void handlePostWifiTest(AsyncWebServerRequest *request, JsonVariant &json);
 static void handlePostSavedSSIDs(AsyncWebServerRequest *request, JsonVariant &json);
 static void handleDeleteSavedSSIDs(AsyncWebServerRequest *request);
 static void handleGetActiveSSID(AsyncWebServerRequest *request);
@@ -628,6 +629,7 @@ void webserverStart(void) {
 		wServer.on("/savedSSIDs", HTTP_DELETE, handleDeleteSavedSSIDs);
 		wServer.on("/activeSSID", HTTP_GET, handleGetActiveSSID);
 		wServer.on("/wifistatus", HTTP_GET, handleGetWifiStatus);
+		wServer.addHandler(new AsyncCallbackJsonWebHandler("/wifitest", handlePostWifiTest));
 
 		wServer.on("/wificonfig", HTTP_GET, handleGetWiFiConfig);
 		wServer.addHandler(new AsyncCallbackJsonWebHandler("/wificonfig", handlePostWiFiConfig));
@@ -2236,6 +2238,8 @@ void handleGetSavedSSIDs(AsyncWebServerRequest *request) {
 // reported alongside for the curious/for support.
 static const char *classifyDisconnectReason(uint8_t reason) {
 	switch (reason) {
+		case 0: // no disconnect event: association held, but no IP arrived
+			return "timeout";
 		case WIFI_REASON_AUTH_EXPIRE:
 		case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
 		case WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT:
@@ -2282,8 +2286,34 @@ void handleGetWifiStatus(AsyncWebServerRequest *request) {
 		fail["class"] = classifyDisconnectReason(failReason);
 	}
 
+	// live connection test (started via POST /wifitest from the setup page)
+	const char *testPhase = Wlan_GetTestPhase();
+	if (strcmp(testPhase, "idle") != 0) {
+		JsonObject test = obj["test"].to<JsonObject>();
+		test["phase"] = testPhase;
+		test["ssid"] = Wlan_GetTestSsid();
+		if (strcmp(testPhase, "failed") == 0) {
+			const uint8_t reason = Wlan_GetTestReason();
+			test["reason"] = reason;
+			test["class"] = classifyDisconnectReason(reason);
+		} else if (strcmp(testPhase, "success") == 0) {
+			test["ip"] = Wlan_GetIpAddress();
+		}
+	}
+
 	response->setLength();
 	request->send(response);
+}
+
+// Start a live connection test while in AP mode. Body: {"ssid": "..."} —
+// the credentials must have been saved via POST /savedSSIDs beforehand.
+void handlePostWifiTest(AsyncWebServerRequest *request, JsonVariant &json) {
+	const char *ssid = json["ssid"].as<const char *>();
+	if (!ssid || !Wlan_StartConnectionTest(ssid)) {
+		request->send(400);
+		return;
+	}
+	request->send(200);
 }
 
 void handlePostSavedSSIDs(AsyncWebServerRequest *request, JsonVariant &json) {

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -339,7 +339,10 @@ void handleWifiStateConnectLast() {
 		return;
 	}
 
-	if (connectStartTimestamp > 0 && millis() - connectStartTimestamp < 3000) {
+	// Allow enough time for association AND DHCP: on VLAN'd/mesh networks
+	// (e.g. UniFi IoT SSIDs) the lease can take well over 5s to arrive, and
+	// tearing the connection down before it lands means never getting an IP.
+	if (connectStartTimestamp > 0 && millis() - connectStartTimestamp < 15000) {
 		return;
 	}
 
@@ -403,7 +406,9 @@ void handleWifiStateScanConnect() {
 			Log_Printf(LOGLEVEL_NOTICE, wifiScanResult, WiFi.SSID(i).c_str(), WiFi.RSSI(i), WiFi.channel(i), WiFi.BSSIDstr(i).c_str());
 		}
 	} else {
-		if (millis() - connectStartTimestamp < 5000) {
+		// 15s, not 5s: association + DHCP on VLAN'd/mesh networks (UniFi IoT
+		// SSIDs etc.) regularly needs >5s; see matching window above.
+		if (millis() - connectStartTimestamp < 15000) {
 			return;
 		}
 	}

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -63,6 +63,27 @@ static String lastAttemptSsid;
 static constexpr const char *nvsFailSsidKey = "wifiFailSsid";
 static constexpr const char *nvsFailReasonKey = "wifiFailReason";
 
+// Live connection test, runnable while the setup AP stays up (WIFI_AP_STA):
+// the accesspoint page saves credentials, POSTs /wifitest and then polls
+// /wifistatus — so the user gets immediate feedback (wrong password, no IP,
+// success + IP) instead of the old save → reboot → hope flow.
+enum class WifiTestPhase : uint8_t {
+	Idle = 0,
+	Pending, // requested by the web handler, not yet started
+	Connecting,
+	Success,
+	Failed
+};
+static volatile WifiTestPhase testPhase = WifiTestPhase::Idle;
+static WiFiSettings testSettings;
+static uint8_t testFailReason = 0;
+static uint32_t testStartTimestamp = 0;
+static uint32_t testSuccessTimestamp = 0;
+// how long a test attempt may take before it is declared failed (assoc + DHCP)
+static constexpr uint32_t testTimeout = 25000;
+// how long the result stays visible on the AP before switching to normal mode
+static constexpr uint32_t testSuccessLinger = 15000;
+
 // state for persistent settings
 static constexpr const char *nvsWiFiNamespace = "wifi-settings";
 static constexpr const char *nvsWiFiKey = "wifi-";
@@ -627,6 +648,57 @@ void handleWifiStateAP() {
 		return;
 	}
 
+	switch (testPhase) {
+		case WifiTestPhase::Pending:
+			// bring the station interface up next to the AP and try the
+			// credentials. The AP may hop to the target network's channel,
+			// briefly interrupting the portal client — the page just keeps
+			// polling.
+			wifiAPStartedTimestamp = millis(); // user is mid-setup: keep AP alive
+			WiFi.mode(WIFI_AP_STA);
+			connectToKnownNetwork(testSettings);
+			testStartTimestamp = millis();
+			testPhase = WifiTestPhase::Connecting;
+			break;
+		case WifiTestPhase::Connecting:
+			wifiAPStartedTimestamp = millis();
+			if (WiFi.status() == WL_CONNECTED) {
+				testSuccessTimestamp = millis();
+				testPhase = WifiTestPhase::Success;
+				// the credentials work — drop any stale failure diagnostics
+				if (gPrefsSettings.isKey(nvsFailReasonKey)) {
+					gPrefsSettings.remove(nvsFailReasonKey);
+					gPrefsSettings.remove(nvsFailSsidKey);
+				}
+				Log_Printf(LOGLEVEL_NOTICE, "WiFi-test: connected to %s, IP: %s", testSettings.ssid.c_str(), WiFi.localIP().toString().c_str());
+			} else if (millis() - testStartTimestamp > testTimeout) {
+				// reason stays 0 when association worked but no IP arrived
+				testFailReason = lastDisconnectReason;
+				testPhase = WifiTestPhase::Failed;
+				gPrefsSettings.putString(nvsFailSsidKey, testSettings.ssid);
+				gPrefsSettings.putUChar(nvsFailReasonKey, testFailReason);
+				Log_Printf(LOGLEVEL_ERROR, "WiFi-test: failed for %s (reason %u)", testSettings.ssid.c_str(), testFailReason);
+				WiFi.disconnect(true, true);
+				WiFi.mode(WIFI_AP);
+			}
+			break;
+		case WifiTestPhase::Success:
+			wifiAPStartedTimestamp = millis();
+			// leave the result on screen for a moment, then close the AP and
+			// continue as a normally connected station
+			if (millis() - testSuccessTimestamp > testSuccessLinger) {
+				testPhase = WifiTestPhase::Idle;
+				WiFi.softAPdisconnect(false);
+				WiFi.mode(WIFI_STA);
+				wifiState = WIFI_STATE_CONN_SUCCESS;
+				return;
+			}
+			break;
+		default:
+			// Idle: nothing to do; Failed: wait for the user to retry
+			break;
+	}
+
 	dnsServer->processNextRequest();
 }
 
@@ -819,6 +891,48 @@ const char *Wlan_GetConnectState(void) {
 		default:
 			return "connecting";
 	}
+}
+
+// Start a live connection test for a saved network while the setup AP is up.
+// Returns false when not in AP mode, a test is already running, or the SSID
+// has no saved settings.
+bool Wlan_StartConnectionTest(const String &ssid) {
+	if (wifiState != WIFI_STATE_AP) {
+		return false;
+	}
+	if (testPhase == WifiTestPhase::Pending || testPhase == WifiTestPhase::Connecting) {
+		return false;
+	}
+	const auto entry = getNvsWifiSettings(ssid);
+	if (!entry) {
+		return false;
+	}
+	testSettings = entry->value;
+	testFailReason = 0;
+	testPhase = WifiTestPhase::Pending; // picked up by handleWifiStateAP()
+	return true;
+}
+
+const char *Wlan_GetTestPhase(void) {
+	switch (testPhase) {
+		case WifiTestPhase::Pending:
+		case WifiTestPhase::Connecting:
+			return "connecting";
+		case WifiTestPhase::Success:
+			return "success";
+		case WifiTestPhase::Failed:
+			return "failed";
+		default:
+			return "idle";
+	}
+}
+
+uint8_t Wlan_GetTestReason(void) {
+	return testFailReason;
+}
+
+const String Wlan_GetTestSsid(void) {
+	return testSettings.ssid;
 }
 
 // Diagnostics of the last failed connection attempt (cleared on success)

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -52,6 +52,17 @@ static uint8_t connectionAttemptCounter = 0;
 static unsigned long connectStartTimestamp = 0;
 static uint32_t connectionFailedTimestamp = 0;
 
+// diagnostics of the running/last connection attempt. The state machine only
+// polls WiFi.status(), which never surfaces WHY an attempt failed — the 802.11
+// reason code (wrong password vs. network not found vs. AP refused) only
+// arrives via the disconnect event. Captured here and persisted to NVS on
+// failure so the accesspoint page can show it to the user, even after the
+// reboot that sits between entering credentials and reading the result.
+static volatile uint8_t lastDisconnectReason = 0;
+static String lastAttemptSsid;
+static constexpr const char *nvsFailSsidKey = "wifiFailSsid";
+static constexpr const char *nvsFailReasonKey = "wifiFailReason";
+
 // state for persistent settings
 static constexpr const char *nvsWiFiNamespace = "wifi-settings";
 static constexpr const char *nvsWiFiKey = "wifi-";
@@ -287,6 +298,12 @@ void Wlan_Init(void) {
 	// for Arduino 2.0.9 this does not seem to bring any advantage just more memory use, so leave it outcommented
 	// WiFi.useStaticBuffers(true);
 
+	// capture the reason code of station disconnects (see lastDisconnectReason)
+	WiFi.onEvent([](WiFiEvent_t event, arduino_event_info_t info) {
+		lastDisconnectReason = info.wifi_sta_disconnected.reason;
+	},
+		WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+
 	wifiState = WIFI_STATE_INIT;
 	handleWifiStateInit();
 }
@@ -307,6 +324,8 @@ void connectToKnownNetwork(const WiFiSettings &settings, const uint8_t *bssid = 
 
 	Log_Printf(LOGLEVEL_NOTICE, wifiConnectionInProgress, settings.ssid.c_str());
 
+	lastAttemptSsid = settings.ssid;
+	lastDisconnectReason = 0;
 	WiFi.begin(settings.ssid, settings.password, 0, bssid);
 }
 
@@ -515,6 +534,12 @@ void handleWifiStateConnectionSuccess() {
 		}
 	}
 
+	// a successful connection invalidates the stored failure diagnostics
+	if (gPrefsSettings.isKey(nvsFailReasonKey)) {
+		gPrefsSettings.remove(nvsFailReasonKey);
+		gPrefsSettings.remove(nvsFailSsidKey);
+	}
+
 	wifiState = WIFI_STATE_CONNECTED;
 	Mqtt_OnWifiConnected();
 }
@@ -561,6 +586,20 @@ void handleWifiStateConnectionFailed() {
 	if (connectionFailedTimestamp == 0) {
 		Log_Println(cantConnectToWifi, LOGLEVEL_INFO);
 		connectionFailedTimestamp = millis();
+
+		// persist the failure diagnostics for the accesspoint page. If no
+		// connect was even attempted, none of the saved networks was in the
+		// scan results — report that as NO_AP_FOUND for the last known SSID.
+		if (lastAttemptSsid.length() && lastDisconnectReason != 0) {
+			gPrefsSettings.putString(nvsFailSsidKey, lastAttemptSsid);
+			gPrefsSettings.putUChar(nvsFailReasonKey, lastDisconnectReason);
+		} else if (!lastAttemptSsid.length()) {
+			const String lastSSID = gPrefsSettings.getString("LAST_SSID");
+			if (lastSSID.length()) {
+				gPrefsSettings.putString(nvsFailSsidKey, lastSSID);
+				gPrefsSettings.putUChar(nvsFailReasonKey, WIFI_REASON_NO_AP_FOUND);
+			}
+		}
 	}
 
 	if (initialStart) {
@@ -764,6 +803,32 @@ bool Wlan_DeleteNetwork(String ssid) {
 
 bool Wlan_ConnectionTryInProgress(void) {
 	return wifiState == WIFI_STATE_SCAN_CONN;
+}
+
+// Coarse connection state for the web API (/wifistatus)
+const char *Wlan_GetConnectState(void) {
+	switch (wifiState) {
+		case WIFI_STATE_CONNECTED:
+			return "connected";
+		case WIFI_STATE_CONN_FAILED:
+			return "failed";
+		case WIFI_STATE_AP:
+			return "ap";
+		case WIFI_STATE_END:
+			return "off";
+		default:
+			return "connecting";
+	}
+}
+
+// Diagnostics of the last failed connection attempt (cleared on success)
+bool Wlan_GetLastFailure(String &ssid, uint8_t &reason) {
+	if (!gPrefsSettings.isKey(nvsFailReasonKey)) {
+		return false;
+	}
+	ssid = gPrefsSettings.getString(nvsFailSsidKey);
+	reason = gPrefsSettings.getUChar(nvsFailReasonKey);
+	return true;
 }
 
 String Wlan_GetIpAddress(void) {

--- a/src/Wlan.h
+++ b/src/Wlan.h
@@ -131,3 +131,5 @@ void Wlan_ToggleEnable(void);
 String Wlan_GetIpAddress(void);
 int8_t Wlan_GetRssi(void);
 bool Wlan_ConnectionTryInProgress(void);
+const char *Wlan_GetConnectState(void);
+bool Wlan_GetLastFailure(String &ssid, uint8_t &reason);

--- a/src/Wlan.h
+++ b/src/Wlan.h
@@ -133,3 +133,7 @@ int8_t Wlan_GetRssi(void);
 bool Wlan_ConnectionTryInProgress(void);
 const char *Wlan_GetConnectState(void);
 bool Wlan_GetLastFailure(String &ssid, uint8_t &reason);
+bool Wlan_StartConnectionTest(const String &ssid);
+const char *Wlan_GetTestPhase(void);
+uint8_t Wlan_GetTestReason(void);
+const String Wlan_GetTestSsid(void);


### PR DESCRIPTION
## What

Four improvements to getting an ESPuino onto WiFi, from the low-level connect loop up to the setup page:

1. **Connect window 5 s → 15 s** so DHCP can finish on slow networks.
2. **Setup page honors the browser language** (+ a language selector) instead of always German.
3. **The box tells you *why* a connect failed** (wrong password / not found / rejected) instead of retrying silently.
4. **Credentials are tested live from the setup page** — no more save → reboot → hope.

## Why / Fix, per commit

### `3a4907e` — 15 s connect window
On VLAN'd / mesh networks (UniFi IoT SSIDs and similar) the DHCP lease regularly takes more than 5 s after association. The old 5 s window tore the connection down and moved to the next BSSID before the lease arrived, so the station associated repeatedly but never got an IP. Widened to 15 s.

### `ca0501e` — browser language + selector
The setup page already embedded full de/en/fr i18next locales, but initialized with no language detection and `fallbackLng: 'de'` — so every user got German regardless of browser settings. Mirrors `management.html`: resolve the language from `localStorage('language')` or the browser with English fallback, add a small selector to change it on the spot, and localize `document.title` (which sat outside the `localize('body')` scope).

### `bc2ad9d` — tell the user why a connect failed
The connect state machine polls `WiFi.status()`, which never surfaces the 802.11 disconnect reason — so a wrong password, an out-of-range network and a router-side rejection all looked identical: silent retries, then fallback to the setup AP with no explanation.
- **Wlan:** capture the disconnect reason via `WiFi.onEvent`, remember the SSID of the running attempt, persist both to NVS when a connect cycle fails (cleared again on the next successful connection). If no attempt was started because no saved network showed up in the scan, report `NO_AP_FOUND`.
- **Web:** new `GET /wifistatus` returning the coarse connection state plus the last failure (ssid, raw reason code, and a user-explainable class: `wrong_password` / `not_found` / `rejected` / `other`).
- **accesspoint page:** localized banner with that diagnosis on load, so after a failed attempt the user is told e.g. "the password is probably wrong" instead of guessing. Locale strings added for en/de/fr.

### `1d537d8` — test credentials live from the setup page
Replaces the save → reboot → hope onboarding flow. After saving, the setup page POSTs `/wifitest` and the box tries the credentials on the station interface **while the setup AP stays up** (`WIFI_AP_STA`). The page polls `/wifistatus`
and shows the outcome in place:
- **connecting:** progress note (survives the brief hiccup when the AP hops to the target network's channel)
- **failed:** the classified reason (wrong password / not found / rejected / associated-but-no-IP), same vocabulary as the last-failure banner; the AP stays up so the user can correct and retry immediately
- **success:** the obtained IP is shown for ~15 s, then the box closes the AP and continues as a normally connected station — no reboot, no vanishing portal, and the user knows where to find the box afterwards

The AP idle-close timer is suspended while a test is running, so the portal can no longer disappear under a slow typist mid-setup.

## Testing

- **Live on ESP32-S3 hardware (2026-07-06):** on an English-locale browser the setup page came up in English with the language selector present; a deliberately wrong password produced the classified failure banner; and a correct-credential entry connected successfully via the live test and reported the obtained IP. Verified on the actual box, not just in a browser.
- Platform-agnostic — touches only `Wlan.*`, `Web.cpp`, `html/accesspoint.html` and locales; no board- or S3-specific code. Compile-checked on `esp32-s3-devkitc-1`.

## Splitting (if preferred)

The commits are layered but separable. `3a4907e` (the 15 s timeout) is an independent, low-risk bugfix and is happy to go as its own quick-merge PR if you'd rather not take the setup-page feature work at the same time. `bc2ad9d`
and `1d537d8` are coupled (the live test reuses the failure classification and `/wifistatus`); `ca0501e` is standalone frontend.