### PR TITLE
Wlan/Web/accesspoint: test WiFi credentials live from the setup page

### DIFF
--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -91,7 +91,6 @@
 		</div>
 		<h1 data-i18n="wifi.title"></h1>
 		<div id="connstatus" style="display:none;background:#f8d7da;color:#721c24;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
-		<div id="teststatus" style="display:none;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
 		<div id="WiFiList"></div>
 		<label for="ssid" data-i18n="wifi.ssid.title"></label>: <br>
 		<input type="text" id="ssid" name="ssid" placeholder="SSID" required>
@@ -134,7 +133,8 @@
 		</div>
 		<button type="submit" class="btn" id="save-button" data-i18n="wifi.saveButton"></button>
 	</form>
-	<form action="/restart" method="POST" class="box">
+	<div id="teststatus" style="display:none;border-radius:4px;padding:10px;margin:0 auto 20px;max-width:500px;text-align:left"></div>
+	<form id="restartform" action="/restart" method="POST" class="box">
 		<h1 data-i18n="wifi.restartPrompt"></h1>
 		<button type="submit" class="btn" id="restart-button" data-i18n="restart" value="Reboot"></button>
 	</form>
@@ -245,16 +245,31 @@
 			box.innerText = text;
 			box.style.display = "block";
 		}
