### PR TITLE
Update via GitHub repo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## DEV-branch
 
+* 10.07.2026: Add firmware update from GitHub: list and install the last 5 builds from biologist79/ESPuino-Firmware directly in the web UI, with OTA progress shown on the LED ring
+* 10.07.2026: Self-host management webinterface locally (no more CDN dependency) & make AP SSID/password/timeout configurable via the web UI (#417)
+
 ## Version 2.8 (10.07.2026)
 
 * 10.07.2026: Fix stack buffer overflow in RfidPn5180_WakeupCheck() when formatting the card UID for NVS lookup (#421)

--- a/gitVersion.py
+++ b/gitVersion.py
@@ -23,6 +23,7 @@ TEMPLATE = """
     #define __GIT_REVISION_H__
     constexpr const char gitRevision[] = "Git-revision: {git_revision}";
     constexpr const char gitRevShort[] = "\\"{git_revision}\\"";
+    constexpr const char gitBranch[] = "{git_branch}";
 #endif
 """
 
@@ -42,14 +43,28 @@ def git_revision():
         return "unknown"
 
 
+def git_branch():
+    """Returns the current Git branch name or unknown (e.g. detached HEAD in CI checkouts)."""
+    try:
+        branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+        return branch if branch != "HEAD" else "unknown"
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
+
+
 def generate():
     """Generates header file."""
     print("GENERATING GIT REVISION HEADER FILE")
     gitrev = git_revision()
-    print(f'  "{gitrev}" -> {OUTPUT_PATH}')
+    gitbranch = git_branch()
+    print(f'  "{gitrev}" (branch "{gitbranch}") -> {OUTPUT_PATH}')
     OUTPUT_PATH.parent.mkdir(exist_ok=True, parents=True)
     with OUTPUT_PATH.open("w") as output_file:
-        output_file.write(TEMPLATE.format(git_revision=gitrev))
+        output_file.write(TEMPLATE.format(git_revision=gitrev, git_branch=gitbranch))
 
 
 generate()

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -21,7 +21,8 @@
 		"success": "Aktion erfolgreich ausgeführt.",
 		"conlost": "Die Verbindung zum ESPuino ist unterbrochen! Bitte Seite neu laden.",
 		"dropout": "Langsamer Stream, Aussetzer möglich.",
-		"saved": "Einstellungen gespeichert."
+		"saved": "Einstellungen gespeichert.",
+		"ledCountRestart": "Die Anzahl der LEDs wurde geändert. Der ESPuino startet neu, um das zu übernehmen."
 	},
 	"nav": {
 		"control": "Steuerung",
@@ -498,7 +499,22 @@
 		},
 		"fwupdate": {
 			"title": "Firmware-Update",
-			"desc": "Hier kann ein Firmware-Update durchgeführt werden."
+			"desc": "Hier kann ein Firmware-Update durchgeführt werden.",
+			"github": {
+				"title": "Firmware von GitHub laden",
+				"desc": "Lädt eine fertig gebaute Firmware direkt aus dem ESPuino-Firmware-Repository und installiert sie – ohne manuellen Download.",
+				"branch": "Branch",
+				"checkButton": "Nach Updates suchen",
+				"searching": "Suche läuft…",
+				"noBuilds": "Für diese Auswahl wurden keine Builds gefunden.",
+				"notAvailablePlatform": "Für diese Plattform ({{platform}}) werden im Repository keine fertigen Firmwares bereitgestellt. Bitte die Firmware manuell hochladen.",
+				"notAvailableCustomBuild": "Dieses Board wurde mit individuellen Einstellungen (settings-override.h / platformio-override.ini) gebaut. Die offizielle Firmware enthält diese Anpassungen nicht – bitte selbst bauen und wie gewohnt manuell hochladen.",
+				"notAvailableOta": "Dieses Board unterstützt kein Firmware-Update über das Webinterface. Bitte die Firmware seriell flashen.",
+				"buildEntry": "{{date}} – Commit:",
+				"installButton": "Installieren",
+				"installPrompt": "Firmware vom {{date}} (Commit {{commit}}) jetzt installieren?\n\nPlattform: {{platform}}\nBranch: {{branch}}\nSprache: {{language}}\n\nDie neue Firmware wird nun auf deinem ESPuino installiert. Dies dauert ungefähr eine Minute - sofern ein Neopixel mit mehreren LEDs angeschlossen ist, wird währenddessen eine Fortschritts-Animation angezeigt (blau). Ist es nur eine LED, so blinkt diese blau.",
+				"fetchError": "Firmware-Liste konnte nicht abgerufen werden."
+			}
 		}
 	},
 	"help": {
@@ -525,6 +541,7 @@
 		"title": "Information",
 		"softwareversion": "ESPuino {{softwareversion}}",
 		"gitversion": "ESPuino {{gitversion}}",
+		"branch": "Branch: {{branch}}",
 		"arduinoversion": "Arduino Version: {{arduinoversion}} (ESP-IDF {{idfversion}})",
 		"hardware": "Hardware: {{hwmodel}}, Revision {{hwrevision}}, CPU: {{hwfreq}} MHZ",
 		"freeheap": "Freier Heap: {{freeheap}} Bytes",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -21,7 +21,8 @@
 		"success": "Action performed successfully.",
 		"conlost": "Connection to ESPuino broken! Please reload website.",
 		"dropout": "slow stream, dropouts are possible.",
-		"saved": "Settings saved."
+		"saved": "Settings saved.",
+		"ledCountRestart": "The number of LEDs was changed. ESPuino will restart to apply it."
 	},
 	"nav": {
 		"control": "Control",
@@ -498,7 +499,22 @@
 		},
 		"fwupdate": {
 			"title": "Firmware-Update",
-			"desc": "Firmware can be updated right here."
+			"desc": "Firmware can be updated right here.",
+			"github": {
+				"title": "Load firmware from GitHub",
+				"desc": "Downloads a ready-built firmware directly from the ESPuino-Firmware repository and installs it – no manual download needed.",
+				"branch": "Branch",
+				"checkButton": "Check for updates",
+				"searching": "Searching…",
+				"noBuilds": "No builds found for this selection.",
+				"notAvailablePlatform": "No prebuilt firmwares are provided in the repository for this platform ({{platform}}). Please upload the firmware manually.",
+				"notAvailableCustomBuild": "This board was built with custom settings (settings-override.h / platformio-override.ini). The official firmware does not include these customizations – please build it yourself and upload it manually as usual.",
+				"notAvailableOta": "This board does not support firmware updates via the web interface. Please flash the firmware over serial.",
+				"buildEntry": "{{date}} – commit:",
+				"installButton": "Install",
+				"installPrompt": "Install the firmware from {{date}} (commit {{commit}}) now?\n\nPlatform: {{platform}}\nBranch: {{branch}}\nLanguage: {{language}}\n\nThe new firmware will now be installed on your ESPuino. This takes about a minute - if a Neopixel strip with multiple LEDs is connected, a progress animation (blue) will be shown during this time. With just a single LED, it will blink blue instead.",
+				"fetchError": "Could not fetch the firmware list."
+			}
 		}
 	},
 	"help": {
@@ -525,6 +541,7 @@
 		"title": "Information",
 		"softwareversion": "ESPuino {{softwareversion}}",
 		"gitversion": "ESPuino {{gitversion}}",
+		"branch": "Branch: {{branch}}",
 		"arduinoversion": "Arduino Version: {{arduinoversion}} (ESP-IDF {{idfversion}})",
 		"hardware": "Hardware: {{hwmodel}}, Revision {{hwrevision}}, CPU: {{hwfreq}} MHZ",
 		"freeheap": "Free heap: {{freeheap}} Bytes",

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -21,7 +21,8 @@
 		"success": "Action effectuée avec succès.",
 		"conlost": "Connexion à l'ESPuino perdue! Veuillez recharger la page.",
 		"dropout": "flux lent, des interruptions sont possibles.",
-		"saved": "Paramètres enregistrés."
+		"saved": "Paramètres enregistrés.",
+		"ledCountRestart": "Le nombre de LEDs a été modifié. L'ESPuino va redémarrer pour appliquer ce changement."
 	},
 	"nav": {
 		"control": "Contrôle",
@@ -498,7 +499,22 @@
 		},
 		"fwupdate": {
 			"title": "Mise à jour du micrologiciel",
-			"desc": "La mise à jour du micrologiciel peut être effectuée ici."
+			"desc": "La mise à jour du micrologiciel peut être effectuée ici.",
+			"github": {
+				"title": "Charger le micrologiciel depuis GitHub",
+				"desc": "Télécharge un micrologiciel prêt à l'emploi directement depuis le dépôt ESPuino-Firmware et l'installe – sans téléchargement manuel.",
+				"branch": "Branche",
+				"checkButton": "Rechercher des mises à jour",
+				"searching": "Recherche en cours…",
+				"noBuilds": "Aucune version trouvée pour cette sélection.",
+				"notAvailablePlatform": "Aucun micrologiciel prêt à l'emploi n'est fourni dans le dépôt pour cette plateforme ({{platform}}). Veuillez télécharger le micrologiciel manuellement.",
+				"notAvailableCustomBuild": "Cette carte a été compilée avec des paramètres personnalisés (settings-override.h / platformio-override.ini). Le micrologiciel officiel ne contient pas ces personnalisations – veuillez le compiler vous-même et le télécharger manuellement comme d'habitude.",
+				"notAvailableOta": "Cette carte ne prend pas en charge la mise à jour du micrologiciel via l'interface web. Veuillez flasher le micrologiciel via le port série.",
+				"buildEntry": "{{date}} – commit :",
+				"installButton": "Installer",
+				"installPrompt": "Installer le micrologiciel du {{date}} (commit {{commit}}) maintenant ?\n\nPlateforme : {{platform}}\nBranche : {{branch}}\nLangue : {{language}}\n\nLe nouveau micrologiciel va maintenant être installé sur votre ESPuino. Cela prend environ une minute - si un ruban Neopixel avec plusieurs LEDs est connecté, une animation de progression (bleue) sera affichée pendant ce temps. S'il n'y a qu'une seule LED, elle clignotera en bleu.",
+				"fetchError": "Impossible de récupérer la liste des micrologiciels."
+			}
 		}
 	},
 	"help": {
@@ -525,6 +541,7 @@
 		"title": "Informations",
 		"softwareversion": "ESPuino {{softwareversion}}",
 		"gitversion": "ESPuino {{gitversion}}",
+		"branch": "Branche : {{branch}}",
 		"arduinoversion": "Version Arduino : {{arduinoversion}} (ESP-IDF {{idfversion}})",
 		"hardware": "Matériel : {{hwmodel}}, Révision {{hwrevision}}, CPU : {{hwfreq}} MHZ",
 		"freeheap": "Mémoire libre : {{freeheap}} octets",

--- a/html/management.html
+++ b/html/management.html
@@ -423,6 +423,22 @@
 			</div>
 		</div>
 	</div>
+	<!-- Modal dialog for GitHub firmware build list -->
+	<div class="modal fade" data-bs-backdrop="static" id="githubBuildListModal" role="dialog">
+		<div class="modal-dialog" role="document">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title" data-i18n="tools.fwupdate.github.title"></h5>
+				</div>
+				<div class="modal-body">
+					<ul class="list-group" id="githubBuildList"></ul>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-primary" data-bs-dismiss="modal" data-i18n="ok"></button>
+				</div>
+			</div>
+		</div>
+	</div>
 	<nav class="mb-4">
 		<div class="container nav nav-tabs" id="nav-tab" role="tablist">
 			<a class="nav-item nav-link main-tab-item" id="nav-control-tab" data-bs-toggle="tab" href="#nav-control"
@@ -1496,6 +1512,30 @@
 					</div>
 				</form>
 			</div>
+			<div class="container" id="githubUpdate">
+				<legend id="legendfwupdategithub" data-i18n="tools.fwupdate.github.title"></legend>
+				<p data-i18n="tools.fwupdate.github.desc"></p>
+				<p id="githubUpdateUnavailableText" class="text-warning" style="display:none;"></p>
+				<div id="githubUpdateAvailable" style="display:none;">
+					<div class="mb-3 d-flex align-items-center flex-wrap gap-2">
+						<label for="githubBranchSel" class="me-1" data-i18n="tools.fwupdate.github.branch"></label>
+						<select class="form-control form-select" id="githubBranchSel" style="width: auto;">
+							<!-- Do not translate those texts! -->
+							<option value="dev">dev</option>
+							<option value="master">master</option>
+						</select>
+						<button type="button" class="btn btn-primary" id="githubCheckButton"
+							data-i18n="tools.fwupdate.github.checkButton"></button>
+					</div>
+					<div id="githubUpdateProgress"
+						class="progress upload-progress-bar position-relative" style="display:none;">
+						<div class="progress-bar" role="progressbar" aria-labelledby="legendfwupdategithub"></div>
+						<div
+							class="label d-flex position-absolute flex-column align-self-center text-center w-100 text-nowrap text-light">
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
 		<!-- ### Tab Help ### -->
 		<div class="tab-pane main-tab-pane fade mb-4" id="nav-help" role="tabpanel" aria-labelledby="nav-help-tab">
@@ -1514,6 +1554,9 @@
 		var ActiveTab = 'nav-rfid-tab';
 		var ActiveSubTab = 'rfid-music-tab';
 		var initialSettingsLoaded = false;
+		// last known-saved led count, to detect a change on save (device restarts to apply it)
+		var lastNumIndicatorLeds = null;
+		var lastNumControlLeds = null;
 		var host = $(location).attr('hostname');
 		var currentOpMode = 0;
 		var language = navigator.language || navigator.userLanguage;
@@ -1899,6 +1942,163 @@
 				}
 			});
 		});
