### PR TITLE
accesspoint: fix the blank save button (locale key was renamed)

### DIFF
--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -123,7 +123,7 @@
 			<br>
 			<br>
 		</div>
-		<button type="submit" class="btn" id="save-button" data-i18n="submit"></button>
+		<button type="submit" class="btn" id="save-button" data-i18n="wifi.saveButton"></button>
 	</form>
 	<form action="/restart" method="POST" class="box">
 		<h1 data-i18n="wifi.restartPrompt"></h1>


### PR DESCRIPTION
The WiFi setup page's save button is localized via `data-i18n="submit"`, but the web-UI
locale restructure (731ac13) renamed that key to `wifi.saveButton`. Nothing on `dev`
provides `submit` any more, so the button renders with **no label at all** — the one
button a user has to press to get the box onto WiFi.

One line: point it at the key that exists.

Before:

<img width="780" height="1688" alt="pr0-before-page-r" src="https://github.com/user-attachments/assets/47fbf2bd-8490-4e8a-a016-c00105b7df21" />

After:

<img width="780" height="1688" alt="pr0-after-page-r" src="https://github.com/user-attachments/assets/c2624d83-78b9-42d2-87ca-80b355f98db8" />
