### PR TITLE
Bt: small memory tweaks

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ extra_scripts =
     pre:updateSdkConfig.py
     pre:processHtml.py
 lib_deps =
-	https://github.com/Joe91/ESP32-audioI2S.git#14c64e462acb1daa117b1271d01e9af895a96053 ;v3.4.7e
+	https://github.com/schreibfaul1/ESP32-audioI2S.git#f43dcba2abc3e69ff9f4b166d7295ed09c3b49fa ;v3.4.7h
 	https://github.com/madhephaestus/ESP32Encoder.git#7501cb47ec702c43de3c64df56d0b10930b9bc70 ; v0.12.0
 	https://github.com/Joe91/ESP-FTP-Server-Lib.git#517a2c90876659bfd6692d1f464784a05296e8d8 ; v1.0.1
 	https://github.com/FastLED/FastLED.git#20667c3a6413ed46a828f78ec95fb57e58d753f8 ; v3.10.3

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ extra_scripts =
     pre:updateSdkConfig.py
     pre:processHtml.py
 lib_deps =
-	https://github.com/schreibfaul1/ESP32-audioI2S.git#f43dcba2abc3e69ff9f4b166d7295ed09c3b49fa ;v3.4.7h
+	https://github.com/Joe91/ESP32-audioI2S.git#3c2a6b804afcb796fdefc755570ac28f6198d5e5 ;v3.4.7h
 	https://github.com/madhephaestus/ESP32Encoder.git#7501cb47ec702c43de3c64df56d0b10930b9bc70 ; v0.12.0
 	https://github.com/Joe91/ESP-FTP-Server-Lib.git#517a2c90876659bfd6692d1f464784a05296e8d8 ; v1.0.1
 	https://github.com/FastLED/FastLED.git#20667c3a6413ed46a828f78ec95fb57e58d753f8 ; v3.10.3

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,331 +1,92 @@
-# This file was generated using idf.py save-defconfig or menuconfig [D] key. It can be edited manually.
-# Espressif IoT Development Framework (ESP-IDF)  Project Minimal Configuration
-#
-
-#
-# Bootloader config
-#
-
-#
-# Application Rollback
-#
 CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
-# end of Application Rollback
-
-#
-# Log
-#
 CONFIG_BOOTLOADER_LOG_LEVEL_NONE=y
-# end of Log
-
 CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP=y
-# end of Bootloader config
-
-#
-# Serial flasher config
-#
 CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
 CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
 CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
-# end of Serial flasher config
-
-#
-# Arduino Configuration
-#
 CONFIG_AUTOSTART_ARDUINO=y
 CONFIG_ARDUINO_EVENT_RUN_CORE0=y
 CONFIG_ARDUINO_SERIAL_EVENT_RUN_CORE0=y
-
-#
-# Debug Log Configuration
-#
 CONFIG_ARDUHAL_ESP_LOG=y
-# end of Debug Log Configuration
-# end of Arduino Configuration
-
-#
-# Compiler options
-#
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y
 CONFIG_COMPILER_OPTIMIZATION_CHECKS_SILENT=y
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_STACK_CHECK_MODE_NORM=y
-# end of Compiler options
-
-#
-# Component config
-#
-
-#
-# Bluetooth
-#
 CONFIG_BT_ENABLED=y
-
-#
-# Bluedroid Options
-#
-CONFIG_BT_BTC_TASK_STACK_SIZE=4096
-CONFIG_BT_BTU_TASK_STACK_SIZE=4096
+CONFIG_BT_BTU_TASK_STACK_SIZE=3072
 CONFIG_BT_CLASSIC_ENABLED=y
 CONFIG_BT_A2DP_ENABLE=y
 CONFIG_BT_SPP_ENABLED=y
-CONFIG_BT_BLE_ENABLED=n
+# CONFIG_BT_BLE_ENABLED is not set
 CONFIG_BT_STACK_NO_LOG=y
 CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST=y
 CONFIG_BT_BLE_DYNAMIC_ENV_MEMORY=y
