### PR TITLE
Fix intermittent boot-hang with PN5180-LPCD enabled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## DEV-branch
 
+* 10.07.2026: Fix intermittent boot-hang with PN5180-LPCD enabled by deferring RFID-task start until after peripheral init
 * 09.07.2026: Remove unmaintained MAX17055 fuel-gauge support (MEASURE_BATTERY_MAX17055). Voltage-based battery measurement (MEASURE_BATTERY_VOLTAGE) is unaffected.
 * 08.07.2026: Fix DONT_ACCEPT_SAME_RFID_TWICE / PLAY_LAST_RFID_AFTER_REBOOT in combination with WiFi not yet available
 * 25.06.2026: update some libaries and platform (#411), thanks to @Joe91

--- a/src/Rfid.h
+++ b/src/Rfid.h
@@ -7,6 +7,8 @@ extern char gCurrentRfidTagId[cardIdStringSize];
 
 void Rfid_ResetOldRfid(void);
 void Rfid_Init(void);
+void Rfid_WakeupHandling(void);
+void Rfid_StartTask(void);
 void Rfid_Cyclic(void);
 void Rfid_Exit(void);
 void Rfid_TaskPause(void);

--- a/src/RfidPn5180.cpp
+++ b/src/RfidPn5180.cpp
@@ -62,7 +62,14 @@ bool Rfid_GetLpcdShutdownStatus(void) {
 	return enabledLpcdShutdown;
 }
 
-void RfidPn5180_Init(void) {
+// Handles a possible deep-sleep wakeup via card-detection and releases GPIO pin holds left
+// over from a previous LPCD-armed deep-sleep. Must run early (before other peripherals are
+// powered), since a wakeup without a known card can send the device straight back to sleep
+// via RfidPn5180_WakeupCheck(). Does NOT start the scanning task: RfidPn5180_Task performing
+// SPI traffic concurrently with the rest of setup()'s peripheral init (Power_PeripheralOn(),
+// Led_Init(), SdCard_Init(), ...) was found to cause an intermittent full boot-hang, so task
+// creation is deferred to RfidPn5180_StartTask(), called once peripherals are up.
+void RfidPn5180_WakeupHandling(void) {
 	if (Rfid_Pn5180LpcdEnabled()) {
 		// Check if wakeup-reason was card-detection (PN5180 only)
 		// This only works if RFID.IRQ is connected to a GPIO and not to a port-expander
@@ -95,7 +102,9 @@ void RfidPn5180_Init(void) {
 		pinMode(RFID_IRQ, INPUT); // Not necessary for port-expander as for pca9555 all pins are configured as input per default
 	#endif
 	}
+}
 
+void RfidPn5180_StartTask(void) {
 	if (rfidTaskHandle == NULL) {
 		xTaskCreatePinnedToCore(
 			RfidPn5180_Task, /* Function to implement the task */
@@ -107,6 +116,11 @@ void RfidPn5180_Init(void) {
 			0 /* Core where the task should run */
 		);
 	}
+}
+
+void RfidPn5180_Init(void) {
+	RfidPn5180_WakeupHandling();
+	RfidPn5180_StartTask();
 }
 
 void RfidPn5180_Cyclic(void) {

--- a/src/RfidRuntime.cpp
+++ b/src/RfidRuntime.cpp
@@ -14,6 +14,8 @@ extern void RfidMfrc522_TaskReset(void);
 extern void RfidMfrc522_WakeupCheck(void);
 
 extern void RfidPn5180_Init(void);
+extern void RfidPn5180_WakeupHandling(void);
+extern void RfidPn5180_StartTask(void);
 extern void RfidPn5180_Cyclic(void);
 extern void RfidPn5180_Exit(void);
 extern void RfidPn5180_TaskReset(void);
@@ -29,6 +31,31 @@ void Rfid_Init(void) {
 		RfidMfrc522_Init(readerType);
 	} else {
 		RfidPn5180_Init();
+	}
+#endif
+}
+
+// Only meaningful for a PN5180 with LPCD enabled: handles a possible deep-sleep wakeup via
+// card-detection and releases GPIO pin holds from a previous LPCD-armed deep-sleep. Must be
+// called early (before other peripherals are powered) so a wakeup without a known card can
+// send the device straight back to sleep. Does not start the RFID scanning task; call
+// Rfid_StartTask() for that once peripherals are up.
+void Rfid_WakeupHandling(void) {
+#if defined(RFID_READER_TYPE_RUNTIME)
+	RfidConfig_Init();
+	if (RfidConfig_GetReaderType() == RfidReaderType::TYPE_PN5180) {
+		RfidPn5180_WakeupHandling();
+	}
+#endif
+}
+
+// Starts the RFID scanning task. For PN5180 with LPCD enabled, this is called separately
+// from Rfid_WakeupHandling() (see there for why); for all other cases, Rfid_Init() already
+// starts the task itself and this is a no-op.
+void Rfid_StartTask(void) {
+#if defined(RFID_READER_TYPE_RUNTIME)
+	if (RfidConfig_GetReaderType() == RfidReaderType::TYPE_PN5180) {
+		RfidPn5180_StartTask();
 	}
 #endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,7 +122,10 @@ void setup() {
 	System_Init_Rfid_Prefs();
 	const bool pn5180LpcdEnabled = gPrefsRfid.getBool("pn5180Lpcd", false);
 	if (pn5180LpcdEnabled) {
-		Rfid_Init();
+		// Only handle a possible deep-sleep wakeup here; starting the RFID scanning task
+		// this early raced with the peripheral init below and could hang the boot (see
+		// Rfid_StartTask() call further down).
+		Rfid_WakeupHandling();
 	}
 	System_Init();
 
@@ -173,6 +176,9 @@ void setup() {
 	Ftp_Init();
 	if (!pn5180LpcdEnabled) {
 		Rfid_Init();
+	} else {
+		// Peripherals are up now, safe to start the scanning task deferred above.
+		Rfid_StartTask();
 	}
 	RotaryEncoder_Init();
 	Bluetooth_Init();

--- a/src/revision.h
+++ b/src/revision.h
@@ -1,4 +1,4 @@
 #pragma once
 
 #include "gitrevision.h"
-constexpr const char softwareRevision[] = "Software-revision: 20260708-1-DEV";
+constexpr const char softwareRevision[] = "Software-revision: 20260710-1-DEV";


### PR DESCRIPTION
When LPCD is enabled, main.cpp used to call Rfid_Init() very early in setup() (before System_Init(), Power_Init(), Power_PeripheralOn(), Led_Init() and SdCard_Init()), so that a deep-sleep wakeup caused by an unknown card could send the device straight back to sleep without booting the rest of the system. But this same early call also started the permanent RfidPn5180_Task, which immediately began doing SPI traffic concurrently with the rest of setup()'s peripheral init - a race that caused the boot to hang completely in ~80-90% of attempts, reproducible even with the PN5180 physically disconnected.

Split RfidPn5180_Init() into RfidPn5180_WakeupHandling() (the deep-sleep wakeup check and GPIO-hold release, still run early) and RfidPn5180_StartTask() (task creation, now deferred until after Power_PeripheralOn()/Led_Init()/SdCard_Init() have completed, matching the timing already used when LPCD is disabled). Verified with repeated reboots, with and without the reader attached, that the hang no longer occurs while the deep-sleep wakeup behavior is unaffected.