### PR TITLE
Improve web-upload throughput: disable WiFi power-save + enlarge TCP …

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -244,6 +244,14 @@ CONFIG_LWIP_IPV6_AUTOCONFIG=y
 CONFIG_LWIP_TCP_SYNMAXRTX=6
 CONFIG_LWIP_TCP_MSS=1436
 CONFIG_LWIP_TCP_RTO_TIME=3000
+# Enlarge the TCP window (default 5760 = 4*MSS) to lift the web-upload throughput ceiling. On upload the
+# ESP is the receiver, so throughput is bound by window/RTT - effective once WiFi modem-sleep is disabled
+# during uploads (see System_PauseTasksDuringUpload), which keeps the RTT low. 16*MSS is where the gain
+# materializes; the extra ~11KB of buffered data per socket is more than offset by reducing the upload
+# double-buffer from 3 to 2 buffers (see nr_of_buffers in Web.cpp). Kept below 64KB so no window-scaling.
+CONFIG_LWIP_TCP_WND_DEFAULT=22976
+CONFIG_LWIP_TCP_SND_BUF_DEFAULT=22976
+CONFIG_LWIP_TCP_RECVMBOX_SIZE=16
 # end of TCP
 
 CONFIG_LWIP_TCPIP_TASK_STACK_SIZE=2560

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -16,6 +16,7 @@
 #include "Rfid.h"
 #include "SdCard.h"
 #include "Web.h"
+#include "Wlan.h"
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -275,7 +276,9 @@ void System_PauseTasksDuringUpload(bool pause) {
 		AudioPlayer_NotifyUploadStart();
 		Rfid_TaskPause();
 		Led_TaskPause();
+		Wlan_SetPowerSave(false); // full WiFi power for max upload throughput (restored below when done)
 	} else {
+		Wlan_SetPowerSave(true); // restore power-save to keep idle power low (esp. on battery)
 		Led_TaskResume();
 		Rfid_TaskResume();
 		AudioPlayer_NotifyUploadEnd();

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -47,7 +47,7 @@ AsyncEventSource events("/events");
 static bool webserverStarted = false;
 
 static const uint32_t start_chunk_size = 16384; // bigger chunks increase write-performance to SD-Card
-static constexpr uint32_t nr_of_buffers = 3; // at least two buffers. No speed improvement yet with more than two.
+static constexpr uint32_t nr_of_buffers = 2; // at least two buffers. No speed improvement yet with more than two. Kept at 2 to save ~16KB heap during uploads.
 
 static constexpr size_t retry_count = 3; // how often we retry is a malloc fails (also the times we halfe the chunk_size)
 

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -791,6 +791,14 @@ bool Wlan_IsConnected(void) {
 	return (wifiState == WIFI_STATE_CONNECTED);
 }
 
+// Enable/disable WiFi modem power-save. Power-save (WIFI_PS_MIN_MODEM, the Arduino default) saves power
+// when idle but inflates latency and cripples TCP throughput - so it is temporarily disabled during
+// bulk transfers (e.g. web-uploads, see System_PauseTasksDuringUpload()) and re-enabled afterwards.
+void Wlan_SetPowerSave(bool enabled) {
+	WiFi.setSleep(enabled);
+	Log_Printf(LOGLEVEL_DEBUG, "WiFi power-save %s", enabled ? "on" : "off");
+}
+
 std::optional<std::vector<uint8_t>> WiFiSettings::serialize() const {
 	if (!isValid()) {
 		// we refuse to serialize a corrupted data set

--- a/src/Wlan.h
+++ b/src/Wlan.h
@@ -119,6 +119,7 @@ bool Wlan_DeleteNetwork(String);
 bool Wlan_ValidateHostname(String);
 bool Wlan_SetHostname(String);
 bool Wlan_IsConnected(void);
+void Wlan_SetPowerSave(bool enabled);
 void Wlan_ToggleEnable(void);
 String Wlan_GetIpAddress(void);
 int8_t Wlan_GetRssi(void);


### PR DESCRIPTION
…window

Web-uploads (and OTA) were bound by WiFi modem-sleep (default WIFI_PS_MIN_MODEM), which inflates RTT and throttles TCP throughput. System_PauseTasksDuringUpload() now also disables WiFi power-save for the duration of the transfer and restores it afterwards, so idle power draw on battery is unaffected.

With power-save disabled, the default TCP receive window (5760B = 4*MSS) becomes the next bottleneck; enlarged to 16*MSS (22976B, still below 64KB so no window- scaling is required). To offset the extra per-socket buffering, the upload double-buffer was reduced from 3 to 2 chunks (~16KB saved), which the existing code comment already noted as sufficient ("no speed improvement with more than two buffers").

Measured on lolin_d32_pro_sdmmc_pe (RSSI -38dBm, router 1m away):
- baseline: ~360-400 kiB/s
- with this change: ~430-464 kiB/s
- free heap during upload+Bluetooth: ~20kiB (down from ~30kiB at baseline) - tight but headroom kept by the buffer reduction; worth keeping an eye on for setups running BT + large uploads concurrently.

Note: an AsyncTCP-core-affinity change was evaluated and rejected - it would free up core 0 further, but pinning network tasks to core 1 previously caused Neopixel/WS2812 flicker due to preemption during the timing-critical bit-banged protocol.