### PR TITLE
Fix connection watchdog false-positive and spurious success toasts

### DIFF
--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -19,10 +19,13 @@
 	"toast": {
 		"rfidDetect": "RFID Tag mit {{rfidId}} erkannt.",
 		"success": "Aktion erfolgreich ausgeführt.",
-		"conlost": "Die Verbindung zum ESPuino ist unterbrochen! Bitte Seite neu laden.",
 		"dropout": "Langsamer Stream, Aussetzer möglich.",
 		"saved": "Einstellungen gespeichert.",
 		"ledCountRestart": "Die Anzahl der LEDs wurde geändert. Der ESPuino startet neu, um das zu übernehmen."
+	},
+	"status": {
+		"connected": "Verbindung zum ESPuino: OK",
+		"disconnected": "Verbindung zum ESPuino unterbrochen - versuche erneut zu verbinden..."
 	},
 	"nav": {
 		"control": "Steuerung",
@@ -412,9 +415,9 @@
 				"auto": "Auto-detect",
 				"mfrc522_spi": "MFRC522 (SPI)",
 				"mfrc522_i2c": "MFRC522 (I2C)",
-				"pn5180": "PN5180"
+				"pn5180": "PN5180",
+				"description": "Wähle den Typ des RFID readers. Auto-detect wird versuchen den Reader automatisch zu erkennen."
 			},
-			"description": "Wähle den Typ des RFID readers. Auto-detect wird versuchen den Reader automatisch zu erkennen.",
 			"pn5180Lpcd": "PN5180 LPCD aktivieren",
 			"pn5180LpcdExp": "Aktiviert Low Power Card Detection für PN5180 RFID Reader. Nur möglich, wenn Lötbrücken richtig gesetzt sind.",
 			"mfrc522Gain": "MFRC522 Gain",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -19,10 +19,13 @@
 	"toast": {
 		"rfidDetect": "RFID tag {{rfidId}} detected.",
 		"success": "Action performed successfully.",
-		"conlost": "Connection to ESPuino broken! Please reload website.",
 		"dropout": "slow stream, dropouts are possible.",
 		"saved": "Settings saved.",
 		"ledCountRestart": "The number of LEDs was changed. ESPuino will restart to apply it."
+	},
+	"status": {
+		"connected": "Connection to ESPuino: OK",
+		"disconnected": "Connection to ESPuino lost - trying to reconnect..."
 	},
 	"nav": {
 		"control": "Control",
@@ -412,9 +415,9 @@
 				"auto": "Auto-detect",
 				"mfrc522_spi": "MFRC522 (SPI)",
 				"mfrc522_i2c": "MFRC522 (I2C)",
-				"pn5180": "PN5180"
+				"pn5180": "PN5180",
+				"description": "Select the type of RFID reader connected to your ESPuino. Auto-detect will try to determine the connected reader type automatically."
 			},
-			"description": "Select the type of RFID reader connected to your ESPuino. Auto-detect will try to determine the connected reader type automatically.",
 			"pn5180Lpcd": "Enable PN5180 LPCD",
 			"pn5180LpcdExp": "Enable Low Power Card Detection for PN5180 RFID reader. Only possible if solder-pins are set correctly.",
 			"mfrc522Gain": "MFRC522 Gain",

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -19,10 +19,13 @@
 	"toast": {
 		"rfidDetect": "Étiquette RFID {{rfidId}} détectée.",
 		"success": "Action effectuée avec succès.",
-		"conlost": "Connexion à l'ESPuino perdue! Veuillez recharger la page.",
 		"dropout": "flux lent, des interruptions sont possibles.",
 		"saved": "Paramètres enregistrés.",
 		"ledCountRestart": "Le nombre de LEDs a été modifié. L'ESPuino va redémarrer pour appliquer ce changement."
+	},
+	"status": {
+		"connected": "Connexion à l'ESPuino : OK",
+		"disconnected": "Connexion à l'ESPuino perdue - tentative de reconnexion..."
 	},
 	"nav": {
 		"control": "Contrôle",
@@ -412,9 +415,9 @@
 				"auto": "Auto-detect",
 				"mfrc522_spi": "MFRC522 (SPI)",
 				"mfrc522_i2c": "MFRC522 (I2C)",
-				"pn5180": "PN5180"
+				"pn5180": "PN5180",
+				"description": "Sélectionnez le type de lecteur RFID connecté à votre ESPuino. La détection automatique tentera de déterminer le type de lecteur connecté automatiquement."
 			},