-# end of Bluedroid Options
-
-#
-# Controller Options
-#
 CONFIG_BTDM_CTRL_MODE_BTDM=y
-CONFIG_BTDM_SCAN_DUPL_CACHE_SIZE=20
-# end of Controller Options
-# end of Bluetooth
-
-#
-# Driver Configurations
-#
-
-#
-# Legacy PCNT Driver Configurations
-#
 CONFIG_PCNT_SUPPRESS_DEPRECATE_WARN=y
-# end of Legacy PCNT Driver Configurations
-# end of Driver Configurations
-
-#
-# ESP-Driver:SPI Configurations
-#
-CONFIG_SPI_MASTER_ISR_IN_IRAM=n
-CONFIG_SPI_SLAVE_ISR_IN_IRAM=n
-# end of ESP-Driver:SPI Configurations
-
-#
-# ESP HTTP client
-#
+# CONFIG_SPI_MASTER_ISR_IN_IRAM is not set
+# CONFIG_SPI_SLAVE_ISR_IN_IRAM is not set
 CONFIG_ESP_HTTP_CLIENT_ENABLE_BASIC_AUTH=y
-# end of ESP HTTP client
-
-#
-# HTTP Server
-#
 CONFIG_HTTPD_WS_SUPPORT=y
-# end of HTTP Server
-
-#
-# ESP HTTPS server
-#
 CONFIG_ESP_HTTPS_SERVER_ENABLE=y
-# end of ESP HTTPS server
-
-#
-# Hardware Settings
-#
-
-#
-# Chip revision
-#
 CONFIG_ESP32_REV_MIN_3=y
-# end of Chip revision
-
-#
-# Main XTAL Config
-#
 CONFIG_XTAL_FREQ_AUTO=y
-# end of Main XTAL Config
-# end of Hardware Settings
-
-#
-# ESP PSRAM
-#
 CONFIG_SPIRAM=y
-
-#
-# SPI RAM config
-#
 CONFIG_SPIRAM_SPEED_80M=y
 CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=128
 CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL=8192
 CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY=y
 CONFIG_SPIRAM_OCCUPY_HSPI_HOST=y
-# end of SPI RAM config
-# end of ESP PSRAM
-
-#
-# ESP System Settings
-#
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=2048
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096
 CONFIG_ESP_INT_WDT_TIMEOUT_MS=300
 CONFIG_ESP_TASK_WDT_PANIC=y
-CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1=n
-# end of ESP System Settings
-
-#
-# ESP Timer (High Resolution Timer)
-#
+# CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1 is not set
 CONFIG_ESP_TIMER_TASK_STACK_SIZE=4096
-# end of ESP Timer (High Resolution Timer)
-
-#
-# Wi-Fi
-#
 CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=8
 CONFIG_ESP_WIFI_CSI_ENABLED=y
-CONFIG_ESP_WIFI_ENABLE_WPA3_SAE=n
-# end of Wi-Fi
-
-#
-# Core dump
-#
+# CONFIG_ESP_WIFI_ENABLE_WPA3_SAE is not set
 CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y
-# end of Core dump
-
-#
-# FAT Filesystem support
-#
 CONFIG_FATFS_LFN_STACK=y
 CONFIG_FATFS_CODEPAGE_850=y
 CONFIG_FATFS_API_ENCODING_UTF_8=y
-# end of FAT Filesystem support
-
-#
-# FreeRTOS
-#
-
-#
-# Kernel
-#
 CONFIG_FREERTOS_HZ=1000
 CONFIG_FREERTOS_IDLE_TASK_STACKSIZE=1024
 CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID=y
 CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y
-# end of Kernel
-
-#
-# Port
-#
 CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK=y
 CONFIG_FREERTOS_FPU_IN_ISR=y
 CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH=y
