### PR TITLE
Wlan/Web/accesspoint: tell the user WHY a connection attempt failed

### DIFF
--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -90,6 +90,7 @@
 			</select>
 		</div>
 		<h1 data-i18n="wifi.title"></h1>
+		<div id="connstatus" style="display:none;background:#f8d7da;color:#721c24;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
 		<div id="WiFiList"></div>
 		<label for="ssid" data-i18n="wifi.ssid.title"></label>: <br>
 		<input type="text" id="ssid" name="ssid" placeholder="SSID" required>
@@ -165,6 +166,9 @@
 			if (typeof localize === "function") {
 				localize('body');
 			}
+			// the failure banner is built with i18next.t(), so it has to be
+			// re-rendered whenever the language changes
+			renderWifiStatus();
 		});
 		document.querySelector('#langSel').addEventListener('change', (event) => {
 			const lang = event.target.value;
@@ -174,6 +178,26 @@
 			}
 		});
 
+		let wifiStatusData = null;
+		function renderWifiStatus() {
+			const box = document.getElementById("connstatus");
+			const failure = wifiStatusData && wifiStatusData.last_failure;
+			if (!failure || !i18next.isInitialized) {
+				box.style.display = "none";
+				return;
+			}
+			const cls = ["wrong_password", "not_found", "rejected"].includes(failure.class) ? failure.class : "other";
+			box.innerText = i18next.t("wifi.fail." + cls, { ssid: failure.ssid, code: failure.reason });
+			box.style.display = "block";
+		}
+		async function getWifiStatus() {
+			try {
+				wifiStatusData = await (await fetch("/wifistatus")).json();
+				renderWifiStatus();
+			} catch (error) {
+				console.log(error);
+			}
+		}
 		function selectWiFi(ssid) {
 			document.getElementById("ssid").value = ssid;
 			document.getElementById("pwd").focus();
@@ -245,6 +269,7 @@
 			getWiFiList();
 			updateWifiFields();
 			setupFullInterfaceLink();
+			getWifiStatus();
 		});
 
 		// Show the full management interface's URL and offer a "copy to clipboard" button. Uses the

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -168,6 +168,12 @@
 			"copy": "Adresse kopieren",
 			"copied": "Adresse kopiert!",
 			"copyFailed": "Kopieren nicht möglich - bitte Adresse oben manuell markieren und kopieren."
