### PR TITLE
Fix intermittent false "card removed" events with PN5180

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## DEV-branch
 
+* 11.07.2026: Fix intermittent false "card removed" events with PN5180: avoid an unnecessary hardware reset on every poll while a tag is being tracked, clear stale IRQ flags before each ISO15693 inventory poll, switch to a PN5180-Library fork with shorter RF-field/transceive timeouts, and make the removal-debounce configurable in the web UI (General -> RFID-Reader)
 * 11.07.2026: Restructure web UI settings tabs: split "General" into focused sub-tabs (Playback, RFID-Reader, Rotary encoder & buttons, LED, Power), add a new "Updates" tab, consistent row layout and left-aligned buttons across WiFi/MQTT/FTP/Bluetooth/RFID-reader, compact button-assignment tables, scrollable RFID assignments modal, and various smaller UX fixes
 * 10.07.2026: Automatically derive Software-revision from the Git commit date at build time instead of maintaining it by hand in src/revision.h
 * 10.07.2026: Fix connection watchdog false-positive and spurious "action performed successfully" toasts (#426)

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -426,7 +426,9 @@
 			"pn5180Lpcd": "PN5180 LPCD aktivieren",
 			"pn5180LpcdExp": "Aktiviert Low Power Card Detection für PN5180 RFID Reader. Nur möglich, wenn Lötbrücken richtig gesetzt sind.",
 			"mfrc522Gain": "MFRC522 Gain",
-			"mfrc522GainExp": "Stellt die Empfindlichkeit des MFRC522 RFID Readers ein. Mögliche Werte sind 0 (niedrigste Empfindlichkeit) bis 7 (höchste Empfindlichkeit). Standard ist 7."
+			"mfrc522GainExp": "Stellt die Empfindlichkeit des MFRC522 RFID Readers ein. Mögliche Werte sind 0 (niedrigste Empfindlichkeit) bis 7 (höchste Empfindlichkeit). Standard ist 7.",
+			"pn5180Debounce": "PN5180 Debounce",
+			"pn5180DebounceExp": "Zeit in Millisekunden, die eine Karte ununterbrochen nicht erkannt werden muss, bevor sie als entfernt gilt. Verhindert, dass kurze Leseaussetzer (z.B. bei größerem Abstand zwischen Karte und Leser) fälschlich als Kartenentfernung gewertet werden. Ein Neustart ist nötig, damit eine Änderung wirksam wird. Standard ist 500ms."
 		},
 		"options": {
 			"title": "Optionen",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -426,7 +426,9 @@
 			"pn5180Lpcd": "Enable PN5180 LPCD",
 			"pn5180LpcdExp": "Enable Low Power Card Detection for PN5180 RFID reader. Only possible if solder-pins are set correctly.",
 			"mfrc522Gain": "MFRC522 Gain",
-			"mfrc522GainExp": "Sets the sensitivity of the MFRC522 RFID reader. Possible values are 0 (lowest sensitivity) to 7 (highest sensitivity). Default is 7."
+			"mfrc522GainExp": "Sets the sensitivity of the MFRC522 RFID reader. Possible values are 0 (lowest sensitivity) to 7 (highest sensitivity). Default is 7.",
+			"pn5180Debounce": "PN5180 debounce",
+			"pn5180DebounceExp": "Time in milliseconds a card must go undetected before it's considered removed. Prevents brief read dropouts (e.g. with a larger gap between card and reader) from being mistaken for card removal. A restart is required for a change to take effect. Default is 500ms."
 		},
 		"options": {
 			"title": "Options",

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -426,7 +426,9 @@
 			"pn5180Lpcd": "Activer PN5180 LPCD",
 			"pn5180LpcdExp": "Active la détection de carte à faible puissance pour le lecteur RFID PN5180. Uniquement possible si les broches de soudure sont correctement configurées.",
 			"mfrc522Gain": "MFRC522 Gain",
-			"mfrc522GainExp": "Définit la sensibilité du lecteur RFID MFRC522. Les valeurs possibles sont de 0 (sensibilité la plus faible) à 7 (sensibilité la plus élevée). La valeur par défaut est 7."
+			"mfrc522GainExp": "Définit la sensibilité du lecteur RFID MFRC522. Les valeurs possibles sont de 0 (sensibilité la plus faible) à 7 (sensibilité la plus élevée). La valeur par défaut est 7.",
+			"pn5180Debounce": "Anti-rebond PN5180",
+			"pn5180DebounceExp": "Durée en millisecondes pendant laquelle une carte doit rester non détectée avant d'être considérée comme retirée. Évite que de brèves pertes de lecture (par ex. avec un écart plus important entre la carte et le lecteur) soient interprétées à tort comme un retrait de carte. Un redémarrage est nécessaire pour qu'une modification prenne effet. La valeur par défaut est 500ms."
 		},
 		"options": {
 			"title": "Options",

--- a/html/management.html
+++ b/html/management.html
@@ -1336,6 +1336,19 @@
 										min="0" max="7">
 								</div>
 							</div>
+							<div class="row mb-2 align-items-center">
+								<div class="col-sm-4 d-flex align-items-center gap-2">
+									<label for="pn5180Debounce" class="col-form-label"
+										data-i18n="general.rfid.pn5180Debounce"></label>
+									<a href="#" class="link-secondary" data-bs-toggle="popover"
+										data-i18n="[data-bs-content]general.rfid.pn5180DebounceExp" tabindex="0">
+										<i class="fas fa-circle-question"></i></a>
+								</div>
+								<div class="col-sm-8">
+									<input type="number" class="form-control" id="pn5180Debounce" name="pn5180Debounce"
+										min="0" max="2000" step="10">
+								</div>
+							</div>
 						</fieldset>
 					</div>
 					<div>
@@ -3040,6 +3053,7 @@
 				$('#pn5180Lpcd').prop('checked', genSettings.pn5180Lpcd);
 				$('#pn5180Lpcd').prop('disabled', genSettings.rfidReaderType == 1 || genSettings.rfidReaderType == 2);
 				$('#mfrc522Gain').val(genSettings.mfrc522Gain);
+				$('#pn5180Debounce').val(genSettings.pn5180Debounce);
 			}
 			// current values
 			let currSettings = settings.current;