+		// Disable the form and turn the Connect button into a "Connecting …"
+		// indicator while a live test is in flight, so it's obvious the box is
+		// working (the button is where the eye already is). Re-enabled on failure
+		// so the user can fix the credentials and retry.
+		function setFormBusy(busy) {
+			const form = document.getElementById("settings");
+			for (const el of form.elements) {
+				el.disabled = busy;
+			}
+			const btn = document.getElementById("save-button");
+			btn.innerText = busy ? i18next.t("wifi.test.connectingBtn") : i18next.t("wifi.saveButton");
+		}
 		async function pollTestStatus() {
 			try {
 				const data = await (await fetch("/wifistatus")).json();
 				if (data.test) {
 					const t = data.test;
 					if (t.phase === "success") {
+						document.getElementById("settings").style.display = "none";
+						document.getElementById("restartform").style.display = "none";
 						showTestStatus("success", i18next.t("wifi.test.success", { ssid: t.ssid, ip: t.ip }));
 						return;
 					}
 					if (t.phase === "failed") {
+						setFormBusy(false);
 						const cls = ["wrong_password", "not_found", "rejected", "timeout"].includes(t.class) ? t.class : "other";
 						showTestStatus("failed", i18next.t("wifi.fail." + cls, { ssid: t.ssid, code: t.reason }));
 						return;
@@ -268,6 +283,7 @@
 			setTimeout(pollTestStatus, 1500);
 		}
 		async function wifiConfig() {
+			setFormBusy(true);
 			let static = document.getElementById('static_enabled').checked;
 			const ssid = document.getElementById('ssid').value;
 			var myObj = {
@@ -316,6 +332,7 @@
 				showTestStatus("progress", i18next.t("wifi.test.connecting", { ssid: ssid }));
 				setTimeout(pollTestStatus, 1000);
 			} else {
+				setFormBusy(false);
 				showTestStatus("failed", i18next.t("wifi.fail.other", { ssid: ssid, code: 0 }));
 			}
 		}

--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -265,6 +265,7 @@
 					if (t.phase === "success") {
 						document.getElementById("settings").style.display = "none";
 						document.getElementById("restartform").style.display = "none";
+						retargetFullInterfaceCard(t.ip);
 						showTestStatus("success", i18next.t("wifi.test.success", { ssid: t.ssid, ip: t.ip }));
 						return;
 					}
@@ -355,6 +356,25 @@
 		// IP. Copying a URL built from that would produce a link that resolves to the real apple.com (or
 		// whichever host) once opened outside the captive session - not back to ESPuino. The AP's IP is a
 		// fixed constant (see apIP in Wlan.cpp), so hardcoding it here is the robust choice.
+		// A successful test closes the AP moments later, which kills the 192.168.4.1
+		// address this card advertises — and the card's premise ("skip WiFi setup")
+		// no longer applies either. Repoint it at the address the box just obtained
+		// and relabel it, so the copy button hands the user a link that still works
+		// once the setup network is gone.
+		function retargetFullInterfaceCard(ip) {
+			document.getElementById("full-interface-url").value = `http://${ip}/management.html`;
+			const title = document.querySelector('[data-i18n="wifi.fullInterface.title"]');
+			const hint = document.querySelector('[data-i18n="wifi.fullInterface.hint"]');
+			if (title) {
+				title.setAttribute("data-i18n", "wifi.test.reachTitle");
+			}
+			if (hint) {
+				hint.setAttribute("data-i18n", "wifi.test.reachHint");
+			}
+			if (typeof localize === "function") {
+				localize('body');
+			}
+		}
 		function setupFullInterfaceLink() {
 			const urlField = document.getElementById("full-interface-url");
 			urlField.value = "http://192.168.4.1/management.html";

--- a/html/accesspoint.html
+++ b/html/accesspoint.html
@@ -91,6 +91,7 @@
 		</div>
 		<h1 data-i18n="wifi.title"></h1>
 		<div id="connstatus" style="display:none;background:#f8d7da;color:#721c24;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
+		<div id="teststatus" style="display:none;border-radius:4px;padding:10px;margin:10px 0;text-align:left"></div>
 		<div id="WiFiList"></div>
 		<label for="ssid" data-i18n="wifi.ssid.title"></label>: <br>
 		<input type="text" id="ssid" name="ssid" placeholder="SSID" required>
@@ -229,10 +230,48 @@
 			let new_style = this.checked ? null : "none";
 			document.getElementById("wifi_static_div").style.display = new_style;
 		};
+		// live connection test: kicked off after saving, result shown in-page
+		const testStatusColors = {
+			progress: ["#cce5ff", "#004085"],
+			success: ["#d4edda", "#155724"],
+			failed: ["#f8d7da", "#721c24"]
+		};
+		let lastTestState = null;
+		function showTestStatus(kind, text) {
+			lastTestState = { kind: kind, text: text };
+			const box = document.getElementById("teststatus");
+			box.style.background = testStatusColors[kind][0];
+			box.style.color = testStatusColors[kind][1];
+			box.innerText = text;
+			box.style.display = "block";
+		}
+		async function pollTestStatus() {
+			try {
+				const data = await (await fetch("/wifistatus")).json();
+				if (data.test) {
+					const t = data.test;
+					if (t.phase === "success") {
+						showTestStatus("success", i18next.t("wifi.test.success", { ssid: t.ssid, ip: t.ip }));
+						return;
+					}
+					if (t.phase === "failed") {
+						const cls = ["wrong_password", "not_found", "rejected", "timeout"].includes(t.class) ? t.class : "other";
+						showTestStatus("failed", i18next.t("wifi.fail." + cls, { ssid: t.ssid, code: t.reason }));
+						return;
+					}
+					showTestStatus("progress", i18next.t("wifi.test.connecting", { ssid: t.ssid }));
+				}
+			} catch (error) {
+				// expected while the AP hops to the target network's channel
+				console.log(error);
+			}
+			setTimeout(pollTestStatus, 1500);
+		}
 		async function wifiConfig() {
 			let static = document.getElementById('static_enabled').checked;
+			const ssid = document.getElementById('ssid').value;
 			var myObj = {
-				ssid: document.getElementById('ssid').value,
+				ssid: ssid,
 				pwd: document.getElementById('pwd').value,
 				static: static
 			};
@@ -264,6 +303,21 @@
 				},
 				body: JSON.stringify(myObj)
 			});
+			// try the credentials right away, while the AP stays up
+			document.getElementById("connstatus").style.display = "none";
+			const response = await fetch("/wifitest", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify({ ssid: ssid })
+			});
+			if (response.ok) {
+				showTestStatus("progress", i18next.t("wifi.test.connecting", { ssid: ssid }));
+				setTimeout(pollTestStatus, 1000);
+			} else {
+				showTestStatus("failed", i18next.t("wifi.fail.other", { ssid: ssid, code: 0 }));
+			}
 		}
 		addEventListener("DOMContentLoaded", (event) => {
 			getWiFiList();

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -178,6 +178,7 @@
 		},
 		"test": {
 			"connecting": "Verbinde mit \"{{ssid}}\" …",
+			"connectingBtn": "Verbinde …",
 			"success": "Verbunden! Die Box hat die IP {{ip}} erhalten und verlässt jetzt den Einrichtungsmodus. Verbinde dein Telefon wieder mit deinem normalen WLAN und erreiche die Box unter http://{{ip}}"
 		}
 	},

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -173,7 +173,12 @@
 			"wrong_password": "Verbindung mit \"{{ssid}}\" fehlgeschlagen — vermutlich ist das Passwort falsch (Code {{code}}). Bitte prüfen und erneut eingeben.",
 			"not_found": "Das Netzwerk \"{{ssid}}\" wurde nicht gefunden (Code {{code}}). Ist es in Reichweite und auf 2,4 GHz?",
 			"rejected": "Der Router hat die Verbindung mit \"{{ssid}}\" abgelehnt (Code {{code}}). MAC-Filter, Client-Limits oder Sicherheitseinstellungen prüfen (WPA2 erforderlich).",