+		},
+		"fail": {
+			"wrong_password": "Verbindung mit \"{{ssid}}\" fehlgeschlagen — vermutlich ist das Passwort falsch (Code {{code}}). Bitte prüfen und erneut eingeben.",
+			"not_found": "Das Netzwerk \"{{ssid}}\" wurde nicht gefunden (Code {{code}}). Ist es in Reichweite und auf 2,4 GHz?",
+			"rejected": "Der Router hat die Verbindung mit \"{{ssid}}\" abgelehnt (Code {{code}}). MAC-Filter, Client-Limits oder Sicherheitseinstellungen prüfen (WPA2 erforderlich).",
+			"other": "Verbindung mit \"{{ssid}}\" fehlgeschlagen (Code {{code}})."
 		}
 	},
 	"control": {

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -168,6 +168,12 @@
 			"copy": "Copy address",
 			"copied": "Address copied!",
 			"copyFailed": "Could not copy - please select and copy the address above manually."
+		},
+		"fail": {
+			"wrong_password": "Could not join \"{{ssid}}\" — the password is probably wrong (code {{code}}). Please check it and try again.",
+			"not_found": "Network \"{{ssid}}\" was not found (code {{code}}). Is it in range and on 2.4 GHz?",
+			"rejected": "The router refused the connection to \"{{ssid}}\" (code {{code}}). Check MAC filters, client limits or security settings (WPA2 required).",
+			"other": "Connecting to \"{{ssid}}\" failed (code {{code}})."
 		}
 	},
 	"control": {

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -168,6 +168,12 @@
 			"copy": "Copier l'adresse",
 			"copied": "Adresse copiée !",
 			"copyFailed": "Impossible de copier - veuillez sélectionner et copier l'adresse ci-dessus manuellement."
+		},
+		"fail": {
+			"wrong_password": "Impossible de rejoindre « {{ssid}} » — le mot de passe est probablement incorrect (code {{code}}). Veuillez le vérifier et réessayer.",
+			"not_found": "Le réseau « {{ssid}} » est introuvable (code {{code}}). Est-il à portée et en 2,4 GHz ?",
+			"rejected": "Le routeur a refusé la connexion à « {{ssid}} » (code {{code}}). Vérifiez les filtres MAC, les limites de clients ou les paramètres de sécurité (WPA2 requis).",
+			"other": "Échec de la connexion à « {{ssid}} » (code {{code}})."
 		}
 	},
 	"control": {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -75,6 +75,7 @@ static void explorerHandleRenameRequest(AsyncWebServerRequest *request);
 static void explorerHandleAudioRequest(AsyncWebServerRequest *request);
 static void handleTrackProgressRequest(AsyncWebServerRequest *request);
 static void handleGetSavedSSIDs(AsyncWebServerRequest *request);
+static void handleGetWifiStatus(AsyncWebServerRequest *request);
 static void handlePostSavedSSIDs(AsyncWebServerRequest *request, JsonVariant &json);
 static void handleDeleteSavedSSIDs(AsyncWebServerRequest *request);
 static void handleGetActiveSSID(AsyncWebServerRequest *request);
@@ -626,6 +627,7 @@ void webserverStart(void) {
 		wServer.addRewrite(new OneParamRewrite("/savedSSIDs/{ssid}", "/savedSSIDs?ssid={ssid}"));
 		wServer.on("/savedSSIDs", HTTP_DELETE, handleDeleteSavedSSIDs);
 		wServer.on("/activeSSID", HTTP_GET, handleGetActiveSSID);
+		wServer.on("/wifistatus", HTTP_GET, handleGetWifiStatus);
 
 		wServer.on("/wificonfig", HTTP_GET, handleGetWiFiConfig);
 		wServer.addHandler(new AsyncCallbackJsonWebHandler("/wificonfig", handlePostWiFiConfig));
@@ -2227,6 +2229,61 @@ void handleGetSavedSSIDs(AsyncWebServerRequest *request) {
 	Wlan_GetSavedNetworks([json_ssids](const WiFiSettings &network) {
 		json_ssids.add(network.ssid);
 	});
+
+	response->setLength();
+	request->send(response);
+}
+
+// Map an 802.11 disconnect reason code onto a coarse, user-explainable class.
+// The page translates the class into a localized message; the raw code is
+// reported alongside for the curious/for support.
+static const char *classifyDisconnectReason(uint8_t reason) {
+	switch (reason) {
+		case WIFI_REASON_AUTH_EXPIRE:
+		case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
+		case WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT:
+		case WIFI_REASON_IE_IN_4WAY_DIFFERS:
+		case WIFI_REASON_AUTH_FAIL:
+		case WIFI_REASON_HANDSHAKE_TIMEOUT:
+			return "wrong_password";
+		case WIFI_REASON_NO_AP_FOUND:
+		case 210: // NO_AP_FOUND_IN_RSSI_THRESHOLD (IDF >= 5.3)
+		case 211: // NO_AP_FOUND_IN_AUTHMODE_THRESHOLD
+		case 212: // NO_AP_FOUND_IN_BAND
+		case 213: // NO_AP_FOUND_W_COMPATIBLE_SECURITY
+			return "not_found";
+		case WIFI_REASON_ASSOC_TOOMANY:
+		case WIFI_REASON_802_1X_AUTH_FAILED:
+		case WIFI_REASON_CIPHER_SUITE_REJECTED:
+		case WIFI_REASON_ASSOC_FAIL:
+		case WIFI_REASON_CONNECTION_FAIL:
+			return "rejected";
+		default:
+			return "other";
+	}
+}
+
+// Current WiFi state plus diagnostics of the last failed connection attempt.
+// Used by the accesspoint page to tell the user why their credentials didn't
+// work instead of silently falling back to the setup AP.
+void handleGetWifiStatus(AsyncWebServerRequest *request) {
+	AsyncJsonResponse *response = new AsyncJsonResponse();
+	JsonObject obj = response->getRoot();
+
+	obj["state"] = Wlan_GetConnectState();
+	if (Wlan_IsConnected()) {
+		obj["ssid"] = Wlan_GetCurrentSSID();
+		obj["ip"] = Wlan_GetIpAddress();
+	}
+
+	String failSsid;
+	uint8_t failReason;
+	if (Wlan_GetLastFailure(failSsid, failReason)) {
+		JsonObject fail = obj["last_failure"].to<JsonObject>();
+		fail["ssid"] = failSsid;
+		fail["reason"] = failReason;
+		fail["class"] = classifyDisconnectReason(failReason);
+	}
 
 	response->setLength();
 	request->send(response);

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -52,6 +52,17 @@ static uint8_t connectionAttemptCounter = 0;
 static unsigned long connectStartTimestamp = 0;
 static uint32_t connectionFailedTimestamp = 0;
 
+// diagnostics of the running/last connection attempt. The state machine only
+// polls WiFi.status(), which never surfaces WHY an attempt failed — the 802.11
+// reason code (wrong password vs. network not found vs. AP refused) only
+// arrives via the disconnect event. Captured here and persisted to NVS on
+// failure so the accesspoint page can show it to the user, even after the
+// reboot that sits between entering credentials and reading the result.
+static volatile uint8_t lastDisconnectReason = 0;
+static String lastAttemptSsid;
+static constexpr const char *nvsFailSsidKey = "wifiFailSsid";
+static constexpr const char *nvsFailReasonKey = "wifiFailReason";
+
 // state for persistent settings
 static constexpr const char *nvsWiFiNamespace = "wifi-settings";
 static constexpr const char *nvsWiFiKey = "wifi-";
@@ -287,6 +298,20 @@ void Wlan_Init(void) {
 	// for Arduino 2.0.9 this does not seem to bring any advantage just more memory use, so leave it outcommented
 	// WiFi.useStaticBuffers(true);
 
+	// capture the reason code of station disconnects (see lastDisconnectReason)
+	WiFi.onEvent([](WiFiEvent_t event, arduino_event_info_t info) {
+		const uint8_t reason = info.wifi_sta_disconnected.reason;
+		// The connect state machine tears down its own attempts (WiFi.disconnect()
+		// before every retry), which raises ASSOC_LEAVE/AUTH_LEAVE. Recording those
+		// would overwrite the reason we actually want — the one the AP gave when the
+		// attempt failed — so keep the last meaningful code instead.
+		if (reason == WIFI_REASON_ASSOC_LEAVE || reason == WIFI_REASON_AUTH_LEAVE) {
+			return;
+		}
+		lastDisconnectReason = reason;
+	},
+		WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+
 	wifiState = WIFI_STATE_INIT;
 	handleWifiStateInit();
 }
@@ -307,6 +332,8 @@ void connectToKnownNetwork(const WiFiSettings &settings, const uint8_t *bssid = 
 
 	Log_Printf(LOGLEVEL_NOTICE, wifiConnectionInProgress, settings.ssid.c_str());
 
+	lastAttemptSsid = settings.ssid;
+	lastDisconnectReason = 0;
 	WiFi.begin(settings.ssid, settings.password, 0, bssid);
 }
 
@@ -515,6 +542,12 @@ void handleWifiStateConnectionSuccess() {
 		}
 	}
 
+	// a successful connection invalidates the stored failure diagnostics
+	if (gPrefsSettings.isKey(nvsFailReasonKey)) {
+		gPrefsSettings.remove(nvsFailReasonKey);
+		gPrefsSettings.remove(nvsFailSsidKey);
+	}
+
 	wifiState = WIFI_STATE_CONNECTED;
 	Mqtt_OnWifiConnected();
 }
@@ -561,6 +594,20 @@ void handleWifiStateConnectionFailed() {
 	if (connectionFailedTimestamp == 0) {
 		Log_Println(cantConnectToWifi, LOGLEVEL_INFO);
 		connectionFailedTimestamp = millis();
+
+		// persist the failure diagnostics for the accesspoint page. If no
+		// connect was even attempted, none of the saved networks was in the
+		// scan results — report that as NO_AP_FOUND for the last known SSID.
+		if (lastAttemptSsid.length() && lastDisconnectReason != 0) {
+			gPrefsSettings.putString(nvsFailSsidKey, lastAttemptSsid);
+			gPrefsSettings.putUChar(nvsFailReasonKey, lastDisconnectReason);
+		} else if (!lastAttemptSsid.length()) {
+			const String lastSSID = gPrefsSettings.getString("LAST_SSID");
+			if (lastSSID.length()) {
+				gPrefsSettings.putString(nvsFailSsidKey, lastSSID);
+				gPrefsSettings.putUChar(nvsFailReasonKey, WIFI_REASON_NO_AP_FOUND);
+			}
+		}
 	}
 
 	if (initialStart) {
@@ -764,6 +811,32 @@ bool Wlan_DeleteNetwork(String ssid) {
 
 bool Wlan_ConnectionTryInProgress(void) {
 	return wifiState == WIFI_STATE_SCAN_CONN;
+}
+
+// Coarse connection state for the web API (/wifistatus)
+const char *Wlan_GetConnectState(void) {
+	switch (wifiState) {
+		case WIFI_STATE_CONNECTED:
+			return "connected";
+		case WIFI_STATE_CONN_FAILED:
+			return "failed";
+		case WIFI_STATE_AP:
+			return "ap";
+		case WIFI_STATE_END:
+			return "off";
+		default:
+			return "connecting";
+	}
+}
+
+// Diagnostics of the last failed connection attempt (cleared on success)
+bool Wlan_GetLastFailure(String &ssid, uint8_t &reason) {
+	if (!gPrefsSettings.isKey(nvsFailReasonKey)) {
+		return false;
+	}
+	ssid = gPrefsSettings.getString(nvsFailSsidKey);
+	reason = gPrefsSettings.getUChar(nvsFailReasonKey);
+	return true;
 }
 
 String Wlan_GetIpAddress(void) {

--- a/src/Wlan.h
+++ b/src/Wlan.h
@@ -132,3 +132,5 @@ void Wlan_ToggleEnable(void);
 String Wlan_GetIpAddress(void);
 int8_t Wlan_GetRssi(void);
 bool Wlan_ConnectionTryInProgress(void);
+const char *Wlan_GetConnectState(void);
+bool Wlan_GetLastFailure(String &ssid, uint8_t &reason);


### PR DESCRIPTION
The connect state machine polls `WiFi.status()`, which never surfaces the 802.11 disconnect
reason — so a wrong password, an out-of-range network and a router-side rejection all look
identical: silent retries, then a fallback to the setup AP with no explanation.

- **Wlan:** capture the disconnect reason via `WiFi.onEvent` and persist it (plus the SSID)
  to NVS when a connect cycle fails, cleared again on the next successful connection. Reasons
  raised by our *own* teardown (`ASSOC_LEAVE` / `AUTH_LEAVE` — the state machine calls
  `WiFi.disconnect()` before every retry) are ignored, otherwise they overwrite the reason the
  AP actually gave.
- **Web:** new `GET /wifistatus` returning the connection state plus the last failure (ssid,
  raw reason code, and a user-explainable class: `wrong_password` / `not_found` / `rejected` /
  `other`).
- **accesspoint:** a localized banner with that diagnosis on load, so after a failed attempt
  the user is told e.g. "the password is probably wrong" instead of guessing. Locale strings
  for en/de/fr.

Verified on hardware: a wrong password now yields `{"reason": 15, "class": "wrong_password"}`
and the banner says so.

<img width="780" height="1688" alt="pr3-failure-reason-wrong-password" src="https://github.com/user-attachments/assets/92d15c02-587a-4b9d-89cd-7fb3be7207ad" />