@@ -3496,7 +3510,8 @@
 					volumeCurve: $("#volumeCurve").prop('checked') ? 1 : 0,
 					rfidReaderType: Number($('#rfidReaderType').val()),
 					pn5180Lpcd: $('#pn5180Lpcd').prop('checked'),
-					mfrc522Gain: Number($('#mfrc522Gain').val())
+					mfrc522Gain: Number($('#mfrc522Gain').val()),
+					pn5180Debounce: Number($('#pn5180Debounce').val())
 				},
 				"led": {
 					initBrightness: Number($('#initBrightness').val()),
@@ -4172,7 +4187,11 @@
 					resumeOnSameRfid.prop('disabled', true);
 					return;
 				}
-				resumeOnSameRfid.prop('disabled', !$(this).prop('checked'));
+				const enabled = $(this).prop('checked');
+				if (!enabled) {
+					resumeOnSameRfid.prop('checked', false);
+				}
+				resumeOnSameRfid.prop('disabled', !enabled);
 			});
 
 			const lightSwitch = $('#lightSwitch');

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,7 +44,7 @@ lib_deps =
 	https://github.com/Joe91/MFRC522_I2C.git#3cabf223fb6b2950474ff41f70c28922f8551341
 	https://github.com/tueddy/rfid.git#caa3e6d4f9cc592e800b4467d61d64f765c3156f ; avoid warnings, fork from https://github.com/miguelbalboa/rfid.git#0ff12a1
 	https://github.com/tuniii/LogRingBuffer.git#89d7d3e5b74e773cae38345e23ddaf2c4fd3e367
