### PR TITLE
Fix stack buffer overflow in RfidPn5180_WakeupCheck()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## DEV-branch
 
+* 10.07.2026: Fix stack buffer overflow in RfidPn5180_WakeupCheck() when formatting the card UID for NVS lookup
 * 10.07.2026: Fix intermittent boot-hang with PN5180-LPCD enabled by deferring RFID-task start until after peripheral init
 * 09.07.2026: Remove unmaintained MAX17055 fuel-gauge support (MEASURE_BATTERY_MAX17055). Voltage-based battery measurement (MEASURE_BATTERY_VOLTAGE) is unaffected.
 * 08.07.2026: Fix DONT_ACCEPT_SAME_RFID_TWICE / PLAY_LAST_RFID_AFTER_REBOOT in combination with WiFi not yet available

--- a/src/RfidPn5180.cpp
+++ b/src/RfidPn5180.cpp
@@ -427,11 +427,20 @@ void RfidPn5180_WakeupCheck(void) {
 
 	// check for card id in NVS
 	if (isCardPresent) {
-		// uint8_t[10] -> char[cardIdStringSize]
+		// Only the first cardIdSize bytes of the UID are used, matching the same ID scheme used for
+		// NVS lookups everywhere else (see RfidPn5180_Task below, memcpy(cardId, uid, cardIdSize)).
+		// Formatting all 10 raw UID bytes here previously overflowed this cardIdStringSize-sized
+		// stack buffer (cardIdStringSize is sized for exactly cardIdSize formatted bytes): once the
+		// write position exceeded the buffer, "cardIdStringSize - pos" (both size_t/unsigned) wrapped
+		// to a huge value, so snprintf kept writing well past the end of tagId.
 		char tagId[cardIdStringSize];
 		size_t pos = 0;
-		for (size_t i = 0; i < 10; i++) {
-			pos += snprintf(tagId + pos, cardIdStringSize - pos, "%03d", uid[i]);
+		for (size_t i = 0; i < cardIdSize; i++) {
+			const int written = snprintf(tagId + pos, cardIdStringSize - pos, "%03d", uid[i]);
+			if (written < 0 || static_cast<size_t>(written) >= cardIdStringSize - pos) {
+				break;
+			}
+			pos += written;
 		}
 		tagId[cardIdStringSize - 1] = '\0';
 

--- a/src/revision.h
+++ b/src/revision.h
@@ -1,4 +1,4 @@
 #pragma once
 
 #include "gitrevision.h"
-constexpr const char softwareRevision[] = "Software-revision: 20260710-1-DEV";
+constexpr const char softwareRevision[] = "Software-revision: 20260710-2-DEV";


### PR DESCRIPTION
The UID-to-string loop iterated over all 10 raw bytes returned by the PN5180 library, but tagId is only sized for cardIdSize (4) formatted bytes, matching the ID scheme used everywhere else for NVS lookups. snprintf()'s return value is the number of bytes that *would* have been written, not the number actually written; once pos exceeded cardIdStringSize, "cardIdStringSize - pos" underflowed (both are size_t) to a huge value, so snprintf kept writing well past the end of the stack buffer for the remaining iterations.

Limit the loop to cardIdSize and track the actually-written length, stopping once the buffer is full - mirroring how the card ID is already truncated to cardIdSize everywhere else (see RfidPn5180_Task/memcpy(cardId, uid, cardIdSize)).