-			"description": "Sélectionnez le type de lecteur RFID connecté à votre ESPuino. La détection automatique tentera de déterminer le type de lecteur connecté automatiquement.",
 			"pn5180Lpcd": "Activer PN5180 LPCD",
 			"pn5180LpcdExp": "Active la détection de carte à faible puissance pour le lecteur RFID PN5180. Uniquement possible si les broches de soudure sont correctement configurées.",
 			"mfrc522Gain": "MFRC522 Gain",

--- a/html/management.html
+++ b/html/management.html
@@ -208,6 +208,38 @@
 			/* Make sure the jstree context menu is most top */
 			z-index: 99999;
 		}
+
+		@keyframes heartbeat-pulse {
+			0% {
+				transform: scale(1);
+			}
+
+			30% {
+				transform: scale(1.5);
+			}
+
+			100% {
+				transform: scale(1);
+			}
+		}
+
+		#connectionStatusIndicator {
+			font-size: 1.4em;
+		}
+
+		#connectionStatusIndicator.heartbeat-pulse {
+			display: inline-block;
+			animation: heartbeat-pulse 0.3s ease-out;
+		}
+
+		/* text-success/text-danger are too dark/muted against the navbar's blue background */
+		#connectionStatusIndicator.connection-ok {
+			color: #4ade80;
+		}
+
+		#connectionStatusIndicator.connection-lost {
+			color: #ff6b6b;
+		}
 	</style>
 </head>
 
@@ -227,7 +259,10 @@
 				<span id="navbar-heading" data-i18n="title"></span>
 			</a>
 			<div class="collapse navbar-collapse justify-content-end">
-				<ul class="navbar-nav">
+				<ul class="navbar-nav align-items-center">
+					<li class="nav-item me-3">
+						<i class="fas fa-heartbeat" id="connectionStatusIndicator" title=""></i>
+					</li>
 					<li class="nav-item">
 						<button class="btn dropdown-toggle border-0 text-white" id="menuToggle"
 							data-bs-toggle="dropdown" aria-expanded="false">
@@ -1636,6 +1671,7 @@
 			error: msg => toaster.toast(msg, 'text-bg-danger')
 		}
 