-	https://github.com/tueddy/PN5180-Library.git#69ec032289457b1adae3e1b269ca22ea16aa46fd
+	https://github.com/biologist79/PN5180-Library.git#2479510696c81860938453a7e754da0d7cd1e20b ; fork from https://github.com/tueddy/PN5180-Library.git#69ec032, reduced hardcoded RF-field/transceive timeouts (500/200ms -> 100ms) to fix intermittent false "card removed" events at marginal read distance
 	https://github.com/tueddy/natsort.git#ebbf6604c573c5315daa8fa77da8f047f202bd63 ; avoid warnings, fork from https://github.com/sourcefrog/natsort.git#cdd8df9
 
 board_build.embed_txtfiles =

--- a/src/RfidPn5180.cpp
+++ b/src/RfidPn5180.cpp
@@ -136,6 +136,7 @@ void RfidPn5180_Task(void *parameter) {
 	static PN5180ISO15693 nfc15693(RFID_CS, RFID_BUSY, RFID_RST);
 	uint32_t lastTimeDetected14443 = 0;
 	uint32_t lastTimeDetected15693 = 0;
+	const uint16_t debounceMs = gPrefsRfid.getUShort("pn5180Debounce", 500);
 	byte lastValidcardId[cardIdSize];
 	bool cardAppliedCurrentRun = false;
 	bool cardAppliedLastRun = false;
@@ -165,6 +166,11 @@ void RfidPn5180_Task(void *parameter) {
 		if (RFID_PN5180_STATE_INIT == stateMachine) {
 			nfc14443.begin();
 			nfc14443.reset();
+			// Lower than the library default (500ms): transceiveCommand()'s BUSY-pin wait loops
+			// should normally resolve in well under this, so fail/retry faster if the chip is
+			// genuinely unresponsive instead of stalling the polling loop for half a second.
+			nfc14443.commandTimeout = 100;
+			nfc15693.commandTimeout = 100;
 			// show PN5180 reader version
 			// uint8_t firmwareVersion[2];
 			// nfc14443.readEEprom(FIRMWARE_VERSION, firmwareVersion, sizeof(firmwareVersion));
@@ -189,7 +195,7 @@ void RfidPn5180_Task(void *parameter) {
 				// Reset to dummy-value if no card is there
 				// Necessary to differentiate between "card is still applied" and "card is re-applied again after removal"
 				// lastTimeDetected14443 is used to prevent "new card detection with old card" with single events where no card was detected
-				if (!lastTimeDetected14443 || (millis() - lastTimeDetected14443 >= 1000)) {
+				if (!lastTimeDetected14443 || (millis() - lastTimeDetected14443 >= debounceMs)) {
 					lastTimeDetected14443 = 0;
 					cardAppliedCurrentRun = false;
 					for (uint8_t i = 0; i < cardIdSize; i++) {
@@ -224,6 +230,12 @@ void RfidPn5180_Task(void *parameter) {
 				}
 			}
 		} else if ((RFID_PN5180_NFC15693_STATE_GETINVENTORY == stateMachine) || (RFID_PN5180_NFC15693_STATE_GETINVENTORY_PRIVACY == stateMachine)) {
+			// Unlike the ISO14443 path, PN5180ISO15693::issueISO15693Command() (called by
+			// getInventory()) never clears the chip's IRQ-status register before checking for a
+			// fresh response. Without this, a stale RX-IRQ flag left over from an earlier
+			// successful read could make the next poll immediately look like "new data arrived"
+			// and return leftover buffer content as a phantom card - even with no tag present.
+			nfc15693.clearIRQStatus(0xffffffff);
 			// try to read ISO15693 inventory
 			ISO15693ErrorCode rc = nfc15693.getInventory(uid);
 			if (rc == ISO15693_EC_OK) {
@@ -233,7 +245,7 @@ void RfidPn5180_Task(void *parameter) {
 				cardAppliedCurrentRun = true;
 			} else {
 				// lastTimeDetected15693 is used to prevent "new card detection with old card" with single events where no card was detected
-				if (!lastTimeDetected15693 || (millis() - lastTimeDetected15693 >= 400)) {
+				if (!lastTimeDetected15693 || (millis() - lastTimeDetected15693 >= debounceMs)) {
 					lastTimeDetected15693 = 0;
 					cardAppliedCurrentRun = false;
 					for (uint8_t i = 0; i < cardIdSize; i++) {
@@ -259,12 +271,15 @@ void RfidPn5180_Task(void *parameter) {
 
 			// check for different card id
 			if (memcmp((const void *) cardId, (const void *) lastCardId, sizeof(cardId)) == 0) {
-				// reset state machine
+				// Same card as last poll (the common case while a tag sits continuously on the
+				// reader): skip the "new card" processing below (logging/queueing) and poll again
+				// directly, without a RESET in between - see the comment on the ACTIVE-bypass at
+				// the end of this loop for why avoiding the hardware reset here matters.
 				if (RFID_PN5180_NFC14443_STATE_ACTIVE == stateMachine) {
-					stateMachine = RFID_PN5180_NFC14443_STATE_RESET;
+					stateMachine = RFID_PN5180_NFC14443_STATE_READCARD;
 					continue;
 				} else if (RFID_PN5180_NFC15693_STATE_ACTIVE == stateMachine) {
-					stateMachine = RFID_PN5180_NFC15693_STATE_RESET;
+					stateMachine = RFID_PN5180_NFC15693_STATE_GETINVENTORY;
 					continue;
 				}
 			}
@@ -315,10 +330,19 @@ void RfidPn5180_Task(void *parameter) {
 			}
 		}
 
-		if (RFID_PN5180_NFC14443_STATE_ACTIVE == stateMachine) { // If 14443 is active, bypass 15693 as next check (performance)
-			stateMachine = RFID_PN5180_NFC14443_STATE_RESET;
-		} else if (RFID_PN5180_NFC15693_STATE_ACTIVE == stateMachine) { // If 15693 is active, bypass 14443 as next check (performance)
-			stateMachine = RFID_PN5180_NFC15693_STATE_RESET;
+		if (RFID_PN5180_NFC14443_STATE_ACTIVE == stateMachine) {
+			// Poll again directly, without a RESET in between: nfc14443.reset() is a full hardware
+			// reset of the PN5180 (RST-pin toggle + reboot wait) that collapses the RF field, and
+			// readCardSerial() re-establishes the field on every call anyway. Cycling a hard reset
+			// on every ~20ms poll while a card is already confirmed present forces marginally-coupled
+			// tags (e.g. a case with a larger antenna-to-card gap) to fully re-power from scratch each
+			// time, which is a plausible cause of intermittent "card not recognized" blips while a tag
+			// sits untouched on the reader. A RESET is still done for the initial scan (state machine
+			// starts at RESET) and after the tag is confirmed gone (see debounce below).
+			stateMachine = RFID_PN5180_NFC14443_STATE_READCARD;
+		} else if (RFID_PN5180_NFC15693_STATE_ACTIVE == stateMachine) {
+			// Same reasoning as above, for ISO15693.
+			stateMachine = RFID_PN5180_NFC15693_STATE_GETINVENTORY;
 		} else {
 			stateMachine++;
 			if (stateMachine > RFID_PN5180_NFC15693_STATE_GETINVENTORY_PRIVACY) {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -742,6 +742,7 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 		success = success && (gPrefsRfid.putUChar("rfidReaderType", generalObj["rfidReaderType"].as<uint8_t>()) != 0);
 		success = success && (gPrefsRfid.putBool("pn5180Lpcd", generalObj["pn5180Lpcd"].as<bool>()) != 0);
 		success = success && (gPrefsRfid.putUChar("mfrc522Gain", generalObj["mfrc522Gain"].as<uint8_t>()) != 0);
+		success = success && (gPrefsRfid.putUShort("pn5180Debounce", generalObj["pn5180Debounce"].as<uint16_t>()) != 0);
 		if (!success) {
 			Log_Printf(LOGLEVEL_ERROR, webSaveSettingsError, "general");
 			return WebsocketCodeType::Error;
@@ -1095,6 +1096,7 @@ static void settingsToJSON(JsonObject obj, const String section) {
 		generalObj["rfidReaderType"].set(gPrefsRfid.getUChar("rfidReaderType", 0)); // RFID_READER_TYPE_RUNTIME
 		generalObj["pn5180Lpcd"].set(gPrefsRfid.getBool("pn5180Lpcd", false)); // PN5180 LPCD
 		generalObj["mfrc522Gain"].set(gPrefsRfid.getUChar("mfrc522Gain", 7)); // MFRC522_GAIN
+		generalObj["pn5180Debounce"].set(gPrefsRfid.getUShort("pn5180Debounce", 500)); // PN5180 debounce (ms)
 		generalObj["pauseOnMinVol"].set(gPrefsSettings.getBool("pauseOnMinVol", false)); // PAUSE_ON_MIN_VOLUME
 		generalObj["recoverVolBoot"].set(gPrefsSettings.getBool("recoverVolBoot", false)); // USE_LAST_VOLUME_AFTER_REBOOT
 		generalObj["volumeCurve"].set(gPrefsSettings.getUChar("volumeCurve", 0)); // VOLUMECURVE
@@ -1243,6 +1245,7 @@ static void settingsToJSON(JsonObject obj, const String section) {
 		genSettings["rfidReaderType"].set(0u); // RFID_READER_TYPE_RUNTIME (auto-detect)
 		genSettings["pn5180Lpcd"].set(false); // PN5180 LPCD disabled
 		genSettings["mfrc522Gain"].set(7u); // MFRC522_GAIN default (max gain)
+		genSettings["pn5180Debounce"].set(500u); // PN5180 debounce (ms) default
 		JsonObject eqSettings = defaultsObj["equalizer"].to<JsonObject>();
 		eqSettings["gainHighPass"].set(0);
 		eqSettings["gainBandPass"].set(0);


### PR DESCRIPTION
Root-caused via targeted timing instrumentation (measuring vTaskDelay overrun vs. per-state processing time) that a card sitting continuously on the reader was periodically mistaken for removed and reapplied, even at zero read distance. Two contributing issues in RfidPn5180.cpp:

- The state machine routed back through a full PN5180 hardware reset (RST-pin toggle + reboot wait) on every ~20ms poll while a tag was being tracked - both via the ACTIVE-state bypass and, more importantly, via the "same card as last poll" fast path, which forced a reset+continue on every single successful re-read of an already- known tag (the dominant case while a tag sits on the reader). Both paths now poll again directly (READCARD/GETINVENTORY) without resetting the chip in between.
- issueISO15693Command() (PN5180-Library) never clears the chip's IRQ status register before checking for a fresh response, so a stale RX-IRQ flag left over from an earlier successful read could look like a new response arrived. Added an explicit clearIRQStatus() before each ISO15693 poll.

Neither fix alone eliminated the worst-case ~700-800ms poll stalls observed on hardware; further instrumentation traced those to two hardcoded timeouts in the (forked, git-pinned) PN5180-Library itself - setRF_on()/setRF_off()'s RF-field-ready wait (500ms) and activateTypeA()'s PN5180_TS_WaitTransmit wait (200ms), neither of which uses the already-configurable commandTimeout member. Repinned platformio.ini to a patched fork (biologist79/PN5180-Library) with both lowered to 100ms, which cut the worst observed stalls from ~780ms to ~260ms on the same hardware.

The remaining debounce needed to mask occasional multi-poll dropouts is now a configurable NVS-backed setting (General -> RFID-Reader -> PN5180 Debounce, default 500ms, requires a restart to apply) instead of a hardcoded 1000/400ms split between ISO14443/ISO15693.