-			"other": "Verbindung mit \"{{ssid}}\" fehlgeschlagen (Code {{code}})."
+			"other": "Verbindung mit \"{{ssid}}\" fehlgeschlagen (Code {{code}}).",
+			"timeout": "Mit \"{{ssid}}\" verbunden, aber keine IP-Adresse erhalten (Code {{code}}). DHCP-Einstellungen des Routers prüfen."
+		},
+		"test": {
+			"connecting": "Verbinde mit \"{{ssid}}\" …",
+			"success": "Verbunden! Die Box hat die IP {{ip}} erhalten und verlässt jetzt den Einrichtungsmodus. Verbinde dein Telefon wieder mit deinem normalen WLAN und erreiche die Box unter http://{{ip}}"
 		}
 	},
 	"control": {

--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -179,7 +179,9 @@
 		"test": {
 			"connecting": "Verbinde mit \"{{ssid}}\" …",
 			"connectingBtn": "Verbinde …",
-			"success": "Verbunden! Die Box hat die IP {{ip}} erhalten und verlässt jetzt den Einrichtungsmodus. Verbinde dein Telefon wieder mit deinem normalen WLAN und erreiche die Box unter http://{{ip}}"
+			"success": "Verbunden! Die Box hat die IP {{ip}} erhalten und verlässt jetzt den Einrichtungsmodus. Verbinde dein Telefon wieder mit deinem normalen WLAN und erreiche die Box unter http://{{ip}}",
+			"reachTitle": "ESPuino erreichen",
+			"reachHint": "Dein ESPuino ist jetzt unter dieser Adresse in deinem WLAN erreichbar. Kopiere sie oder speichere sie als Lesezeichen — das Einrichtungs-WLAN wird geschlossen."
 		}
 	},
 	"control": {

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -179,7 +179,9 @@
 		"test": {
 			"connecting": "Trying to connect to \"{{ssid}}\" …",
 			"connectingBtn": "Connecting …",
-			"success": "Connected! The box got IP {{ip}}. It will now leave setup mode — reconnect your phone to your normal WiFi and reach the box at http://{{ip}}"
+			"success": "Connected! The box got IP {{ip}}. It will now leave setup mode — reconnect your phone to your normal WiFi and reach the box at http://{{ip}}",
+			"reachTitle": "Reach your ESPuino",
+			"reachHint": "Your ESPuino is now on your WiFi at this address. Copy it or save it as a bookmark — the setup network is closing."
 		}
 	},
 	"control": {

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -173,7 +173,12 @@
 			"wrong_password": "Could not join \"{{ssid}}\" — the password is probably wrong (code {{code}}). Please check it and try again.",
 			"not_found": "Network \"{{ssid}}\" was not found (code {{code}}). Is it in range and on 2.4 GHz?",
 			"rejected": "The router refused the connection to \"{{ssid}}\" (code {{code}}). Check MAC filters, client limits or security settings (WPA2 required).",
-			"other": "Connecting to \"{{ssid}}\" failed (code {{code}})."
+			"other": "Connecting to \"{{ssid}}\" failed (code {{code}}).",
+			"timeout": "Joined \"{{ssid}}\", but no IP address was received (code {{code}}). Check the router's DHCP settings."
+		},
+		"test": {
+			"connecting": "Trying to connect to \"{{ssid}}\" …",
+			"success": "Connected! The box got IP {{ip}}. It will now leave setup mode — reconnect your phone to your normal WiFi and reach the box at http://{{ip}}"
 		}
 	},
 	"control": {

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -178,6 +178,7 @@
 		},
 		"test": {
 			"connecting": "Trying to connect to \"{{ssid}}\" …",
+			"connectingBtn": "Connecting …",
 			"success": "Connected! The box got IP {{ip}}. It will now leave setup mode — reconnect your phone to your normal WiFi and reach the box at http://{{ip}}"
 		}
 	},

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -173,7 +173,12 @@
 			"wrong_password": "Impossible de rejoindre « {{ssid}} » — le mot de passe est probablement incorrect (code {{code}}). Veuillez le vérifier et réessayer.",
 			"not_found": "Le réseau « {{ssid}} » est introuvable (code {{code}}). Est-il à portée et en 2,4 GHz ?",
 			"rejected": "Le routeur a refusé la connexion à « {{ssid}} » (code {{code}}). Vérifiez les filtres MAC, les limites de clients ou les paramètres de sécurité (WPA2 requis).",
