### PR TITLE
Explorer raw upload - great improvement for upload speed

### DIFF
--- a/REST-API.yaml
+++ b/REST-API.yaml
@@ -42,24 +42,23 @@ paths:
                         True if item is a directory. This parameter is omitted
                         for a file.
     post:
-      summary: Upload a file to a directory.
-      description: Upload a file to the specified directory.
+      summary: Upload a file.
+      description: >-
+        Uploads a single file, given as a raw binary body (not multipart/
+        form-data). To upload several files, send one request per file.
       parameters:
         - in: query
           name: path
           schema:
             type: string
-          description: Directory path to upload the file.
+          description: Full target path, including the filename, to upload the file to.
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/octet-stream:
             schema:
-              type: object
-              properties:
-                file:
-                  type: string
-                  format: binary
+              type: string
+              format: binary
       responses:
         "200":
           description: File successfully uploaded.

--- a/html/management.html
+++ b/html/management.html
@@ -2567,10 +2567,14 @@
 			});
 		}
 		/* File Upload */
+		// EXPERIMENTAL (feature-mediahub): raw-body PUT per file instead of one
+		// multipart/form-data POST for the whole batch, to test whether skipping
+		// MIME boundary parsing on the ESPuino side measurably improves upload
+		// throughput. Server side: explorerHandleRawUpload() in Web.cpp. Promote
+		// to its own branch/PR if this pans out, revert otherwise.
 		$('#explorerUploadForm').submit(function (e) {
 			e.preventDefault();
 			console.log("Upload!");
-			var data = new FormData(this);
 			var ref = $('#explorerTree').jstree(true),
 				sel = ref.get_selected(),
 				path = "/";
@@ -2578,7 +2582,8 @@
 				alert(i18next.t("files.upload.selectFolder"));
 				return false;
 			}
-			if (!document.getElementById('uploaded_file').files.length > 0) {
+			const fileInput = document.getElementById('uploaded_file');
+			if (!(fileInput.files.length > 0)) {
 				alert(i18next.t("files.upload.selectFile"));
 				return false;
 			}
@@ -2593,87 +2598,111 @@
 				path = parentNode.data.path;
 				console.log("Parent path: " + path);
 			}
+
+			const files = Array.from(fileInput.files);
+			const bytesTotal = files.reduce((sum, f) => sum + f.size, 0);
 			const startTime = new Date().getTime();
-			let bytesTotal = 0;
 			const eup = $("#explorerUploadProgress");
-			$.ajax({
-				url: '/explorer?path=' + encodeURIComponent(path),
-				type: 'POST',
-				data: data,
-				contentType: false,
-				processData: false,
-				xhr: function () {
-					var xhr = new window.XMLHttpRequest();
-					xhr.upload.addEventListener("progress", function (evt) {
-						if (evt.lengthComputable) {
-							const now = new Date().getTime();
-							const percent = parseInt(evt.loaded * 100 / evt.total);
-							const elapsed = (now - startTime) / 1000;
-							bytesTotal = evt.total;
-							let progressText = i18next.t("files.upload.timeCalc");
-							if (elapsed) {
-								const bps = evt.loaded / elapsed;
-								const kbps = bps / 1024;
-								const remaining = Math.round((evt.total - evt.loaded) / bps);
-								const data = {
-									percent: percent,
-									remaining: {
-										unit: (remaining > 60) ? i18next.t("files.upload.minutes", {
-											count: Math.round(remaining / 60)
-										}) : i18next.t("files.upload.seconds"),
-										value: (remaining > 60) ? Math.round(remaining / 60) : ((remaining > 2) ? remaining : i18next.t("files.upload.fewSec"))
-									},
-									speed: kbps.toFixed(2)
-								}
-								progressText = i18next.t("files.upload.progress", data);
-								console.log("Percent: " + percent + "%% " + kbps.toFixed(2) + " KB/s");
-							}
-							$('.progress-bar', eup).css('width', percent + "%");
-							$('.label', eup).text(progressText);
-						}
-					}, false);
-					eup.addClass('bg-primary bg-opacity-75');
-					$('.progress-bar', eup).removeClass('bg-danger');
-					return xhr;
-				},
-				success: function (data, textStatus, jqXHR) {
-					const now = new Date().getTime();
-					const elapsed = (now - startTime) / 1000;
-					let transData = {
-						elapsed: "00:00",
-						speed: "0,00"
-					};
-					if (elapsed) {
-						const bps = bytesTotal / elapsed;
-						const kbps = bps / 1024;
-						const date = new Date(null);
-						date.setSeconds(elapsed);
-						const timeText = date.toISOString().substr(11, 8);
-						transData = {
-							elapsed: timeText,
-							speed: kbps.toFixed(2)
-						};
+			eup.addClass('bg-primary bg-opacity-75');
+			$('.progress-bar', eup).removeClass('bg-danger');
+			let bytesDoneBefore = 0;
+
+			function showProgress(loaded) {
+				const now = new Date().getTime();
+				const percent = bytesTotal ? parseInt(loaded * 100 / bytesTotal) : 100;
+				const elapsed = (now - startTime) / 1000;
+				let progressText = i18next.t("files.upload.timeCalc");
+				if (elapsed && loaded) {
+					const bps = loaded / elapsed;
+					const kbps = bps / 1024;
+					const remaining = Math.round((bytesTotal - loaded) / bps);
+					const data = {
+						percent: percent,
+						remaining: {
+							unit: (remaining > 60) ? i18next.t("files.upload.minutes", {
+								count: Math.round(remaining / 60)
+							}) : i18next.t("files.upload.seconds"),
+							value: (remaining > 60) ? Math.round(remaining / 60) : ((remaining > 2) ? remaining : i18next.t("files.upload.fewSec"))
+						},
+						speed: kbps.toFixed(2)
 					}
-					console.log("Upload success (" + transData.elapsed + ", " + transData.speed + " KB/s): " + textStatus);
-					const progressText = i18next.t("files.upload.success", transData);
-					$('.label', eup).text(progressText);
-					document.getElementById('uploaded_file').value = '';
-					document.getElementById('uploaded_file_text').innerHTML = '';
-					getData("http://" + host + "/explorer?path=" + path, function (data) {
-						/* We now have data! */
-						deleteChildrenNodes(sel);
-						addFileDirectory(sel, data);
-						ref.open_node(sel);
-					});
-				},
-				error: function (request, status, error) {
-					console.log("Upload ERROR!", request);
-					eup.removeClass('bg-primary bg-opacity-75');
-					$('.progress-bar', eup).addClass('bg-danger');
-					$('.label', eup).text(i18next.t("files.upload.error") + ": " + request.statusText);
-					toaster.error(i18next.t("files.upload.error") + ": " + request.statusText);
+					progressText = i18next.t("files.upload.progress", data);
 				}
-			});
+				$('.progress-bar', eup).css('width', percent + "%");
+				$('.label', eup).text(progressText);
+			}
+
+			function uploadFailed(statusText) {
+				console.log("Upload ERROR!", statusText);
+				eup.removeClass('bg-primary bg-opacity-75');
+				$('.progress-bar', eup).addClass('bg-danger');
+				$('.label', eup).text(i18next.t("files.upload.error") + ": " + statusText);
+				toaster.error(i18next.t("files.upload.error") + ": " + statusText);
+			}
+
+			function uploadDone() {
+				const now = new Date().getTime();
+				const elapsed = (now - startTime) / 1000;
+				let transData = {
+					elapsed: "00:00",
+					speed: "0,00"
+				};
+				if (elapsed) {
+					const bps = bytesTotal / elapsed;
+					const kbps = bps / 1024;
+					const date = new Date(null);
+					date.setSeconds(elapsed);
+					const timeText = date.toISOString().substr(11, 8);
+					transData = {
+						elapsed: timeText,
+						speed: kbps.toFixed(2)
+					};
+				}
+				console.log("Upload success (" + transData.elapsed + ", " + transData.speed + " KB/s)");
+				$('.label', eup).text(i18next.t("files.upload.success", transData));
+				fileInput.value = '';
+				document.getElementById('uploaded_file_text').innerHTML = '';
+				getData("http://" + host + "/explorer?path=" + path, function (data) {
+					/* We now have data! */
+					deleteChildrenNodes(sel);
+					addFileDirectory(sel, data);
+					ref.open_node(sel);
+				});
+			}
+
+			// Files upload one at a time (the shared double-buffer/writer-task
+			// on the ESPuino only supports one active upload at a time) - each as
+			// its own raw PUT, with the target path (folder + filename) passed as
+			// a query param since a raw body carries no per-part filename.
+			function uploadNext(idx) {
+				if (idx >= files.length) {
+					uploadDone();
+					return;
+				}
+				const file = files[idx];
+				const targetPath = (path.endsWith('/') ? path : path + '/') + file.name;
+				const xhr = new XMLHttpRequest();
+				xhr.open('PUT', '/explorerraw?path=' + encodeURIComponent(targetPath));
+				xhr.setRequestHeader('Content-Type', 'application/octet-stream');
+				xhr.upload.addEventListener('progress', function (evt) {
+					if (evt.lengthComputable) {
+						showProgress(bytesDoneBefore + evt.loaded);
+					}
+				}, false);
+				xhr.onload = function () {
+					if (xhr.status >= 200 && xhr.status < 300) {
+						bytesDoneBefore += file.size;
+						uploadNext(idx + 1);
+					} else {
+						uploadFailed(xhr.statusText || ("HTTP " + xhr.status));
+					}
+				};
+				xhr.onerror = function () {
+					uploadFailed(i18next.t("files.upload.error"));
+				};
+				xhr.send(file);
+			}
+			uploadNext(0);
 		});
 		/* File Delete */
 		function handleDeleteData(nodeId) {

--- a/html/management.html
+++ b/html/management.html
@@ -2567,11 +2567,10 @@
 			});
 		}
 		/* File Upload */