+
 		i18next.use(i18nextHttpBackend).init({
 			backend: {
 				loadPath: "http://" + host + "/locales/{{lng}}.json"
@@ -2546,6 +2582,9 @@
 				clearInterval(getTrackProgressInterval);
 				pingInterval = setInterval(ping, 3000);
 				setTrackProgressInterval = setInterval(getTrackProgress, 1000);
+				// arm the watchdog now too, so a connection that dies before its first pong
+				// arrives is still caught (not just ones that were alive at some point)
+				armConnectionWatchdog();
 				// clear old socket messages
 				socket.sendBuffer = [];
 				socket.send('{"settings":{"settings":"settings"}}'); // request settings
@@ -2556,6 +2595,13 @@
 			socket.onclose = function (e) {
 				console.log('Socket is closed. Reconnect will be attempted in 5 seconds.', e.reason);
 				socket = null;
+				// stop ping()/getTrackProgress() - otherwise they keep firing against a null
+				// socket (or a dead server) until the reconnect below succeeds and re-arms them
+				clearInterval(pingInterval);
+				clearInterval(getTrackProgressInterval);
+				// a definitive close is known for certain - mark it right away instead of
+				// waiting for the watchdog timeout below
+				setConnectionStatus(false);
 				setTimeout(function () {
 					connect();
 				}, 5000);
@@ -3104,6 +3150,9 @@
 		toolsTabObserver.observe(toolsTab, config);
 
 		async function ping() {
+			if (!socket) {
+				return;
+			}
 			var myObj = {
 				"ping": {
 					ping: 'ping'
@@ -3111,13 +3160,35 @@
 			};
 			var myJSON = JSON.stringify(myObj);
 			socket.send(myJSON);
+			// sending doesn't confirm the connection is alive - only a received pong does
+		}
+
+		function setConnectionStatus(connected) {
+			const icon = $('#connectionStatusIndicator');
+			icon.toggleClass('connection-ok', connected).toggleClass('connection-lost', !connected);
+			icon.attr('title', i18next.t(connected ? "status.connected" : "status.disconnected"));
+		}
+
+		function armConnectionWatchdog() {
+			// called on a positive confirmation (a pong, or having just connected) - the
+			// connection is known good right now, so mark it OK and give it a fresh window
+			// before considering it stale again
+			setConnectionStatus(true);
+			clearTimeout(tm);
 			tm = setTimeout(function () {
-				toaster.warning(i18next.t("toast.conlost"));
+				setConnectionStatus(false);
 			}, 5000);
 		}
 
 		function pong() {
-			clearTimeout(tm);
+			armConnectionWatchdog();
+			// brief pulse on the heartbeat icon to show a pong actually just came in - remove
+			// the class first and force a reflow so the animation restarts even if the previous
+			// pulse (3s ago) already finished and left the class in place
+			const icon = document.getElementById('connectionStatusIndicator');
+			icon.classList.remove('heartbeat-pulse');
+			void icon.offsetWidth;
+			icon.classList.add('heartbeat-pulse');
 		}
 		async function getTrackProgress() {
 			if (ActiveTab !== 'nav-control-tab') {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1015,7 +1015,7 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 			lastPongTimestamp = millis();
 			Web_SendWebsocketData(0, WebsocketCodeType::Pong);
 		}
-		return WebsocketCodeType::Error;
+		return WebsocketCodeType::Silent;
 	} else if (doc["controls"].is<JsonObject>()) {
 		// Prevent website control over volume and player actions in Bluetooth-Speaker mode
 		// we could still allow sone special commands, but it's cleaner this way
@@ -1026,7 +1026,12 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 		const JsonObject controlsObj = doc["controls"].as<JsonObject>();
 		if (controlsObj["set_volume"].is<uint8_t>()) {
 			uint8_t new_vol = controlsObj["set_volume"].as<uint8_t>();
-			AudioPlayer_SetVolume(new_vol);
+			AudioPlayer_SetVolume(new_vol); // already broadcasts its own Volume update
+			if (!controlsObj["action"].is<uint8_t>()) {
+				// pure volume-slider drag (no button action alongside it) - don't also send
+				// back an Ok ack, or dragging the slider spams a "success" toast per tick
+				return WebsocketCodeType::Silent;
+			}
 		}
 		if (controlsObj["action"].is<uint8_t>()) {
 			uint8_t cmd = controlsObj["action"].as<uint8_t>();
@@ -1034,14 +1039,19 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 		}
 	} else if (doc["trackinfo"].is<JsonObject>()) {
 		Web_SendWebsocketData(0, WebsocketCodeType::TrackInfo);
+		return WebsocketCodeType::Silent;
 	} else if (doc["coverimg"].is<JsonObject>()) {
 		Web_SendWebsocketData(0, WebsocketCodeType::CoverImg);
+		return WebsocketCodeType::Silent;
 	} else if (doc["volume"].is<JsonObject>()) {
 		Web_SendWebsocketData(0, WebsocketCodeType::Volume);
+		return WebsocketCodeType::Silent;
 	} else if (doc["settings"].is<JsonObject>()) {
 		Web_SendWebsocketData(0, WebsocketCodeType::Settings);
+		return WebsocketCodeType::Silent;
 	} else if (doc["ssids"].is<JsonObject>()) {
 		Web_SendWebsocketData(0, WebsocketCodeType::Ssid);
+		return WebsocketCodeType::Silent;
 	} else if (doc["trackProgress"].is<JsonObject>()) {
 		// Prevent seeking in Bluetooth mode
 		if (!System_IsWebControlAllowed()) {
@@ -1054,6 +1064,7 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 			gPlayProperties.currentRelPos = trackObj["posPercent"].as<uint8_t>();
 		}
 		Web_SendWebsocketData(0, WebsocketCodeType::TrackProgress);
+		return WebsocketCodeType::Silent;
 	}
 
 	return WebsocketCodeType::Ok;
@@ -1482,7 +1493,7 @@ void handlePostSettings(AsyncWebServerRequest *request, JsonVariant &json) {
 	const JsonObject &jsonObj = json.as<JsonObject>();
 	WebsocketCodeType res = JSONToSettings(jsonObj);
 	if (res != WebsocketCodeType::Error) {
-		if (res != WebsocketCodeType::Ok) {
+		if (res != WebsocketCodeType::Ok && res != WebsocketCodeType::Silent) {
 			Web_SendWebsocketData(0, res);
 		}
 		request->send(200);
@@ -1689,10 +1700,8 @@ void onWebsocketEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsE
 			// Serial.printf("ws[%s][%u] %s-message[%llu]: ", server->url(), client->id(), (info->opcode == WS_TEXT) ? "text" : "binary", info->len);
 
 			WebsocketCodeType result = processJsonRequest((char *) data);
-			if (result != WebsocketCodeType::Error) {
-				if (data && (strncmp((char *) data, "track", 5))) { // Don't send back ok-feedback if track's name is requested in background
-					Web_SendWebsocketData(client->id(), result);
-				}
+			if (result != WebsocketCodeType::Error && result != WebsocketCodeType::Silent) {
+				Web_SendWebsocketData(client->id(), result);
 			}
 
 			if (info->opcode == WS_TEXT) {

--- a/src/Web.h
+++ b/src/Web.h
@@ -15,7 +15,11 @@ typedef enum class WebsocketCode {
 	OperationMode,
 	NotAllowedInCurrentMode,
 	BluetoothScanInProgress,
-	BluetoothScanComplete
+	BluetoothScanComplete,
+	// Request was a read-only data fetch (ssids/settings/trackinfo/coverimg/volume/...) that
+	// already sent its own specific response - the caller should not also forward Ok/an ack
+	// for it, unlike a genuine settings-save or control action.
+	Silent
 } WebsocketCodeType;
 
 void Web_Cyclic(void);


### PR DESCRIPTION
The ping/pong watchdog reset its timeout on every outgoing ping instead of only on a confirmed pong, so a delayed pong left a stale timeout that fired a false "connection lost" warning later on. Replaced with armConnectionWatchdog(), which only (re-)arms on a positive confirmation (pong or initial connect).

Also clear the ping/track-progress intervals on socket close to avoid a crash from sending on a null socket, and replace the repeated "connection lost" toast (which was silently swallowed by the toast de-duplication logic) with a **persistent heartbeat icon in the navbar that pulses on each pong**.

Additionally, several read-only websocket requests (settings, ssids, trackinfo, coverimg, volume, trackProgress, ping, and plain volume-slider drags) fell through to a generic Ok response after already sending their own specific reply, triggering a redundant "action performed successfully" toast. Added a new Silent WebsocketCodeType so these no longer send a second ack, replacing a broken strncmp-based heuristic that could never match.

Fixed a misplaced i18n key (general.rfid.readerType.description) that was nested incorrectly, causing a missing-key warning in the console.