-			"other": "Échec de la connexion à « {{ssid}} » (code {{code}})."
+			"other": "Échec de la connexion à « {{ssid}} » (code {{code}}).",
+			"timeout": "Connecté à « {{ssid}} », mais aucune adresse IP reçue (code {{code}}). Vérifiez les paramètres DHCP du routeur."
+		},
+		"test": {
+			"connecting": "Connexion à « {{ssid}} » …",
+			"success": "Connecté ! La box a reçu l'adresse IP {{ip}} et quitte maintenant le mode configuration. Reconnectez votre téléphone à votre WiFi habituel et accédez à la box via http://{{ip}}"
 		}
 	},
 	"control": {

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -178,6 +178,7 @@
 		},
 		"test": {
 			"connecting": "Connexion à « {{ssid}} » …",
+			"connectingBtn": "Connexion …",
 			"success": "Connecté ! La box a reçu l'adresse IP {{ip}} et quitte maintenant le mode configuration. Reconnectez votre téléphone à votre WiFi habituel et accédez à la box via http://{{ip}}"
 		}
 	},

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -179,7 +179,9 @@
 		"test": {
 			"connecting": "Connexion à « {{ssid}} » …",
 			"connectingBtn": "Connexion …",
-			"success": "Connecté ! La box a reçu l'adresse IP {{ip}} et quitte maintenant le mode configuration. Reconnectez votre téléphone à votre WiFi habituel et accédez à la box via http://{{ip}}"
+			"success": "Connecté ! La box a reçu l'adresse IP {{ip}} et quitte maintenant le mode configuration. Reconnectez votre téléphone à votre WiFi habituel et accédez à la box via http://{{ip}}",
+			"reachTitle": "Accéder à votre ESPuino",
+			"reachHint": "Votre ESPuino est maintenant accessible à cette adresse sur votre WiFi. Copiez-la ou enregistrez-la dans vos favoris — le réseau de configuration va se fermer."
 		}
 	},
 	"control": {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -76,6 +76,7 @@ static void explorerHandleAudioRequest(AsyncWebServerRequest *request);
 static void handleTrackProgressRequest(AsyncWebServerRequest *request);
 static void handleGetSavedSSIDs(AsyncWebServerRequest *request);
 static void handleGetWifiStatus(AsyncWebServerRequest *request);
+static void handlePostWifiTest(AsyncWebServerRequest *request, JsonVariant &json);
 static void handlePostSavedSSIDs(AsyncWebServerRequest *request, JsonVariant &json);
 static void handleDeleteSavedSSIDs(AsyncWebServerRequest *request);
 static void handleGetActiveSSID(AsyncWebServerRequest *request);
@@ -628,6 +629,7 @@ void webserverStart(void) {
 		wServer.on("/savedSSIDs", HTTP_DELETE, handleDeleteSavedSSIDs);
 		wServer.on("/activeSSID", HTTP_GET, handleGetActiveSSID);
 		wServer.on("/wifistatus", HTTP_GET, handleGetWifiStatus);
+		wServer.addHandler(new AsyncCallbackJsonWebHandler("/wifitest", handlePostWifiTest));
 
 		wServer.on("/wificonfig", HTTP_GET, handleGetWiFiConfig);
 		wServer.addHandler(new AsyncCallbackJsonWebHandler("/wificonfig", handlePostWiFiConfig));
@@ -2239,6 +2241,8 @@ void handleGetSavedSSIDs(AsyncWebServerRequest *request) {
 // reported alongside for the curious/for support.
 static const char *classifyDisconnectReason(uint8_t reason) {
 	switch (reason) {
+		case 0: // no disconnect event: association held, but no IP arrived
+			return "timeout";
 		case WIFI_REASON_AUTH_EXPIRE:
 		case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
 		case WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT:
@@ -2285,8 +2289,34 @@ void handleGetWifiStatus(AsyncWebServerRequest *request) {
 		fail["class"] = classifyDisconnectReason(failReason);
 	}
 
+	// live connection test (started via POST /wifitest from the setup page)
+	const char *testPhase = Wlan_GetTestPhase();
+	if (strcmp(testPhase, "idle") != 0) {
+		JsonObject test = obj["test"].to<JsonObject>();
+		test["phase"] = testPhase;
+		test["ssid"] = Wlan_GetTestSsid();
+		if (strcmp(testPhase, "failed") == 0) {
+			const uint8_t reason = Wlan_GetTestReason();
+			test["reason"] = reason;
+			test["class"] = classifyDisconnectReason(reason);
+		} else if (strcmp(testPhase, "success") == 0) {
+			test["ip"] = Wlan_GetIpAddress();
+		}
+	}
+
 	response->setLength();
 	request->send(response);
+}
+
+// Start a live connection test while in AP mode. Body: {"ssid": "..."} —
+// the credentials must have been saved via POST /savedSSIDs beforehand.
+void handlePostWifiTest(AsyncWebServerRequest *request, JsonVariant &json) {
+	const char *ssid = json["ssid"].as<const char *>();
+	if (!ssid || !Wlan_StartConnectionTest(ssid)) {
+		request->send(400);
+		return;
+	}
+	request->send(200);
 }
 
 void handlePostSavedSSIDs(AsyncWebServerRequest *request, JsonVariant &json) {

--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -63,6 +63,27 @@ static String lastAttemptSsid;
 static constexpr const char *nvsFailSsidKey = "wifiFailSsid";
 static constexpr const char *nvsFailReasonKey = "wifiFailReason";
 
+// Live connection test, runnable while the setup AP stays up (WIFI_AP_STA):
+// the accesspoint page saves credentials, POSTs /wifitest and then polls
+// /wifistatus — so the user gets immediate feedback (wrong password, no IP,
+// success + IP) instead of the old save → reboot → hope flow.
+enum class WifiTestPhase : uint8_t {
+	Idle = 0,
+	Pending, // requested by the web handler, not yet started
+	Connecting,
+	Success,
+	Failed
+};
+static volatile WifiTestPhase testPhase = WifiTestPhase::Idle;
+static WiFiSettings testSettings;
+static uint8_t testFailReason = 0;
+static uint32_t testStartTimestamp = 0;
+static uint32_t testSuccessTimestamp = 0;
+// how long a test attempt may take before it is declared failed (assoc + DHCP)
+static constexpr uint32_t testTimeout = 25000;
+// how long the result stays visible on the AP before switching to normal mode
+static constexpr uint32_t testSuccessLinger = 15000;
+
 // state for persistent settings
 static constexpr const char *nvsWiFiNamespace = "wifi-settings";
 static constexpr const char *nvsWiFiKey = "wifi-";
@@ -630,6 +651,57 @@ void handleWifiStateAP() {
 		return;
 	}
 
+	switch (testPhase) {
+		case WifiTestPhase::Pending:
+			// bring the station interface up next to the AP and try the
+			// credentials. The AP may hop to the target network's channel,
+			// briefly interrupting the portal client — the page just keeps
+			// polling.
+			wifiAPStartedTimestamp = millis(); // user is mid-setup: keep AP alive
+			WiFi.mode(WIFI_AP_STA);
+			connectToKnownNetwork(testSettings);
+			testStartTimestamp = millis();
+			testPhase = WifiTestPhase::Connecting;
+			break;
+		case WifiTestPhase::Connecting:
+			wifiAPStartedTimestamp = millis();
+			if (WiFi.status() == WL_CONNECTED) {
+				testSuccessTimestamp = millis();
+				testPhase = WifiTestPhase::Success;
+				// the credentials work — drop any stale failure diagnostics
+				if (gPrefsSettings.isKey(nvsFailReasonKey)) {
+					gPrefsSettings.remove(nvsFailReasonKey);
+					gPrefsSettings.remove(nvsFailSsidKey);
+				}
+				Log_Printf(LOGLEVEL_NOTICE, "WiFi-test: connected to %s, IP: %s", testSettings.ssid.c_str(), WiFi.localIP().toString().c_str());
+			} else if (millis() - testStartTimestamp > testTimeout) {
+				// reason stays 0 when association worked but no IP arrived
+				testFailReason = lastDisconnectReason;
+				testPhase = WifiTestPhase::Failed;
+				gPrefsSettings.putString(nvsFailSsidKey, testSettings.ssid);
+				gPrefsSettings.putUChar(nvsFailReasonKey, testFailReason);
+				Log_Printf(LOGLEVEL_ERROR, "WiFi-test: failed for %s (reason %u)", testSettings.ssid.c_str(), testFailReason);
+				WiFi.disconnect(true, true);
+				WiFi.mode(WIFI_AP);
+			}
+			break;
+		case WifiTestPhase::Success:
+			wifiAPStartedTimestamp = millis();
+			// leave the result on screen for a moment, then close the AP and
+			// continue as a normally connected station
+			if (millis() - testSuccessTimestamp > testSuccessLinger) {
+				testPhase = WifiTestPhase::Idle;
+				WiFi.softAPdisconnect(false);
+				WiFi.mode(WIFI_STA);
+				wifiState = WIFI_STATE_CONN_SUCCESS;
+				return;
+			}
+			break;
+		default:
+			// Idle: nothing to do; Failed: wait for the user to retry
+			break;
+	}
+
 	dnsServer->processNextRequest();
 }
 
@@ -822,6 +894,48 @@ const char *Wlan_GetConnectState(void) {
 		default:
 			return "connecting";
 	}
+}
+
+// Start a live connection test for a saved network while the setup AP is up.
+// Returns false when not in AP mode, a test is already running, or the SSID
+// has no saved settings.
+bool Wlan_StartConnectionTest(const String &ssid) {
+	if (wifiState != WIFI_STATE_AP) {
+		return false;
+	}
+	if (testPhase == WifiTestPhase::Pending || testPhase == WifiTestPhase::Connecting) {
+		return false;
+	}
+	const auto entry = getNvsWifiSettings(ssid);
+	if (!entry) {
+		return false;
+	}
+	testSettings = entry->value;
+	testFailReason = 0;
+	testPhase = WifiTestPhase::Pending; // picked up by handleWifiStateAP()
+	return true;
+}
+
+const char *Wlan_GetTestPhase(void) {
+	switch (testPhase) {
+		case WifiTestPhase::Pending:
+		case WifiTestPhase::Connecting:
+			return "connecting";
+		case WifiTestPhase::Success:
+			return "success";
+		case WifiTestPhase::Failed:
+			return "failed";
+		default:
+			return "idle";
+	}
+}
+
+uint8_t Wlan_GetTestReason(void) {
+	return testFailReason;
+}
+
+const String Wlan_GetTestSsid(void) {
+	return testSettings.ssid;
 }
 
 // Diagnostics of the last failed connection attempt (cleared on success)

--- a/src/Wlan.h
+++ b/src/Wlan.h
@@ -134,3 +134,7 @@ int8_t Wlan_GetRssi(void);
 bool Wlan_ConnectionTryInProgress(void);
 const char *Wlan_GetConnectState(void);
 bool Wlan_GetLastFailure(String &ssid, uint8_t &reason);
+bool Wlan_StartConnectionTest(const String &ssid);
+const char *Wlan_GetTestPhase(void);
+uint8_t Wlan_GetTestReason(void);
+const String Wlan_GetTestSsid(void);


### PR DESCRIPTION
Replaces the save → reboot → hope onboarding flow. After saving, the setup page POSTs
`/wifitest` and the box tries the credentials on the station interface **while the setup AP
stays up** (`WIFI_AP_STA`). The page polls `/wifistatus` and shows the outcome in place:

- **connecting:** the form is disabled and the Connect button becomes a "Connecting …"
  indicator (survives the brief hiccup when the AP hops to the target network's channel)
- **failed:** the classified reason, same vocabulary as PR 3's banner. The AP stays up and the
  form is re-enabled, so the user can correct and retry immediately.
- **success:** the obtained IP is shown, then the box closes the AP and continues as a normally
  connected station — no reboot, no vanishing portal.

Two supporting fixes:
- The AP idle-close timer is suspended while a test runs, so the portal can't disappear under a
  slow typist mid-setup.
- On success the "just want the web interface?" card is repointed at the IP the box just
  obtained and relabelled. It advertises `http://192.168.4.1/management.html` (hardcoded,
  because the captive-portal DNS makes `location.host` unusable) — an address that dies the
  moment the AP closes, so the copy button was handing out a dead link.

Built on PR 3 — it reuses the failure classification and `/wifistatus`. Rebases down to its own
commits once that lands.

**Known intermittency:** in 7 correct-password runs on a weak link (~-74 dBm), one failed with
`AUTH_FAIL` and was reported as "password is probably wrong". The same credentials connect
instantly in plain STA, so it looks like a transient auth failure in `AP_STA` (the radio
time-slices between AP and station). It's recoverable — the AP stays up and a retry works —
but a retry-before-declaring-failure would harden it if you'd rather.


<img width="780" height="1688" alt="pr4-liveflow-wrongpw-2-connecting" src="https://github.com/user-attachments/assets/13a82e0a-7957-44c2-886f-78a42577789c" />
<img width="780" height="1688" alt="pr4-liveflow-wrongpw-3-fail" src="https://github.com/user-attachments/assets/2386740f-caec-467e-9507-30ebd06f6e9b" />
<img width="780" height="1688" alt="pr4-liveflow-success-3-success" src="https://github.com/user-attachments/assets/7e591ffa-4009-49d8-8389-bc2da36a992e" />