-		// EXPERIMENTAL (feature-mediahub): raw-body PUT per file instead of one
-		// multipart/form-data POST for the whole batch, to test whether skipping
-		// MIME boundary parsing on the ESPuino side measurably improves upload
-		// throughput. Server side: explorerHandleRawUpload() in Web.cpp. Promote
-		// to its own branch/PR if this pans out, revert otherwise.
+		// Each selected file is sent as its own raw (application/octet-stream)
+		// POST instead of bundling the whole batch into one multipart/form-data
+		// request - server side (explorerHandleFileUpload() in Web.cpp) never has
+		// to parse MIME boundaries, which measurably improved throughput.
 		$('#explorerUploadForm').submit(function (e) {
 			e.preventDefault();
 			console.log("Upload!");
@@ -2682,7 +2681,7 @@
 				const file = files[idx];
 				const targetPath = (path.endsWith('/') ? path : path + '/') + file.name;
 				const xhr = new XMLHttpRequest();
-				xhr.open('PUT', '/explorerraw?path=' + encodeURIComponent(targetPath));
+				xhr.open('POST', '/explorer?path=' + encodeURIComponent(targetPath));
 				xhr.setRequestHeader('Content-Type', 'application/octet-stream');
 				xhr.upload.addEventListener('progress', function (evt) {
 					if (evt.lengthComputable) {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -65,12 +65,12 @@ static std::atomic<bool> uploadAborted = false;
 
 void Web_DumpSdToNvs(const char *_filename);
 static void handleUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final);
-static void explorerHandleFileUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final);
-// EXPERIMENTAL, feature-mediahub only (see commit message): raw-body upload,
-// tested against the multipart path above to see whether skipping MIME
-// boundary parsing measurably helps throughput. Promote to its own
-// branch/PR if it does, drop otherwise.
-static void explorerHandleRawUpload(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
+// Raw (non-multipart) request body: one PUT/POST per file, the target path
+// (folder + filename) travels in the "path" query param since a raw body
+// carries no per-part filename. The client is responsible for looping over
+// multiple files sequentially - see the double-buffer/writer-task machinery
+// below, which only supports one upload in flight at a time.
+static void explorerHandleFileUpload(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
 static void explorerHandleFileStorageTask(void *parameter);
 static void explorerHandleListRequest(AsyncWebServerRequest *request);
 static void explorerHandleDownloadRequest(AsyncWebServerRequest *request);
@@ -613,18 +613,7 @@ void webserverStart(void) {
 					request->send(200);
 				}
 			},
-			explorerHandleFileUpload);
-
-		// EXPERIMENTAL (feature-mediahub): raw-body upload path, see the
-		// declaration comment above explorerHandleRawUpload().
-		wServer.on(
-			"/explorerraw", HTTP_PUT, [](AsyncWebServerRequest *request) {
-				request->onDisconnect([]() { destroyDoubleBuffer(); });
-				if (!request->_tempObject) {
-					request->send(200);
-				}
-			},
-			NULL, explorerHandleRawUpload);
+			NULL, explorerHandleFileUpload);
 
 		wServer.on("/explorerdownload", HTTP_GET, explorerHandleDownloadRequest);
 
@@ -1740,150 +1729,11 @@ void onWebsocketEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsE
 	}
 }
 
