### PR TITLE
Wlan: give connect attempts 15s instead of 5s so DHCP can complete

### DIFF
--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -339,7 +339,10 @@ void handleWifiStateConnectLast() {
 		return;
 	}
 
-	if (connectStartTimestamp > 0 && millis() - connectStartTimestamp < 3000) {
+	// Allow enough time for association AND DHCP: on VLAN'd/mesh networks
+	// (e.g. UniFi IoT SSIDs) the lease can take well over 5s to arrive, and
+	// tearing the connection down before it lands means never getting an IP.
+	if (connectStartTimestamp > 0 && millis() - connectStartTimestamp < 15000) {
 		return;
 	}
 
@@ -403,7 +406,9 @@ void handleWifiStateScanConnect() {
 			Log_Printf(LOGLEVEL_NOTICE, wifiScanResult, WiFi.SSID(i).c_str(), WiFi.RSSI(i), WiFi.channel(i), WiFi.BSSIDstr(i).c_str());
 		}
 	} else {
-		if (millis() - connectStartTimestamp < 5000) {
+		// 15s, not 5s: association + DHCP on VLAN'd/mesh networks (UniFi IoT
+		// SSIDs etc.) regularly needs >5s; see matching window above.
+		if (millis() - connectStartTimestamp < 15000) {
 			return;
 		}
 	}


### PR DESCRIPTION
On VLAN'd / mesh networks (UniFi IoT SSIDs and similar) the DHCP lease regularly takes
more than 5s after association. The old 5s window tore the connection down and moved on
to the next BSSID before the lease arrived, so the station associated over and over but
never got an IP.

Widened to 15s. `src/Wlan.cpp` only.