### PR TITLE
AudioPlayer: don't enable setOutput16Bit() — garbles MP3 on classic ESP32

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -397,7 +397,9 @@ void AudioPlayer_Init(void) {
 
 	AudioPlayer_CurrentVolume = AudioPlayer_GetInitVolume();
 	// DMA-settings must be adjusted before setting the pinout
-	audio->setOutput16Bit(true); // to save dma-buffer and because we just don't need more than 16 bit
+	// Do NOT enable setOutput16Bit() on classic ESP32: the v3.4.6 16-bit output path
+	// garbles MP3 playback on WROVER (A/B-verified on a LOLIN D32 Pro). 32-bit output
+	// is clean. Re-enable once the upstream 16-bit path is fixed.
 	audio->settings.DMA_DESC_NUM = 32;
 	audio->settings.DMA_FRAME_NUM = 256; // not too high, so safe SRAM
 	if (System_GetOperationMode() == OPMODE_BLUETOOTH_SOURCE) {


### PR DESCRIPTION
The audioI2S v3.4.6 fork (used on dev) added a 16-bit output path via setOutput16Bit(), and AudioPlayer_Init opts into it. On the classic ESP32 (WROVER / LOLIN D32 Pro) that path garbles MP3 playback continuously, independent of volume.

A/B-verified on hardware: removing only this one line — staying on 32-bit output, everything else v3.4.6 intact — restores clean audio. So keep 32-bit output on classic ESP32 until the upstream 16-bit path is fixed.

See: https://github.com/biologist79/ESPuino/issues/423