-// Handles file upload request from the explorer
-// requires a GET parameter path, as directory path to the file
-void explorerHandleFileUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
-
-	System_UpdateActivityTimer();
-
-	// New File
-	if (!index) {
-		// reset abort flag
-		uploadAborted = false;
-
-		String utf8Folder = "/";
-		String utf8FilePath;
-		if (request->hasParam("path")) {
-			const AsyncWebParameter *param = request->getParam("path");
-			utf8Folder = param->value() + "/";
-		}
-		utf8FilePath = utf8Folder + filename;
-
-		const char *filePath = utf8FilePath.c_str();
-
-		Log_Printf(LOGLEVEL_INFO, writingFile, filePath);
-
-		if (!allocateDoubleBuffer()) {
-			// we failed to allocate enough memory
-			Log_Println(unableToAllocateMem, LOGLEVEL_ERROR);
-			handleUploadError(request, 500);
-			return;
-		}
-
-		// Create Queue for receiving a signal from the store task as synchronisation
-		if (explorerFileUploadFinished == NULL) {
-			explorerFileUploadFinished = xSemaphoreCreateBinary();
-		} else {
-			// make sure semaphore is empty
-			xSemaphoreTake(explorerFileUploadFinished, 0);
-		}
-
-		// reset buffers
-		index_buffer_write = 0;
-		index_buffer_read = 0;
-		for (uint32_t i = 0; i < nr_of_buffers; i++) {
-			size_in_buffer[i] = 0;
-			buffer_full[i] = false;
-		}
-
-		// Create Task for handling the storage of the data
-		const char *filePathCopy = x_strdup(filePath);
-		xTaskCreatePinnedToCore(
-			explorerHandleFileStorageTask, /* Function to implement the task */
-			"fileStorageTask", /* Name of the task */
-			4000, /* Stack size in words */
-			(void *) filePathCopy, /* Task input parameter */
-			2 | portPRIVILEGE_BIT, /* Priority of the task */
-			&fileStorageTaskHandle, /* Task handle. */
-			1 /* Core where the task should run */
-		);
-
-		// register for early disconnect events
-		request->onDisconnect([]() {
-			// client went away before we were finished...
-			// trigger task suicide, since we can not use Log_Println here
-			xTaskNotify(fileStorageTaskHandle, 2u, eSetValueWithOverwrite);
-		});
-	}
-
-	if (uploadAborted) {
-		if (!request->_tempObject) {
-			handleUploadError(request, 500);
-		}
-		return;
-	}
-
-	if (len) {
-		// wait till buffer is ready
-		while (buffer_full[index_buffer_write]) {
-			if (uploadAborted) {
-				return;
-			}
-			vTaskDelay(2u);
-		}
-
-		size_t len_to_write = len;
-		size_t space_left = chunk_size - size_in_buffer[index_buffer_write];
-		if (space_left < len_to_write) {
-			len_to_write = space_left;
-		}
-		// write content to buffer
-		memcpy(buffer[index_buffer_write] + size_in_buffer[index_buffer_write], data, len_to_write);
-		size_in_buffer[index_buffer_write] = size_in_buffer[index_buffer_write] + len_to_write;
-
-		// check if buffer is filled. If full, signal that ready and change buffers
-		if (size_in_buffer[index_buffer_write] == chunk_size) {
-			// signal, that buffer is ready. Increment index
-			buffer_full[index_buffer_write] = true;
-			index_buffer_write = (index_buffer_write + 1) % nr_of_buffers;
-
-			// if still content left, put it into next buffer
-			if (len_to_write < len) {
-				// wait till new buffer is ready
-				while (buffer_full[index_buffer_write]) {
-					if (uploadAborted) {
-						return;
-					}
-					vTaskDelay(2u);
-				}
-				size_t len_left_to_write = len - len_to_write;
-				memcpy(buffer[index_buffer_write], data + len_to_write, len_left_to_write);
-				size_in_buffer[index_buffer_write] = len_left_to_write;
-			}
-		}
-	}
-
-	if (final) {
-		if (uploadAborted) {
-			handleUploadError(request, 500);
-			return;
-		}
-		// if file not completely done yet, signal that buffer is filled
-		if (size_in_buffer[index_buffer_write] > 0) {
-			buffer_full[index_buffer_write] = true;
-		}
-		// notify storage task that last data was stored on the ring buffer
-		xTaskNotify(fileStorageTaskHandle, 1u, eSetValueWithOverwrite);
-		// watit until the storage task is sending the signal to finish
-		if (xSemaphoreTake(explorerFileUploadFinished, pdMS_TO_TICKS(30000)) != pdTRUE) {
-			// timeout, something went wrong
-			Log_Println(webTxCanceled, LOGLEVEL_ERROR);
-			handleUploadError(request, 500);
-			return;
-		}
-	}
-}
-
-// EXPERIMENTAL (feature-mediahub): same double-buffer/writer-task machinery
-// as explorerHandleFileUpload() above, fed from a raw (non-multipart) PUT
-// body instead - no MIME boundary parsing on the way in. One request per
-// file (the full target path, filename included, travels in the "path"
-// query param since a raw body carries no per-part filename); the client
-// is responsible for looping over multiple files sequentially. Kept as a
-// separate function rather than refactored to share code with
-// explorerHandleFileUpload() so the existing, proven multipart path can't
-// be affected by this experiment.
-static void explorerHandleRawUpload(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
+// Handles a raw (non-multipart) file upload request from the explorer.
+// requires a GET parameter path (folder + filename) for the target file.
+// One request per file; the client loops over multiple files sequentially
+// since only one upload can be in flight at a time (shared buffers below).
+static void explorerHandleFileUpload(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
 	System_UpdateActivityTimer();
 
 	if (index == 0) {

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -66,6 +66,11 @@ static std::atomic<bool> uploadAborted = false;
 void Web_DumpSdToNvs(const char *_filename);
 static void handleUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final);
 static void explorerHandleFileUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final);
+// EXPERIMENTAL, feature-mediahub only (see commit message): raw-body upload,
+// tested against the multipart path above to see whether skipping MIME
+// boundary parsing measurably helps throughput. Promote to its own
+// branch/PR if it does, drop otherwise.
+static void explorerHandleRawUpload(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
 static void explorerHandleFileStorageTask(void *parameter);
 static void explorerHandleListRequest(AsyncWebServerRequest *request);
 static void explorerHandleDownloadRequest(AsyncWebServerRequest *request);
@@ -609,6 +614,17 @@ void webserverStart(void) {
 				}
 			},
 			explorerHandleFileUpload);
