### PR TITLE
accesspoint: honor browser language and add a language selector

### DIFF
--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -82,6 +82,13 @@
 
 <body>
 	<form id="settings" action="#wifiConfig" class="box" method="POST" onsubmit="wifiConfig(); return false">
+		<div style="text-align:right">
+			<select id="langSel" style="width:auto;height:28px;margin:0;padding:0 5px;font-size:13px">
+				<option value="de">Deutsch</option>
+				<option value="en">English</option>
+				<option value="fr">Français</option>
+			</select>
+		</div>
 		<h1 data-i18n="wifi.title"></h1>
 		<div id="WiFiList"></div>
 		<label for="ssid" data-i18n="wifi.ssid.title"></label>: <br>
@@ -142,10 +149,29 @@
 				loadPath: "/locales/{{lng}}.json"
 			},
 			debug: true,
-			fallbackLng: 'de',
+			load: 'languageOnly',
+			fallbackLng: 'en',
 		}, (err, t) => {
 			localize = locI18next.init(i18next);
-			localize('body');
+			// same language resolution as management.html: explicit choice from
+			// localStorage first, browser language otherwise
+			const lang = localStorage.getItem("language");
+			i18next.changeLanguage(lang !== null ? lang : navigator.language.split("-")[0]);
+		});
+		i18next.on('languageChanged', (lng) => {
+			document.querySelector('#langSel').value = lng;
+			document.documentElement.lang = lng;
+			document.title = i18next.t('wifi.title');
+			if (typeof localize === "function") {
+				localize('body');
+			}
+		});
+		document.querySelector('#langSel').addEventListener('change', (event) => {
+			const lang = event.target.value;
+			if (lang !== i18next.language) {
+				localStorage.setItem("language", lang);
+				i18next.changeLanguage(lang);
+			}
 		});
 
 		function selectWiFi(ssid) {


### PR DESCRIPTION
The setup page already embeds full de/en/fr locales, but initialized with no language
detection and `fallbackLng: 'de'` — so every user got German regardless of their browser.

Mirrors `management.html`: resolve the language from `localStorage('language')` or the
browser with English fallback, add a small selector to change it on the spot, and localize
`document.title` (which sat outside the `localize('body')` scope).

`html/accesspoint.html` only. Verified on hardware with en-GB / fr-FR / de-DE browsers.

<img width="780" height="1688" alt="pr2-translations-de" src="https://github.com/user-attachments/assets/ca571097-5b71-450c-8557-fe355fe0a974" />
<img width="780" height="1688" alt="pr2-translations-en" src="https://github.com/user-attachments/assets/6f97ddcc-db50-4769-b27c-9275c859ac82" />
<img width="780" height="1688" alt="pr2-translations-fr" src="https://github.com/user-attachments/assets/87d764cc-ef15-40ed-8397-a33b178ab038" />