-# end of Port
-# end of FreeRTOS
-
-#
-# Heap memory debugging
-#
 CONFIG_HEAP_POISONING_LIGHT=y
-# end of Heap memory debugging
-
-#
-# Log
-#
-
-#
-# Log Level
-#
 CONFIG_LOG_DEFAULT_LEVEL_ERROR=y
-# end of Log Level
-# end of Log
-
-#
-# LWIP
-#
 CONFIG_LWIP_MAX_SOCKETS=16
 CONFIG_LWIP_DHCP_RESTORE_LAST_IP=y
 CONFIG_LWIP_DHCP_OPTIONS_LEN=128
 CONFIG_LWIP_IPV6_AUTOCONFIG=y
-
-#
-# TCP
-#
 CONFIG_LWIP_TCP_SYNMAXRTX=6
 CONFIG_LWIP_TCP_MSS=1436
-CONFIG_LWIP_TCP_RTO_TIME=3000
-# Enlarge the TCP window (default 5760 = 4*MSS) to lift the web-upload throughput ceiling. On upload the
-# ESP is the receiver, so throughput is bound by window/RTT - effective once WiFi modem-sleep is disabled
-# during uploads (see System_PauseTasksDuringUpload), which keeps the RTT low. 16*MSS is where the gain
-# materializes; the extra ~11KB of buffered data per socket is more than offset by reducing the upload
-# double-buffer from 3 to 2 buffers (see nr_of_buffers in Web.cpp). Kept below 64KB so no window-scaling.
-CONFIG_LWIP_TCP_WND_DEFAULT=22976
 CONFIG_LWIP_TCP_SND_BUF_DEFAULT=22976
+CONFIG_LWIP_TCP_WND_DEFAULT=22976
 CONFIG_LWIP_TCP_RECVMBOX_SIZE=16
-# end of TCP
-
+CONFIG_LWIP_TCP_RTO_TIME=3000
 CONFIG_LWIP_TCPIP_TASK_STACK_SIZE=2560
 CONFIG_LWIP_TCPIP_TASK_AFFINITY_CPU0=y
-
-#
-# SNTP
-#
 CONFIG_LWIP_SNTP_MAX_SERVERS=3
 CONFIG_LWIP_DHCP_GET_NTP_SRV=y
 CONFIG_LWIP_SNTP_UPDATE_DELAY=10800000
-# end of SNTP
-# end of LWIP
-
-#
-# mbedTLS
-#
-CONFIG_MBEDTLS_ASYMMETRIC_CONTENT_LEN=n
-
-#
-# TLS Key Exchange Methods
-#
+# CONFIG_MBEDTLS_ASYMMETRIC_CONTENT_LEN is not set
 CONFIG_MBEDTLS_PSK_MODES=y
 CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y
-# end of TLS Key Exchange Methods
-
 CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
-
-#
-# Symmetric Ciphers
-#
 CONFIG_MBEDTLS_CAMELLIA_C=y
-# end of Symmetric Ciphers
-# end of mbedTLS
-
-#
-# ESP-MQTT Configurations
-#
 CONFIG_MQTT_SKIP_PUBLISH_IF_DISCONNECTED=y
 CONFIG_MQTT_TASK_CORE_SELECTION_ENABLED=y
-# end of ESP-MQTT Configurations
-
-#
-# PThreads
-#
 CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=2048
-# end of PThreads
-
-#
-# SPI Flash driver
-#
 CONFIG_SPI_FLASH_ERASE_YIELD_DURATION_MS=10
 CONFIG_SPI_FLASH_ERASE_YIELD_TICKS=2
 CONFIG_SPI_FLASH_WRITE_CHUNK_SIZE=4096
-# end of SPI Flash driver
-
-#
-# Ultra Low Power (ULP) Co-processor
-#
 CONFIG_ULP_COPROC_ENABLED=y