+
+		// EXPERIMENTAL (feature-mediahub): raw-body upload path, see the
+		// declaration comment above explorerHandleRawUpload().
+		wServer.on(
+			"/explorerraw", HTTP_PUT, [](AsyncWebServerRequest *request) {
+				request->onDisconnect([]() { destroyDoubleBuffer(); });
+				if (!request->_tempObject) {
+					request->send(200);
+				}
+			},
+			NULL, explorerHandleRawUpload);
 
 		wServer.on("/explorerdownload", HTTP_GET, explorerHandleDownloadRequest);
 
@@ -1849,6 +1865,134 @@ void explorerHandleFileUpload(AsyncWebServerRequest *request, String filename, s
 		// notify storage task that last data was stored on the ring buffer
 		xTaskNotify(fileStorageTaskHandle, 1u, eSetValueWithOverwrite);
 		// watit until the storage task is sending the signal to finish
+		if (xSemaphoreTake(explorerFileUploadFinished, pdMS_TO_TICKS(30000)) != pdTRUE) {
+			// timeout, something went wrong
+			Log_Println(webTxCanceled, LOGLEVEL_ERROR);
+			handleUploadError(request, 500);
+			return;
+		}
+	}
+}
+
+// EXPERIMENTAL (feature-mediahub): same double-buffer/writer-task machinery
+// as explorerHandleFileUpload() above, fed from a raw (non-multipart) PUT
+// body instead - no MIME boundary parsing on the way in. One request per
+// file (the full target path, filename included, travels in the "path"
+// query param since a raw body carries no per-part filename); the client
+// is responsible for looping over multiple files sequentially. Kept as a
+// separate function rather than refactored to share code with
+// explorerHandleFileUpload() so the existing, proven multipart path can't
+// be affected by this experiment.
+static void explorerHandleRawUpload(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
+	System_UpdateActivityTimer();
+
+	if (index == 0) {
+		uploadAborted = false;
+
+		String filePath = "/";
+		if (request->hasParam("path")) {
+			filePath = request->getParam("path")->value();
+		}
+
+		Log_Printf(LOGLEVEL_INFO, writingFile, filePath.c_str());
+
+		if (!allocateDoubleBuffer()) {
+			// we failed to allocate enough memory
+			Log_Println(unableToAllocateMem, LOGLEVEL_ERROR);
+			handleUploadError(request, 500);
+			return;
+		}
+
+		if (explorerFileUploadFinished == NULL) {
+			explorerFileUploadFinished = xSemaphoreCreateBinary();
+		} else {
+			// make sure semaphore is empty
+			xSemaphoreTake(explorerFileUploadFinished, 0);
+		}
+
+		// reset buffers
+		index_buffer_write = 0;
+		index_buffer_read = 0;
+		for (uint32_t i = 0; i < nr_of_buffers; i++) {
+			size_in_buffer[i] = 0;
+			buffer_full[i] = false;
+		}
+
+		const char *filePathCopy = x_strdup(filePath.c_str());
+		xTaskCreatePinnedToCore(
+			explorerHandleFileStorageTask, /* Function to implement the task */
+			"fileStorageTask", /* Name of the task */
+			4000, /* Stack size in words */
+			(void *) filePathCopy, /* Task input parameter */
+			2 | portPRIVILEGE_BIT, /* Priority of the task */
+			&fileStorageTaskHandle, /* Task handle. */
+			1 /* Core where the task should run */
+		);
+
+		request->onDisconnect([]() {
+			xTaskNotify(fileStorageTaskHandle, 2u, eSetValueWithOverwrite);
+		});
+	}
+
+	if (uploadAborted) {
+		if (!request->_tempObject) {
+			handleUploadError(request, 500);
+		}
+		return;
+	}
+
+	if (len) {
+		// wait till buffer is ready
+		while (buffer_full[index_buffer_write]) {
+			if (uploadAborted) {
+				return;
+			}
+			vTaskDelay(2u);
+		}
+
+		size_t len_to_write = len;
+		size_t space_left = chunk_size - size_in_buffer[index_buffer_write];
+		if (space_left < len_to_write) {
+			len_to_write = space_left;
+		}
+		// write content to buffer
+		memcpy(buffer[index_buffer_write] + size_in_buffer[index_buffer_write], data, len_to_write);
+		size_in_buffer[index_buffer_write] = size_in_buffer[index_buffer_write] + len_to_write;
+
+		// check if buffer is filled. If full, signal that ready and change buffers
+		if (size_in_buffer[index_buffer_write] == chunk_size) {
+			// signal, that buffer is ready. Increment index
+			buffer_full[index_buffer_write] = true;
+			index_buffer_write = (index_buffer_write + 1) % nr_of_buffers;
+
+			// if still content left, put it into next buffer
+			if (len_to_write < len) {
+				// wait till new buffer is ready
+				while (buffer_full[index_buffer_write]) {
+					if (uploadAborted) {
+						return;
+					}
+					vTaskDelay(2u);
+				}
+				size_t len_left_to_write = len - len_to_write;
+				memcpy(buffer[index_buffer_write], data + len_to_write, len_left_to_write);
+				size_in_buffer[index_buffer_write] = len_left_to_write;
+			}
+		}
+	}
+
+	if (index + len >= total) {
+		if (uploadAborted) {
+			handleUploadError(request, 500);
+			return;
+		}
+		// if file not completely done yet, signal that buffer is filled
+		if (size_in_buffer[index_buffer_write] > 0) {
+			buffer_full[index_buffer_write] = true;
+		}
+		// notify storage task that last data was stored on the ring buffer
+		xTaskNotify(fileStorageTaskHandle, 1u, eSetValueWithOverwrite);
+		// wait until the storage task is sending the signal to finish
 		if (xSemaphoreTake(explorerFileUploadFinished, pdMS_TO_TICKS(30000)) != pdTRUE) {
 			// timeout, something went wrong
 			Log_Println(webTxCanceled, LOGLEVEL_ERROR);


### PR DESCRIPTION
## Summary

File-explorer uploads (drag & drop / file picker in the Web-UI's Files tab) went through one `multipart/form-data` `POST /explorer` request for the whole batch. Measured throughput topped out around **450 kB/s** regardless of buffer size or WiFi tuning.

This switches the upload to a **raw binary body** instead: each selected file is now sent as its own `POST /explorer?path=<target>` request with `Content-Type: application/octet-stream`, one request per file. No functional change from the user's perspective (still pick one or many files, or a whole folder) - same target-path resolution, same progress bar, same double-buffered write path on the ESPuino side.

**Result: ~650 kB/s**, a ~40% improvement, with no observed downsides.

## Why this is faster

Two concrete overheads that a raw body avoids:

1. **MIME boundary parsing.** `multipart/form-data` requires ESPAsyncWebServer to parse `Content-Disposition`/boundary markers out of the stream as it arrives. A raw body has none of that - every byte that arrives is payload.
2. **AsyncTCP's single shared service task.** All of ESPuino's async web traffic (of any kind) is funneled through one `async_tcp` task via one queue (`CONFIG_ASYNC_TCP_QUEUE_SIZE = 64`). This is unrelated to multipart vs. raw and wasn't changed here, but it's worth knowing this is a shared, project-wide bottleneck that a future change could address separately.

The double-buffering/writer-task machinery, 16 KB chunk size, buffered SD writes, and WiFi power-save handling were already in place before this change (from the original multipart implementation) and are unchanged - this PR is purely about the wire format, not the storage path.

## What changed

- `src/Web.cpp`: `explorerHandleFileUpload()` is now a raw-body (`onBody`) handler instead of a multipart (`onUpload`) handler. Registered on the same `POST /explorer` as before - same URL and method, different request body. The old multipart implementation is removed.
- `html/management.html`: the upload form's submit handler now loops over the selected `FileList` and sends one raw `XMLHttpRequest` POST per file sequentially (only one upload is ever in flight, matching the ESPuino's single shared upload buffer), instead of building one `FormData`/multipart request for the whole selection. Progress/ETA/final-speed reporting is aggregated across all files so the UX is unchanged.
- `REST-API.yaml`: `POST /explorer` documentation updated to describe the raw `application/octet-stream` body (one file per request) instead of `multipart/form-data`.