+		/* Firmware Update via GitHub (biologist79/ESPuino-Firmware) */
+		const GITHUB_FW_REPO = "biologist79/ESPuino-Firmware";
+		let githubFirmwareInitialized = false;
+		let githubPlatform = '';
+
+		function showGithubUpdateUnavailable(text) {
+			$('#githubUpdateUnavailableText').text(text).show();
+		}
+
+		async function initGithubFirmwareUpdate() {
+			if (githubFirmwareInitialized) {
+				return;
+			}
+			githubFirmwareInitialized = true;
+			try {
+				let info = await (await fetch("http://" + host + "/info?section=software")).json();
+				const sw = info.software;
+				if (!sw.otaSupported) {
+					showGithubUpdateUnavailable(i18next.t("tools.fwupdate.github.notAvailableOta"));
+					return;
+				}
+				if (sw.customBuild) {
+					showGithubUpdateUnavailable(i18next.t("tools.fwupdate.github.notAvailableCustomBuild"));
+					return;
+				}
+				githubPlatform = sw.platform;
+				$('#githubUpdateAvailable').show();
+				$('#githubCheckButton').on('click', function () {
+					checkGithubFirmwareBuilds();
+				});
+			} catch (e) {
+				console.log("Could not fetch software info for github firmware update", e);
+			}
+		}
+
+		async function checkGithubFirmwareBuilds() {
+			const branch = $('#githubBranchSel').val();
+			// firmware repo languages are DE/EN/FR, matching i18next's 2-letter codes
+			const lang = (i18next.language || 'en').toUpperCase();
+			const path = `Firmwares/${branch}/${githubPlatform}/firmware-${lang}.bin`;
+			const list = $('#githubBuildList');
+			list.empty().append($('<li class="list-group-item"></li>').text(i18next.t("tools.fwupdate.github.searching")));
+			new bootstrap.Modal(document.getElementById('githubBuildListModal')).show();
+			try {
+				const resp = await fetch(`https://api.github.com/repos/${GITHUB_FW_REPO}/commits?path=${encodeURIComponent(path)}&per_page=5&sha=main`);
+				if (!resp.ok) {
+					throw new Error(resp.statusText);
+				}
+				const commits = await resp.json();
+				list.empty();
+				if (!commits.length) {
+					list.append($('<li class="list-group-item"></li>').text(i18next.t("tools.fwupdate.github.noBuilds")));
+					return;
+				}
+				commits.forEach(function (c) {
+					const date = new Date(c.commit.author.date).toLocaleString();
+					// commit message looks like "Firmware built from commit biologist79/ESPuino@<sha>" -
+					// that sha is the original ESPuino commit, not this (firmware repo's own) commit
+					const match = /ESPuino@([0-9a-f]{7,40})/.exec(c.commit.message);
+					const fullSha = match ? match[1] : null;
+					const commitShort = (fullSha || c.sha).substring(0, 10);
+					const label = i18next.t("tools.fwupdate.github.buildEntry", { date: date });
+					const li = $('<li class="list-group-item d-flex justify-content-between align-items-center"></li>');
+					const textSpan = $('<span></span>').append(document.createTextNode(label + " "));
+					if (fullSha) {
+						textSpan.append($('<a target="_blank" rel="noopener noreferrer"></a>')
+							.attr('href', `https://github.com/biologist79/ESPuino/commit/${fullSha}`)
+							.text(commitShort));
+					} else {
+						textSpan.append(document.createTextNode(commitShort));
+					}
+					li.append(textSpan);
+					const btn = $('<button type="button" class="btn btn-sm btn-primary"></button>').text(i18next.t("tools.fwupdate.github.installButton"));
+					btn.on('click', function () {
+						const prompt = i18next.t("tools.fwupdate.github.installPrompt", { date: date, commit: commitShort, platform: githubPlatform, branch: branch, language: lang });
+						if (confirm(prompt)) {
+							installGithubFirmware(c.sha, path);
+						}
+					});
+					li.append(btn);
+					list.append(li);
+				});
+			} catch (e) {
+				list.empty().append($('<li class="list-group-item text-danger"></li>').text(i18next.t("tools.fwupdate.github.fetchError")));
+				console.log("Error fetching github firmware builds", e);
+			}
+		}
+
+		async function installGithubFirmware(sha, path) {
+			const rawUrl = `https://raw.githubusercontent.com/${GITHUB_FW_REPO}/${sha}/${path}`;
+			const gup = $('#githubUpdateProgress');
+			gup.show().addClass('bg-primary bg-opacity-75');
+			$('.progress-bar', gup).removeClass('bg-danger').css('width', '0%');
+			$(".label", gup).text(i18next.t("files.upload.timeCalc"));
+			let blob;
+			try {
+				const blobResp = await fetch(rawUrl);
+				if (!blobResp.ok) {
+					throw new Error(blobResp.statusText);
+				}
+				blob = await blobResp.blob();
+			} catch (e) {
+				gup.removeClass('bg-primary bg-opacity-75');
+				$('.progress-bar', gup).addClass('bg-danger');
+				$(".label", gup).text(i18next.t("tools.fwupdate.github.fetchError"));
+				toaster.error(i18next.t("tools.fwupdate.github.fetchError"));
+				console.log("Error downloading github firmware", e);
+				return;
+			}
+			const data = new FormData();
+			data.append('firmwareUpload', blob, 'firmware.bin');
+			const startTime = new Date().getTime();
+			$.ajax({
+				url: '/update',
+				type: 'POST',
+				data: data,
+				contentType: false,
+				processData: false,
+				xhr: function () {
+					var xhr = new window.XMLHttpRequest();
+					xhr.upload.addEventListener("progress", function (evt) {
+						if (evt.lengthComputable) {
+							const now = new Date().getTime();
+							const percent = parseInt(evt.loaded * 100 / evt.total);
+							const elapsed = (now - startTime) / 1000;
+							let progressText = i18next.t("files.upload.timeCalc");
+							if (elapsed) {
+								const bps = evt.loaded / elapsed;
+								const kbps = bps / 1024;
+								const remaining = Math.round((evt.total - evt.loaded) / bps);
+								progressText = i18next.t("files.upload.progress", {
+									percent: percent,
+									remaining: {
+										unit: (remaining > 60) ? i18next.t("files.upload.minutes", { count: Math.round(remaining / 60) }) : i18next.t("files.upload.seconds"),
+										value: (remaining > 60) ? Math.round(remaining / 60) : ((remaining > 2) ? remaining : i18next.t("files.upload.fewSec"))
+									},
+									speed: kbps.toFixed(2)
+								});
+							}
+							$(".progress-bar", gup).css('width', percent + "%");
+							$(".label", gup).text(progressText);
+						}
+					}, false);
+					return xhr;
+				},
+				success: function () {
+					$(".label", gup).text(i18next.t("files.upload.success", { elapsed: "00:00", speed: "0,00" }));
+					restartDevice();
+				},
+				error: function (request) {
+					gup.removeClass('bg-primary bg-opacity-75');
+					$('.progress-bar', gup).addClass('bg-danger');
+					$(".label", gup).text(i18next.t("files.upload.error") + ": " + request.statusText);
+					toaster.error(i18next.t("files.upload.error") + ': ' + request.statusText);
+				}
+			});
+		}
 		/* File Upload */
 		$('#explorerUploadForm').submit(function (e) {
 			e.preventDefault();
@@ -2601,6 +2801,8 @@
 				$('#atmoBrightness').bootstrapSlider('setValue', ledSettings.atmoBrightness);
 				document.getElementById('led_numIndicator').value = ledSettings.numIndicator;
 				document.getElementById('led_numControl').value = ledSettings.numControl;
+				lastNumIndicatorLeds = ledSettings.numIndicator;
+				lastNumControlLeds = ledSettings.numControl;
 				listControlColors(ledSettings.numControl, ledSettings.controlColors);
 				document.getElementById('led_idleDots').value = ledSettings.numIdleDots;
 				$('#led_hueStart').bootstrapSlider('setValue', ledSettings.hueStart);
@@ -2884,6 +3086,7 @@
 		function onToolsTabOpened() {
 			console.log("tools tab opened!");
 			rebuildRFIDList();
+			initGithubFirmwareUpdate();
 		}
 		const config = {
 			attributes: true
@@ -2951,6 +3154,13 @@
 
 		async function genSettings(clickedId) {
 			lastIdclicked = clickedId;
+			const newNumIndicatorLeds = Number(document.getElementById("led_numIndicator").value);
+			const newNumControlLeds = Number(document.getElementById("led_numControl").value);
+			if ((lastNumIndicatorLeds !== null) && ((newNumIndicatorLeds !== lastNumIndicatorLeds) || (newNumControlLeds !== lastNumControlLeds))) {
+				toaster.warning(i18next.t("toast.ledCountRestart"));
+			}
+			lastNumIndicatorLeds = newNumIndicatorLeds;
+			lastNumControlLeds = newNumControlLeds;
 			var myObj = {
 				"general": {
 					initVolume: Number($('#initialVolume').val()),
@@ -3441,6 +3651,9 @@
 			}) + "<br>";
 			content += i18next.t("systeminfo.gitversion", {
 				gitversion: info.software.git
+			}) + "<br>";
+			content += i18next.t("systeminfo.branch", {
+				branch: info.software.branch
 			}) + "<br>";
 			content += i18next.t("systeminfo.arduinoversion", {
 				arduinoversion: info.software.arduino,

--- a/platformInfo.py
+++ b/platformInfo.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+"""PlatformIO script to generate a platforminfo.h file and adds its path to
+   CPPPATH.
+
+Exposes the PlatformIO environment name (e.g. "complete",
+"lolin_d32_pro_sdmmc_pe") to the firmware at compile time, so the web
+interface can match the running build against the per-platform folders of
+https://github.com/biologist79/ESPuino-Firmware. Also records whether a
+settings-override.h or platformio-override.ini was used for this build: such
+a build no longer matches the official prebuilt firmware for its platform
+(e.g. custom pin mappings), so the web interface must not offer it as a
+drop-in replacement.
+
+Note: see gitVersion.py for why this is a generated header instead of a
+dynamic build flag (avoids forcing a full rebuild on every build).
+"""
+
+from pathlib import Path
+
+Import("env")  # pylint: disable=undefined-variable
+
+
+OUTPUT_PATH = (
+    Path(env.subst("$BUILD_DIR")) / "generated" / "platforminfo.h"
+)  # pylint: disable=undefined-variable
+
+PROJECT_DIR = Path(env.subst("$PROJECT_DIR"))  # pylint: disable=undefined-variable
+
+TEMPLATE = """
+#ifndef __PLATFORM_INFO_H__
+    #define __PLATFORM_INFO_H__
+    constexpr const char espuinoPlatform[] = "{platform}";
+    constexpr bool espuinoCustomBuild = {custom_build};
+#endif
+"""
+
+
+def is_custom_build():
+    """Returns True if this build used settings-override.h or platformio-override.ini."""
+    return (PROJECT_DIR / "src" / "settings-override.h").is_file() or (
+        PROJECT_DIR / "platformio-override.ini"
+    ).is_file()
+
+
+def generate():
+    """Generates header file."""
+    print("GENERATING PLATFORM INFO HEADER FILE")
+    platform = env.subst("$PIOENV")  # pylint: disable=undefined-variable
+    custom_build = is_custom_build()
+    print(f'  platform="{platform}" customBuild={custom_build} -> {OUTPUT_PATH}')
+    OUTPUT_PATH.parent.mkdir(exist_ok=True, parents=True)
+    with OUTPUT_PATH.open("w") as output_file:
+        output_file.write(
+            TEMPLATE.format(
+                platform=platform,
+                custom_build="true" if custom_build else "false",
+            )
+        )
+
+
+generate()
+env.Append(CPPPATH=[str(OUTPUT_PATH.parent)])  # pylint: disable=undefined-variable

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,6 +28,7 @@ monitor_filters = esp32_exception_decoder ; you can use ESP Decoder from VSC-Ext
 extra_scripts =
     pre:install_dependencies.py
     pre:gitVersion.py
+    pre:platformInfo.py
     pre:updateSdkConfig.py
     pre:processHtml.py
 lib_deps =

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -36,6 +36,11 @@ static uint8_t Led_savedBrightness;
 // global led settings
 static LedSettings gLedSettings;
 
+// the strip buffer bound to FastLED via addLeds(); file-scope (rather than local to Led_Task)
+// so Led_ShowOtaProgress() can draw into it directly while Led_Task is suspended during an
+// OTA upload (see System_PauseTasksDuringUpload())
+static CRGB *leds = nullptr;
+
 TaskHandle_t Led_TaskHandle;
 static void Led_Task(void *parameter);
 static uint8_t Led_Address(uint8_t number);
@@ -396,7 +401,6 @@ bool CheckForPowerButtonAnimation() {
 #ifdef NEOPIXEL_ENABLE
 static void Led_Task(void *parameter) {
 	static uint8_t lastLedBrightness = gLedSettings.Led_Brightness;
-	static CRGB *leds = nullptr;
 	static CRGBSet *indicator = nullptr;
 
 	uint8_t numIndicatorLeds = gLedSettings.numIndicatorLeds;
@@ -423,14 +427,17 @@ static void Led_Task(void *parameter) {
 			Led_LoadSettings(gLedSettings);
 			// number of indicator/control leds changed
 			if (((gLedSettings.numIndicatorLeds + gLedSettings.numControlLeds) != (numIndicatorLeds + numControlLeds)) || (gLedSettings.numControlLeds != numControlLeds)) {
-				FastLED.clear(true);
-				numIndicatorLeds = gLedSettings.numIndicatorLeds;
-				numControlLeds = gLedSettings.numControlLeds;
-				delete[] leds;
-				delete indicator;
-				leds = new CRGB[numIndicatorLeds + numControlLeds];
-				indicator = new CRGBSet(leds, numIndicatorLeds);
-				FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, numIndicatorLeds + numControlLeds).setCorrection(TypicalSMD5050);
+				// FastLED's SPI/RMT WS2812 driver lazily creates its internal strip object,
+				// sized for whatever pixel count was in effect on the very first show() call,
+				// and never resizes it afterwards. Calling addLeds() again with a different
+				// count here doesn't reset that internal state, so every following show()
+				// call hits a hard FASTLED_ASSERT (mLedStrip->numPixels() != pixels.size()).
+				// Request a clean restart instead of trying to hot-reallocate the strip, and
+				// stop touching leds/indicator/FastLED until then (their sizes no longer
+				// match gLedSettings).
+				Log_Println("Number of LEDs changed, restarting to apply..", LOGLEVEL_NOTICE);
+				System_Restart();
+				vTaskDelay(portMAX_DELAY);
 			}
 		}
 
@@ -1316,5 +1323,38 @@ void Led_TaskResume(void) {
 	if (Led_TaskHandle != NULL) {
 		vTaskResume(Led_TaskHandle);
 	}
+#endif
+}
+
+// Shows OTA-update progress on the indicator LEDs while Led_Task is suspended (see
+// Led_TaskPause(), called from System_PauseTasksDuringUpload()). No-op if Neopixel is
+// disabled or the strip hasn't been initialized yet. With a single indicator LED (which
+// can't show a fill level), blinks it instead, matching how other animations handle that case.
+void Led_ShowOtaProgress(uint8_t percent) {
+#ifdef NEOPIXEL_ENABLE
+	if ((leds == nullptr) || (gLedSettings.numIndicatorLeds == 0)) {
+		return;
+	}
+	if (percent > 100) {
+		percent = 100;
+	}
+	if (gLedSettings.numIndicatorLeds == 1) {
+		// a single LED can't show a fill level; blink it instead, like other single-LED animations
+		static uint32_t lastToggle = 0;
+		static bool blinkOn = false;
+		const uint32_t now = millis();
+		if (now - lastToggle >= 250) {
+			lastToggle = now;
+			blinkOn = !blinkOn;
+		}
+		leds[0] = blinkOn ? CRGB::Blue : CRGB::Black;
+		FastLED.show();
+		return;
+	}
+	const uint8_t litCount = (uint8_t) (((uint16_t) percent * gLedSettings.numIndicatorLeds) / 100);
+	for (uint8_t i = 0; i < gLedSettings.numIndicatorLeds; i++) {
+		leds[i] = (i < litCount) ? CRGB::Blue : CRGB::Black;
+	}
+	FastLED.show();
 #endif
 }

--- a/src/Led.h
+++ b/src/Led.h
@@ -99,6 +99,7 @@ uint8_t Led_GetBrightness(void);
 void Led_SetBrightness(uint8_t value);
 void Led_TaskPause(void);
 void Led_TaskResume(void);
+void Led_ShowOtaProgress(uint8_t percent);
 
 void Led_SetNightmode(bool enabled);
 bool Led_GetNightmode();

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -25,6 +25,7 @@
 #include "System.h"
 #include "Wlan.h"
 #include "freertos/ringbuf.h"
+#include "platforminfo.h"
 #include "revision.h"
 #include "soc/timer_group_reg.h"
 #include "soc/timer_group_struct.h"
@@ -499,6 +500,11 @@ void webserverStart(void) {
 
 				Update.write(data, len);
 				Log_Print(".", LOGLEVEL_NOTICE, false);
+
+				const size_t contentLength = request->contentLength();
+				if (contentLength > 0) {
+					Led_ShowOtaProgress((uint8_t) (((index + len) * 100) / contentLength));
+				}
 
 				if (final) {
 					Update.end(true);
@@ -1375,8 +1381,16 @@ void handleGetInfo(AsyncWebServerRequest *request) {
 		JsonObject softwareObj = infoObj["software"].to<JsonObject>();
 		softwareObj["version"] = (String) softwareRevision;
 		softwareObj["git"] = (String) gitRevision;
+		softwareObj["branch"] = (String) gitBranch;
 		softwareObj["arduino"] = String(ESP_ARDUINO_VERSION_MAJOR) + "." + String(ESP_ARDUINO_VERSION_MINOR) + "." + String(ESP_ARDUINO_VERSION_PATCH);
 		softwareObj["idf"] = String(ESP.getSdkVersion());
+		softwareObj["platform"] = (String) espuinoPlatform;
+		softwareObj["customBuild"] = espuinoCustomBuild;
+	#ifdef BOARD_HAS_16MB_FLASH_AND_OTA_SUPPORT
+		softwareObj["otaSupported"] = true;
+	#else
+		softwareObj["otaSupported"] = false;
+	#endif
 	}
 	// hardware
 	if ((section == "") || (section == "hardware")) {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1386,11 +1386,11 @@ void handleGetInfo(AsyncWebServerRequest *request) {
 		softwareObj["idf"] = String(ESP.getSdkVersion());
 		softwareObj["platform"] = (String) espuinoPlatform;
 		softwareObj["customBuild"] = espuinoCustomBuild;
-	#ifdef BOARD_HAS_16MB_FLASH_AND_OTA_SUPPORT
+#ifdef BOARD_HAS_16MB_FLASH_AND_OTA_SUPPORT
 		softwareObj["otaSupported"] = true;
-	#else
+#else
 		softwareObj["otaSupported"] = false;
-	#endif
+#endif
 	}
 	// hardware
 	if ((section == "") || (section == "hardware")) {


### PR DESCRIPTION
Adds a way to update firmware directly from the web UI's Tools tab, without leaving the browser or manually downloading a `.bin` file first:

- Pick a branch (`dev`/`master`), then "Check for updates" lists the last 5 builds for that branch from [biologist79/ESPuino-Firmware](https://github.com/biologist79/ESPuino-Firmware) in a modal (date + linked original ESPuino commit).
- Language defaults to the current UI language; picking "Install" shows a confirmation with date, commit, platform, branch and language before doing anything.
- Installing fetches the `.bin` as a blob in the browser and posts it to the existing `/update` endpoint - no device-side download code, no extra TLS/heap usage on the ESP32. The existing manual file-upload stays exactly as it was.

Two new build-time facts make this safe to offer only where it actually applies:

- `platformInfo.py` (new, mirrors `gitVersion.py`) generates `platforminfo.h` with the PlatformIO environment name (matches the firmware repo's per-platform folder names, e.g. `complete`, `lolin_d32_pro_sdmmc_pe`) and whether `settings-override.h`/`platformio-override.ini` were used for this build. A custom build no longer matches the official prebuilt firmware for its platform, so the web UI hides the GitHub-update section for those builds (and for platforms with no matching folder in the firmware repo, or without OTA support at all) instead of offering a possibly-wrong firmware as a one-click install.
- `gitVersion.py` now also records the current git branch, shown in the existing "Information" panel.

## Also included

While testing this, two things came up that are directly tied to it:

- **OTA progress on the LED ring.** `Led_TaskPause()` (called during any upload, manual or GitHub-based) blanks the ring and suspends `Led_Task` to free CPU. `Led_ShowOtaProgress()` now draws directly into the (now file-scope) strip buffer while the task is idle, filling the ring proportionally to upload progress; with a single indicator LED it blinks instead, matching how other animations already handle that case.
- **Fix for a live LED-count crash.** Testing the single-LED case surfaced that changing the number of LEDs at runtime (completely unrelated to OTA) already reliably crashed: FastLED's ESP32 SPI/RMT driver lazily creates its internal strip object sized for whatever pixel count was in effect on the very first `show()` call and never resizes it, so calling `addLeds()` again with a different count doesn't help - every following `show()` call hits `FASTLED_ASSERT(mLedStrip->numPixels() == pixels.size())`. Changing the LED count now triggers a restart instead of trying to hot-reallocate the strip, with a warning toast beforehand.