-# end of Ultra Low Power (ULP) Co-processor
-
-#
-# Wi-Fi Provisioning Manager
-#
 CONFIG_WIFI_PROV_BLE_BONDING=y
 CONFIG_WIFI_PROV_BLE_FORCE_ENCRYPTION=y
-# end of Wi-Fi Provisioning Manager
-
-#
-# Modbus configuration
-#
-CONFIG_FMB_COMM_MODE_TCP_EN=n
-CONFIG_FMB_CONTROLLER_SLAVE_ID_SUPPORT=n
-CONFIG_FMB_TIMER_PORT_ENABLED=y
-# end of Modbus configuration
-# end of Component config
+# CONFIG_FMB_COMM_MODE_TCP_EN is not set
+# CONFIG_FMB_CONTROLLER_SLAVE_ID_SUPPORT is not set

--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -397,12 +397,15 @@ void AudioPlayer_Init(void) {
 
 	AudioPlayer_CurrentVolume = AudioPlayer_GetInitVolume();
 	// DMA-settings must be adjusted before setting the pinout
-	audio->setOutput16Bit(true); // to save dma-buffer and because we just don't need more than 16 bit
-	audio->settings.DMA_DESC_NUM = 32;
-	audio->settings.DMA_FRAME_NUM = 256; // not too high, so safe SRAM
 	if (System_GetOperationMode() == OPMODE_BLUETOOTH_SOURCE) {
 		audio->setOutputSampleRate(Audio::OutputSR_t::SR_44100);
+		audio->settings.DMA_FRAME_NUM = 192; // not too high, to safe some SRAM
+	} else if (System_GetOperationMode() == OPMODE_BLUETOOTH_SINK) {
+		audio->settings.DMA_FRAME_NUM = 192; // not too high, to safe some SRAM
+	} else {
+		// just use default-values
 	}
+
 	audio->setPinout(I2S_BCLK, I2S_LRC, I2S_DOUT);
 	audio->setVolumeSteps(AUDIOPLAYER_VOLUME_MAX);
 	audio->setVolumeCurve(Audio_GetVolume);
@@ -1657,7 +1660,12 @@ void audio_oggimage(File &file, std::vector<uint32_t> v) {
 // record audiodata or send via BT
 void audio_process_i2s(int32_t *outBuff, int16_t validSamples, bool *continueI2S) {
 	if ((System_GetOperationMode() == OPMODE_BLUETOOTH_SOURCE) && Bluetooth_Device_Connected()) {
-		Bluetooth_Source_SendAudioData(outBuff, validSamples);
+		// do downsamling to 16bit and send via BT
+		int16_t *outBuff16 = (int16_t *) outBuff;
+		for (int i = 0; i < validSamples * 2; i++) {
+			outBuff16[i] = outBuff[i] >> 16;
+		}
+		Bluetooth_Source_SendAudioData(outBuff16, validSamples);
 		*continueI2S = false;
 		return;
 	}

--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -1661,10 +1661,11 @@ void audio_oggimage(File &file, std::vector<uint32_t> v) {
 void audio_process_i2s(int32_t *outBuff, int16_t validSamples, bool *continueI2S) {
 	if ((System_GetOperationMode() == OPMODE_BLUETOOTH_SOURCE) && Bluetooth_Device_Connected()) {
 		// do downsamling to 16bit and send via BT
-		int16_t *outBuff16 = (int16_t *) outBuff;
-		for (int i = 0; i < validSamples * 2; i++) {
-			outBuff16[i] = outBuff[i] >> 16;
+		int16_t *outBuff16 = reinterpret_cast<int16_t *>(outBuff);
+		for (int16_t i = 0; i < validSamples * 2; i++) {
+			outBuff16[i] = outBuff16[i * 2 + 1];
 		}
+
 		Bluetooth_Source_SendAudioData(outBuff16, validSamples);
 		*continueI2S = false;
 		return;

--- a/src/Bluetooth.cpp
+++ b/src/Bluetooth.cpp
@@ -839,7 +839,7 @@ uint8_t Bluetooth_GetCurrentVolume() {
 	return 0;
 }
 
-bool Bluetooth_Source_SendAudioData(int32_t *outBuff, int16_t validSamples) {
+bool Bluetooth_Source_SendAudioData(int16_t *outBuff, int16_t validSamples) {
 #ifdef BLUETOOTH_ENABLE
 	if ((System_GetOperationMode() == OPMODE_BLUETOOTH_SOURCE) && (a2dp_source) && bluetoothSourceConnected && (validSamples > 0)) {
 		if (audioSourceRingBuffer == nullptr) {
@@ -873,7 +873,7 @@ bool Bluetooth_Source_SendAudioData(int32_t *outBuff, int16_t validSamples) {
 		}
 
 		const TickType_t sendTimeout = pdMS_TO_TICKS(100);
-		return (pdTRUE == xRingbufferSend(audioSourceRingBuffer, outBuff, 2 * 2 * validSamples, sendTimeout));
+		return (pdTRUE == xRingbufferSend(audioSourceRingBuffer, outBuff, 2 * sizeof(int16_t) * validSamples, sendTimeout));
 	} else {
 		return false;
 	}

--- a/src/Bluetooth.cpp
+++ b/src/Bluetooth.cpp
@@ -35,6 +35,7 @@ I2SClass i2s;
 // Timeout matches ESP-IDF inquiry duration: 10 slots * 1.28s = 12.8s
 static constexpr uint32_t SCAN_TIMEOUT_MS = 13000u;
 static constexpr uint32_t SCAN_TIMEOUT_GUARD_MS = 2000u;
+static constexpr size_t AUDIO_SOURCE_RINGBUFFER_SIZE = 262144; // 256KB
 
 BluetoothA2DPSink *a2dp_sink;
 BluetoothA2DPSource *a2dp_source;
@@ -355,33 +356,68 @@ void avrc_metadata_callback(uint8_t id, const uint8_t *text) {
 
 #ifdef BLUETOOTH_ENABLE
 int32_t get_data_channels(Frame *frame, int32_t channel_len) {
-	if (channel_len < 0 || frame == NULL) {
+	if (channel_len <= 0 || frame == NULL || audioSourceRingBuffer == NULL) {
 		return 0;
 	}
-	if (audioSourceRingBuffer == NULL) {
-		return 0;
-	}
-	size_t len {};
-	vRingbufferGetInfo(audioSourceRingBuffer, nullptr, nullptr, nullptr, nullptr, &len);
-	const size_t PREFILL_THRESHOLD = channel_len * 4 * 4; // 4 frames worth
-	if (len < PREFILL_THRESHOLD) {
-		// Return silence instead of 0
+
+	const size_t bytes_per_frame = 2 * sizeof(int16_t); // ch1 + ch2, 16-bit each
+	const size_t bytes_needed = (size_t) channel_len * bytes_per_frame;
+
+	// --- Gate on actual data available, before touching the buffer ---
+	// uxItemsWaiting is the number of bytes currently queued for a
+	// no-split ring buffer. If there isn't a full frame's worth sitting
+	// there, bail out to silence instead of blocking / partially filling.
+	size_t bytes_waiting = 0;
+	vRingbufferGetInfo(audioSourceRingBuffer, NULL, NULL, NULL, NULL, &bytes_waiting);
+
+	if (bytes_waiting < bytes_needed) {
 		memset(frame, 0, channel_len * sizeof(Frame));
-		return channel_len; // ← keeps A2DP happy, sends silence
+		return channel_len;
 	}
-	size_t sampleSize = 0;
-	uint8_t *sampleBuff;
-	sampleBuff = (uint8_t *) xRingbufferReceiveUpTo(audioSourceRingBuffer, &sampleSize, (TickType_t) portMAX_DELAY, channel_len * 4);
-	if (sampleBuff != NULL) {
-		for (int sample = 0; sample < (channel_len); ++sample) {
-			frame[sample].channel1 = (sampleBuff[sample * 4 + 3] << 8) | sampleBuff[sample * 4 + 2];
-			frame[sample].channel2 = (sampleBuff[sample * 4 + 1] << 8) | sampleBuff[sample * 4];
-		};
+
+	// --- Pull the data, handling one possible wrap-around ---
+	// A no-split buffer returns at most the contiguous run up to the
+	// physical end of the buffer. Since we've already confirmed enough
+	// total bytes are waiting, a short read here means we hit the wrap
+	// boundary, not that data is missing — read again to get the rest.
+	int32_t samples_received = 0;
+	for (int reads = 0; reads < 2 && samples_received < channel_len; ++reads) {
+		size_t sampleSize = 0;
+		size_t bytes_left = bytes_needed - (size_t) samples_received * bytes_per_frame;
+
+		uint8_t *sampleBuff = (uint8_t *) xRingbufferReceiveUpTo(
+			audioSourceRingBuffer,
+			&sampleSize,
+			0,
+			bytes_left);
+
+		if (sampleBuff == NULL) {
+			break; // shouldn't happen given the pre-check, but stay safe
+		}
+
+		int32_t chunk_samples = sampleSize / bytes_per_frame;
+		int16_t *raw_samples = (int16_t *) sampleBuff;
+
+		for (int32_t i = 0; i < chunk_samples; ++i) {
+			frame[samples_received + i].channel1 = raw_samples[i * 2];
+			frame[samples_received + i].channel2 = raw_samples[i * 2 + 1];
+		}
+
+		samples_received += chunk_samples;
 		vRingbufferReturnItem(audioSourceRingBuffer, (void *) sampleBuff);
-	};
-	vTaskDelay(portTICK_PERIOD_MS * 1);
+
+		if (sampleSize == bytes_left) {
+			break; // got the full amount in one contiguous chunk, no wrap
+		}
+		// else: short read == we hit the wrap boundary, loop once more
+	}
+
+	if (samples_received < channel_len) {
+		memset(&frame[samples_received], 0, (channel_len - samples_received) * sizeof(Frame));
+	}
+
 	return channel_len;
-};
+}
 #endif
 
 #ifdef BLUETOOTH_ENABLE
@@ -661,7 +697,8 @@ void Bluetooth_Init(void) {
 		}
 		a2dp_source->set_ssid_callback(scan_bluetooth_device_callback);
 		a2dp_source->set_avrc_passthru_command_callback(button_handler);
-		a2dp_source->start(get_data_channels);
+		a2dp_source->set_data_callback_in_frames(get_data_channels);
+		a2dp_source->start("ESPUINO");
 		btDeviceName = "";
 		if (gPrefsSettings.isKey("btDeviceName")) {
 			btDeviceName = gPrefsSettings.getString("btDeviceName", "");
@@ -843,37 +880,21 @@ bool Bluetooth_Source_SendAudioData(int16_t *outBuff, int16_t validSamples) {
 #ifdef BLUETOOTH_ENABLE
 	if ((System_GetOperationMode() == OPMODE_BLUETOOTH_SOURCE) && (a2dp_source) && bluetoothSourceConnected && (validSamples > 0)) {
 		if (audioSourceRingBuffer == nullptr) {
-			if (psramFound()) {
-				size_t bufferSize = 16384;
-				StaticRingbuffer_t *bufferStruct = (StaticRingbuffer_t *) heap_caps_malloc(sizeof(StaticRingbuffer_t), MALLOC_CAP_SPIRAM);
-				uint8_t *bufferStorage = (uint8_t *) heap_caps_malloc(bufferSize, MALLOC_CAP_SPIRAM);
+			StaticRingbuffer_t *bufferStruct = (StaticRingbuffer_t *) heap_caps_malloc(sizeof(StaticRingbuffer_t), MALLOC_CAP_SPIRAM);
+			uint8_t *bufferStorage = (uint8_t *) heap_caps_malloc(AUDIO_SOURCE_RINGBUFFER_SIZE, MALLOC_CAP_SPIRAM);
 
-				if (bufferStruct != NULL && bufferStorage != NULL) {
-					audioSourceRingBuffer = xRingbufferCreateStatic(bufferSize, RINGBUF_TYPE_BYTEBUF, bufferStorage, bufferStruct); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-					Log_Printf(LOGLEVEL_INFO, "Bluetooth => audioSourceRingBuffer created in PSRAM on demand (%d bytes, free heap: %u Bytes)", bufferSize, ESP.getFreeHeap());
-				} else {
-					Log_Println("Failed to allocate PSRAM for audioSourceRingBuffer, using heap", LOGLEVEL_ERROR);
-					if (bufferStruct) {
-						heap_caps_free(bufferStruct);
-					}
-					if (bufferStorage) {
-						heap_caps_free(bufferStorage);
-					}
-					audioSourceRingBuffer = xRingbufferCreate(16384, RINGBUF_TYPE_BYTEBUF);
-				}
-			} else {
-				audioSourceRingBuffer = xRingbufferCreate(16384, RINGBUF_TYPE_BYTEBUF);
-				Log_Printf(LOGLEVEL_INFO, "Bluetooth => audioSourceRingBuffer created in heap on demand (Free heap: %u Bytes)", ESP.getFreeHeap());
+			if (bufferStruct != NULL && bufferStorage != NULL) {
+				audioSourceRingBuffer = xRingbufferCreateStatic(AUDIO_SOURCE_RINGBUFFER_SIZE, RINGBUF_TYPE_BYTEBUF, bufferStorage, bufferStruct); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+				Log_Printf(LOGLEVEL_INFO, "Bluetooth => audioSourceRingBuffer created in PSRAM on demand (%d bytes, free heap: %u Bytes)", AUDIO_SOURCE_RINGBUFFER_SIZE, ESP.getFreeHeap());
 			}
-
 			if (audioSourceRingBuffer == NULL) {
 				Log_Println("Failed to create audioSourceRingBuffer!", LOGLEVEL_ERROR);
 				return false;
 			}
 		}
 
-		const TickType_t sendTimeout = pdMS_TO_TICKS(100);
-		return (pdTRUE == xRingbufferSend(audioSourceRingBuffer, outBuff, 2 * sizeof(int16_t) * validSamples, sendTimeout));
+		const TickType_t sendTimeout = pdMS_TO_TICKS(50); // Reduced timeout for non-blocking feel
+		return (pdTRUE == xRingbufferSend(audioSourceRingBuffer, outBuff, validSamples * 2 * sizeof(int16_t), sendTimeout));
 	} else {
 		return false;
 	}

--- a/src/Bluetooth.h
+++ b/src/Bluetooth.h
@@ -30,7 +30,7 @@ void Bluetooth_PreviousTrack(void);
 void Bluetooth_SetVolume(const int32_t _newVolume);
 uint8_t Bluetooth_GetCurrentVolume();
 
-bool Bluetooth_Source_SendAudioData(int32_t *outBuff, int16_t validSamples);
+bool Bluetooth_Source_SendAudioData(int16_t *outBuff, int16_t validSamples);
 bool Bluetooth_Device_Connected();
 
 #ifdef BLUETOOTH_ENABLE


### PR DESCRIPTION
Some simple memory-tweaking. Also merged the speedup-branch into this one.
We can still decide, wether we want to spend the 30k extra for 32-Bit Audio on Wifi-Mode. Even if we do, there is still about 100K free heap left, so we should be very safe. In BT-Usage we are now at 60K, that should be enough for stable usage and still performant enough uploads.