### PR TITLE
"hold a button + turn the encoder" gestures

### DIFF
--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -97,7 +97,11 @@
 		"rotary": {
 			"title": "Drehimpulsgeber",
 			"reverse": "Drehrichtung umkehren",
-			"reverseExp": "Kehrt die Zähl-/Drehrichtung des Drehimpulsgebers um, z.B. falls Lauter/Leiser vertauscht ist."
+			"reverseExp": "Kehrt die Zähl-/Drehrichtung des Drehimpulsgebers um, z.B. falls Lauter/Leiser vertauscht ist.",
+			"gestures": "Taste halten + drehen",
+			"gesturesExp": "Solange eine dieser Tasten gehalten wird, löst Drehen am Drehimpulsgeber die zugewiesene Aktion aus, statt die Lautstärke zu ändern. 'Rechts drehen' ist die Richtung, die sonst lauter stellt. Die Lang-Aktion einer solchen Taste wird erst beim Loslassen ausgelöst - und gar nicht, wenn gedreht wurde.",
+			"ccw": "links drehen",
+			"cw": "rechts drehen"
 		}
 	},
 	"wifi": {
@@ -289,6 +293,8 @@
 					"151": "🌐 IP-Adresse ansagen",
 					"152": "🕒 Uhrzeit ansagen",
 					"153": "💡 Ambient Light umschalten",
+					"154": "🔆 LED-Helligkeit erhöhen",
+					"155": "🔅 LED-Helligkeit verringern",
 					"0": "🗑 Lösche Zuordnung",
 					"170": "⏯ Play/Pause",
 					"171": "⏮ Vorheriger Titel",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -97,7 +97,11 @@
 		"rotary": {
 			"title": "Rotary encoder",
 			"reverse": "Reverse direction of rotation",
-			"reverseExp": "Reverses the rotary encoder's counting/turning direction, e.g. if volume up/down is swapped."
+			"reverseExp": "Reverses the rotary encoder's counting/turning direction, e.g. if volume up/down is swapped.",
+			"gestures": "Hold button + turn encoder",
+			"gesturesExp": "While one of these buttons is held down, turning the encoder triggers the assigned action instead of changing the volume. 'Turn right' is the direction that raises the volume. The long-press action of such a button fires when it is released - and not at all if the encoder was turned.",
+			"ccw": "turn left",
+			"cw": "turn right"
 		}
 	},
 	"wifi": {
@@ -289,6 +293,8 @@
 					"151": "🌐 Announce IP-Address",
 					"152": "🕒 Announce current time",
 					"153": "💡 Toggle Ambient Light",
+					"154": "🔆 LED brightness up",
+					"155": "🔅 LED brightness down",
 					"0": "🗑 Remove assignment",
 					"170": "⏯ Toggle Play/Pause",
 					"171": "⏮ Previous track",

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -97,7 +97,11 @@
 		"rotary": {
 			"title": "Codeur rotatif",
 			"reverse": "Inversion du sens de rotation",
-			"reverseExp": "Inverse le sens de comptage/rotation du codeur rotatif, par ex. si volume haut/bas est inversé."
+			"reverseExp": "Inverse le sens de comptage/rotation du codeur rotatif, par ex. si volume haut/bas est inversé.",
+			"gestures": "Bouton maintenu + rotation",
+			"gesturesExp": "Tant qu'un de ces boutons est maintenu, tourner le codeur rotatif déclenche l'action attribuée au lieu de changer le volume. « Tourner à droite » est le sens qui augmente le volume. L'appui long d'un tel bouton ne se déclenche qu'au relâchement - et pas du tout si le codeur a été tourné.",
+			"ccw": "tourner à gauche",
+			"cw": "tourner à droite"
 		}
 	},
 	"wifi": {
@@ -290,6 +294,8 @@
 					"152": "🕒 Annoncer l'heure actuelle",
 					"0": "🗑 Supprimer l'affectation",
 					"153": "💡 Basculement de la lumière ambiante",
+					"154": "🔆 Augmenter la luminosité LED",
+					"155": "🔅 Diminuer la luminosité LED",
 					"170": "⏯ Basculer Lecture/Pause",
 					"171": "⏮ Piste précédente",
 					"172": "⏭ Piste suivante",

--- a/html/management.html
+++ b/html/management.html
@@ -1526,6 +1526,58 @@
 							</div>
 						</fieldset>
 						<hr>
+						<div id="rotaryGesturesConfig" style="display:none">
+							<fieldset>
+								<legend class="w-auto"><span data-i18n="settingsex.rotary.gestures"></span>&nbsp;<a href="#"
+										class="link-secondary" data-bs-toggle="popover"
+										data-i18n="[data-bs-content]settingsex.rotary.gesturesExp" tabindex="0"><i
+											class="fas fa-circle-question"></i></a></legend>
+								<div class="table-responsive">
+									<table class="table table-sm align-middle">
+										<thead>
+											<tr>
+												<th></th>
+												<th data-i18n="settingsex.rotary.ccw"></th>
+												<th data-i18n="settingsex.rotary.cw"></th>
+											</tr>
+										</thead>
+										<tbody>
+											<tr>
+												<td data-i18n="settingsex.buttons.button0"></td>
+												<td><select id="cmdselect_rotccw_0" class="form-control form-select"></select></td>
+												<td><select id="cmdselect_rotcw_0" class="form-control form-select"></select></td>
+											</tr>
+											<tr>
+												<td data-i18n="settingsex.buttons.button1"></td>
+												<td><select id="cmdselect_rotccw_1" class="form-control form-select"></select></td>
+												<td><select id="cmdselect_rotcw_1" class="form-control form-select"></select></td>
+											</tr>
+											<tr>
+												<td data-i18n="settingsex.buttons.button2"></td>
+												<td><select id="cmdselect_rotccw_2" class="form-control form-select"></select></td>
+												<td><select id="cmdselect_rotcw_2" class="form-control form-select"></select></td>
+											</tr>
+											<tr>
+												<td data-i18n="settingsex.buttons.button3"></td>
+												<td><select id="cmdselect_rotccw_3" class="form-control form-select"></select></td>
+												<td><select id="cmdselect_rotcw_3" class="form-control form-select"></select></td>
+											</tr>
+											<tr>
+												<td data-i18n="settingsex.buttons.button4"></td>
+												<td><select id="cmdselect_rotccw_4" class="form-control form-select"></select></td>
+												<td><select id="cmdselect_rotcw_4" class="form-control form-select"></select></td>
+											</tr>
+											<tr>
+												<td data-i18n="settingsex.buttons.button5"></td>
+												<td><select id="cmdselect_rotccw_5" class="form-control form-select"></select></td>
+												<td><select id="cmdselect_rotcw_5" class="form-control form-select"></select></td>
+											</tr>
+										</tbody>
+									</table>
+								</div>
+							</fieldset>
+							<hr>
+						</div>
 						<fieldset>
 							<legend class="w-auto" data-i18n="settingsex.multibuttons.title"></legend><br>
 							<div class="table-responsive">
@@ -3334,6 +3386,7 @@
 			let rotarySettings = settings.rotary;
 			if (rotarySettings) {
 				document.getElementById("rotaryConfig").style.display = null;
+				document.getElementById("rotaryGesturesConfig").style.display = null;
 				$('#rotaryReverse').prop('checked', rotarySettings.reverse);
 			}
 			// buttons
@@ -3351,6 +3404,18 @@
 				document.getElementById("cmdselect_long_3").value = buttonSettings.long3;
 				document.getElementById("cmdselect_long_4").value = buttonSettings.long4;
 				document.getElementById("cmdselect_long_5").value = buttonSettings.long5;
+				document.getElementById("cmdselect_rotcw_0").value = buttonSettings.rotCw0;
+				document.getElementById("cmdselect_rotcw_1").value = buttonSettings.rotCw1;
+				document.getElementById("cmdselect_rotcw_2").value = buttonSettings.rotCw2;
+				document.getElementById("cmdselect_rotcw_3").value = buttonSettings.rotCw3;
+				document.getElementById("cmdselect_rotcw_4").value = buttonSettings.rotCw4;
+				document.getElementById("cmdselect_rotcw_5").value = buttonSettings.rotCw5;
+				document.getElementById("cmdselect_rotccw_0").value = buttonSettings.rotCcw0;
+				document.getElementById("cmdselect_rotccw_1").value = buttonSettings.rotCcw1;
+				document.getElementById("cmdselect_rotccw_2").value = buttonSettings.rotCcw2;
+				document.getElementById("cmdselect_rotccw_3").value = buttonSettings.rotCcw3;
+				document.getElementById("cmdselect_rotccw_4").value = buttonSettings.rotCcw4;
+				document.getElementById("cmdselect_rotccw_5").value = buttonSettings.rotCcw5;
 				document.getElementById("cmdselect_multi_01").value = buttonSettings.multi01;
 				document.getElementById("cmdselect_multi_02").value = buttonSettings.multi02;
 				document.getElementById("cmdselect_multi_03").value = buttonSettings.multi03;
@@ -3780,6 +3845,18 @@
 					long3: Number(document.getElementById("cmdselect_long_3").value),
 					long4: Number(document.getElementById("cmdselect_long_4").value),
 					long5: Number(document.getElementById("cmdselect_long_5").value),
+					rotCw0: Number(document.getElementById("cmdselect_rotcw_0").value),
+					rotCw1: Number(document.getElementById("cmdselect_rotcw_1").value),
+					rotCw2: Number(document.getElementById("cmdselect_rotcw_2").value),
+					rotCw3: Number(document.getElementById("cmdselect_rotcw_3").value),
+					rotCw4: Number(document.getElementById("cmdselect_rotcw_4").value),
+					rotCw5: Number(document.getElementById("cmdselect_rotcw_5").value),
+					rotCcw0: Number(document.getElementById("cmdselect_rotccw_0").value),
+					rotCcw1: Number(document.getElementById("cmdselect_rotccw_1").value),
+					rotCcw2: Number(document.getElementById("cmdselect_rotccw_2").value),
+					rotCcw3: Number(document.getElementById("cmdselect_rotccw_3").value),
+					rotCcw4: Number(document.getElementById("cmdselect_rotccw_4").value),
+					rotCcw5: Number(document.getElementById("cmdselect_rotccw_5").value),
 					multi01: Number(document.getElementById("cmdselect_multi_01").value),
 					multi02: Number(document.getElementById("cmdselect_multi_02").value),
 					multi03: Number(document.getElementById("cmdselect_multi_03").value),
@@ -4502,7 +4579,7 @@
 			const cmdElem = document.createElement('select');
 			const cmdNothing = addOption(cmdElem, 0);
 			cmdNothing.setAttribute('data-i18n', "settingsex.buttons.noaction");
-			const cmds = [170, 171, 172, 173, 174, 184, 185, 175, 176, 177, 178, 179, 180, 181, 182, 183, 199, 130, 140, 141, 142, 150, 151, 152, 153, 120, 100, 101, 102, 103, 104, 105, 106, 107, 110, 111, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250];
+			const cmds = [170, 171, 172, 173, 174, 184, 185, 175, 176, 177, 178, 179, 180, 181, 182, 183, 199, 130, 140, 141, 142, 150, 151, 152, 153, 154, 155, 120, 100, 101, 102, 103, 104, 105, 106, 107, 110, 111, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250];
 			for (const cmd of cmds) {
 				const opt = addOption(cmdElem, cmd);
 				if ([140, 141, 142].includes(cmd)) {

--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -1,6 +1,8 @@
 #include <Arduino.h>
 #include "settings.h"
 
+#include <atomic>
+
 #include "AudioPlayer.h"
 
 #include "Audio.h"
@@ -30,6 +32,13 @@
 
 // Allocate gPlayProperties in PSRAM if available
 EXT_RAM_BSS_ATTR playProps gPlayProperties;
+
+// Pending relative seek in seconds, written from the button/rotary/web tasks and drained by the audio loop.
+static std::atomic<int16_t> AudioPlayer_PendingSeekSeconds {0};
+
+void AudioPlayer_AddSeekOffset(const int16_t seconds) {
+	AudioPlayer_PendingSeekSeconds.fetch_add(seconds, std::memory_order_relaxed);
+}
 
 // Playlist
 static playlistSortMode AudioPlayer_PlaylistSortMode = AUDIOPLAYER_PLAYLIST_SORT_MODE_DEFAULT;
@@ -1054,21 +1063,19 @@ void AudioPlayer_Loop() {
 		}
 	}
 
+	// Relative seek. Accumulated in an atomic so that firing CMD_SEEK_* once per rotary detent scrubs
+	// proportionally instead of collapsing into a single jump (seekmode was a single overwrite-able enum
+	// consumed once per iteration, so rapid repeats were lost).
+	const int16_t seekOffset = AudioPlayer_PendingSeekSeconds.exchange(0, std::memory_order_relaxed);
+	if (seekOffset != 0) {
+		if (audio->setTimeOffset(seekOffset)) {
+			Log_Printf(LOGLEVEL_NOTICE, (seekOffset > 0) ? secondsJumpForward : secondsJumpBackward, abs(seekOffset));
+		}
+	}
+
 	// Handle seekmodes
 	if (gPlayProperties.seekmode != SEEK_NORMAL) {
-		if (gPlayProperties.seekmode == SEEK_FORWARDS) {
-			if (audio->setTimeOffset(jumpOffset)) {
-				Log_Printf(LOGLEVEL_NOTICE, secondsJumpForward, jumpOffset);
-			} else {
-				System_IndicateError();
-			}
-		} else if (gPlayProperties.seekmode == SEEK_BACKWARDS) {
-			if (audio->setTimeOffset(-(jumpOffset))) {
-				Log_Printf(LOGLEVEL_NOTICE, secondsJumpBackward, jumpOffset);
-			} else {
-				System_IndicateError();
-			}
-		} else if ((gPlayProperties.seekmode == SEEK_POS_PERCENT) && (gPlayProperties.currentRelPos > 0) && (gPlayProperties.currentRelPos < 100)) {
+		if ((gPlayProperties.seekmode == SEEK_POS_PERCENT) && (gPlayProperties.currentRelPos > 0) && (gPlayProperties.currentRelPos < 100)) {
 			uint32_t newFileTime = uint32_t((gPlayProperties.currentRelPos / 100.0f) * audio->getAudioFileDuration());
 			if (audio->setAudioPlayTime(newFileTime)) {
 				Log_Printf(LOGLEVEL_NOTICE, JumpToPosition, newFileTime, audio->getAudioFileDuration());
@@ -1208,14 +1215,18 @@ void AudioPlayer_SetVolume(const int32_t _newVolume) {
 	int32_t _volumeBuf = AudioPlayer_GetCurrentVolume();
 
 	Led_Indicate(LedIndicatorType::VolumeChange);
-	if (_newVolume < AudioPlayer_GetMinVolume()) {
+	// Clamp rather than reject: a fast rotary spin can ask for several steps at once, and rejecting the whole
+	// change meant that near the rails (e.g. 20 -> 23 with max 21) nothing happened at all instead of pinning.
+	int32_t clampedVolume = _newVolume;
+	if (clampedVolume < AudioPlayer_GetMinVolume()) {
+		clampedVolume = AudioPlayer_GetMinVolume();
 		Log_Println(minLoudnessReached, LOGLEVEL_INFO);
-		return;
-	} else if (_newVolume > AudioPlayer_GetMaxVolume()) {
+	} else if (clampedVolume > AudioPlayer_GetMaxVolume()) {
+		clampedVolume = AudioPlayer_GetMaxVolume();
 		Log_Println(maxLoudnessReached, LOGLEVEL_INFO);
-		return;
-	} else {
-		_volume = _newVolume;
+	}
+	{
+		_volume = clampedVolume;
 		AudioPlayer_SetCurrentVolume(_volume);
 
 		Log_Printf(LOGLEVEL_INFO, newLoudnessReceived, _volume);
@@ -1224,7 +1235,7 @@ void AudioPlayer_SetVolume(const int32_t _newVolume) {
 #ifdef MQTT_ENABLE
 		publishMqtt(topicLoudness, static_cast<uint32_t>(_volume), false);
 #endif
-		AudioPlayer_PauseOnMinVolume(_volumeBuf, _newVolume);
+		AudioPlayer_PauseOnMinVolume(_volumeBuf, clampedVolume);
 	}
 }
 

--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -1,8 +1,6 @@
 #include <Arduino.h>
 #include "settings.h"
 
-#include <atomic>
-
 #include "AudioPlayer.h"
 
 #include "Audio.h"
@@ -26,6 +24,7 @@
 #include "main.h"
 #include "strnatcmp.h"
 
+#include <atomic>
 #include <esp_task_wdt.h>
 #include <freertos/task.h>
 #include <random>

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -71,6 +71,8 @@ void AudioPlayer_SetVolume(const int32_t _newVolume);
 void AudioPlayer_SetEqualizer(const int8_t gainLowPass, const int8_t gainBandPass, const int8_t gainHighPass);
 void AudioPlayer_SetPlaylist(const char *_itemToPlay, const uint32_t _lastPlayPos, const uint32_t _playMode, const uint16_t _trackLastPlayed);
 void AudioPlayer_SetTrackControl(const uint8_t trackCommand);
+// Queue a relative seek. Accumulates, so one call per rotary detent scrubs proportionally.
+void AudioPlayer_AddSeekOffset(const int16_t seconds);
 // Arm the "don't accept same RFID twice"-lock to be released on the next idle-state. Called when a tag is
 // accepted, independent of whether playback actually starts, so a tag whose first track fails immediately
 // (e.g. a webstream without WiFi) does not stay locked forever.

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -243,6 +243,9 @@ static const struct {
 // Check for multi-button combinations and execute corresponding action
 static bool Button_HandleMultiButtonPress(void) {
 	for (const auto &combo : multiButtonCombos) {
+		if (gButtons[combo.btn1].usedAsModifier || gButtons[combo.btn2].usedAsModifier) {
+			continue; // held as a rotary modifier, not as half of a combo
+		}
 		if (gButtons[combo.btn1].isPressed && gButtons[combo.btn2].isPressed) {
 			gButtons[combo.btn1].isPressed = false;
 			gButtons[combo.btn2].isPressed = false;
@@ -270,10 +273,29 @@ static const struct {
 
 // Handle a single button's short/long press action
 static void Button_HandleSinglePress(uint8_t i, unsigned long currentTimestamp) {
+	// The button was used to modify a rotary gesture, so it must not also fire its own action. Its short
+	// press would otherwise fire on release, and its long press at intervalToLongPress while still held --
+	// which for a button whose long action is CMD_SLEEPMODE means the box falls asleep mid-gesture.
+	if (gButtons[i].usedAsModifier) {
+		if (gButtons[i].lastReleasedTimestamp > gButtons[i].lastPressedTimestamp) {
+			gButtons[i].isPressed = false;
+			gButtons[i].usedAsModifier = false;
+		}
+		return;
+	}
+
 	uint8_t Cmd_Short = gPrefsSettings.getUChar(buttonCmdConfig[i].prefsKeyShort, buttonCmdConfig[i].defaultShort);
 	uint8_t Cmd_Long = gPrefsSettings.getUChar(buttonCmdConfig[i].prefsKeyLong, buttonCmdConfig[i].defaultLong);
 	unsigned long const pressDuration = currentTimestamp - gButtons[i].lastPressedTimestamp;
 	bool const wasReleased = gButtons[i].lastReleasedTimestamp > gButtons[i].lastPressedTimestamp;
+
+	// A button that can act as a rotary modifier must not fire its long action at intervalToLongPress while
+	// it is still held: holding it is also how you start a gesture, and the user has not necessarily begun
+	// turning the encoder yet. (Holding NEXT for 700ms to seek would otherwise first fire BUTTON_0_LONG --
+	// CMD_LASTTRACK by default -- and jump straight to the end of the book.) Defer it to release, exactly as
+	// CMD_SLEEPMODE already is, so that a turn in the meantime can cancel it via usedAsModifier. A plain
+	// long-press with no turn still works, it just resolves when the button comes back up.
+	bool const isRotaryModifier = (Button_GetRotaryAction(i, true) != CMD_NOTHING) || (Button_GetRotaryAction(i, false) != CMD_NOTHING);
 
 	// Handle button release (short or long press completed)
 	if (wasReleased) {
@@ -282,13 +304,18 @@ static void Button_HandleSinglePress(uint8_t i, unsigned long currentTimestamp) 
 
 		if (wasShortPress) {
 			Cmd_Action(Cmd_Short);
-		} else if (Cmd_Long == CMD_SLEEPMODE) {
-			// Sleep-mode only triggers on release to prevent immediate wake-up
+		} else if (Cmd_Long == CMD_SLEEPMODE || isRotaryModifier) {
+			// Sleep-mode only triggers on release to prevent immediate wake-up; modifier buttons defer for
+			// the reason above.
 			Cmd_Action(Cmd_Long);
 		}
 
 		gButtons[i].isPressed = false;
 		return;
+	}
+
+	if (isRotaryModifier) {
+		return; // Still held: wait for release before deciding whether this was a long press or a gesture
 	}
 
 	// Handle volume buttons with repeat functionality
@@ -308,6 +335,96 @@ static void Button_HandleSinglePress(uint8_t i, unsigned long currentTimestamp) 
 	if (Cmd_Long != CMD_SLEEPMODE && pressDuration > intervalToLongPress) {
 		gButtons[i].isPressed = false;
 		Cmd_Action(Cmd_Long);
+	}
+}
+
+// settings-override.h, when present, replaces settings.h wholesale -- so an override written before this
+// feature existed defines none of the BUTTON_n_ROTARY_* macros. Default them to CMD_NOTHING (= button is
+// not a modifier) so those configs keep building and simply have no gestures until they opt in.
+#ifndef BUTTON_0_ROTARY_CW
+	#define BUTTON_0_ROTARY_CW CMD_NOTHING
+#endif
+#ifndef BUTTON_0_ROTARY_CCW
+	#define BUTTON_0_ROTARY_CCW CMD_NOTHING
+#endif
+#ifndef BUTTON_1_ROTARY_CW
+	#define BUTTON_1_ROTARY_CW CMD_NOTHING
+#endif
+#ifndef BUTTON_1_ROTARY_CCW
+	#define BUTTON_1_ROTARY_CCW CMD_NOTHING
+#endif
+#ifndef BUTTON_2_ROTARY_CW
+	#define BUTTON_2_ROTARY_CW CMD_NOTHING
+#endif
+#ifndef BUTTON_2_ROTARY_CCW
+	#define BUTTON_2_ROTARY_CCW CMD_NOTHING
+#endif
+#ifndef BUTTON_3_ROTARY_CW
+	#define BUTTON_3_ROTARY_CW CMD_NOTHING
+#endif
+#ifndef BUTTON_3_ROTARY_CCW
+	#define BUTTON_3_ROTARY_CCW CMD_NOTHING
+#endif
+#ifndef BUTTON_4_ROTARY_CW
+	#define BUTTON_4_ROTARY_CW CMD_NOTHING
+#endif
+#ifndef BUTTON_4_ROTARY_CCW
+	#define BUTTON_4_ROTARY_CCW CMD_NOTHING
+#endif
+#ifndef BUTTON_5_ROTARY_CW
+	#define BUTTON_5_ROTARY_CW CMD_NOTHING
+#endif
+#ifndef BUTTON_5_ROTARY_CCW
+	#define BUTTON_5_ROTARY_CCW CMD_NOTHING
+#endif
+
+// "Hold this button, turn the encoder" -- one action per rotation direction, per button.
+// Mirrors buttonCmdConfig: compile-time default in settings.h, overridable at runtime via NVS.
+static const struct {
+	const char *prefsKeyCw;
+	const char *prefsKeyCcw;
+	uint8_t defaultCw;
+	uint8_t defaultCcw;
+} rotaryCmdConfig[] = {
+	{"btnRotCw0", "btnRotCcw0", BUTTON_0_ROTARY_CW, BUTTON_0_ROTARY_CCW},
+	{"btnRotCw1", "btnRotCcw1", BUTTON_1_ROTARY_CW, BUTTON_1_ROTARY_CCW},
+	{"btnRotCw2", "btnRotCcw2", BUTTON_2_ROTARY_CW, BUTTON_2_ROTARY_CCW},
+	{"btnRotCw3", "btnRotCcw3", BUTTON_3_ROTARY_CW, BUTTON_3_ROTARY_CCW},
+	{"btnRotCw4", "btnRotCcw4", BUTTON_4_ROTARY_CW, BUTTON_4_ROTARY_CCW},
+	{"btnRotCw5", "btnRotCcw5", BUTTON_5_ROTARY_CW, BUTTON_5_ROTARY_CCW},
+};
+
+uint8_t Button_GetRotaryAction(uint8_t buttonIndex, bool clockwise) {
+	if (buttonIndex >= (sizeof(rotaryCmdConfig) / sizeof(rotaryCmdConfig[0]))) {
+		return CMD_NOTHING;
+	}
+	const auto &cfg = rotaryCmdConfig[buttonIndex];
+	return clockwise
+		? gPrefsSettings.getUChar(cfg.prefsKeyCw, cfg.defaultCw)
+		: gPrefsSettings.getUChar(cfg.prefsKeyCcw, cfg.defaultCcw);
+}
+
+// currentState (not isPressed) is the live level: false means physically down right now. isPressed is a
+// consumable latch that the long-press handler clears while the finger is still on the button, so it is
+// useless as a "still held" signal.
+uint8_t Button_GetHeldModifier(void) {
+	if (!gButtonInitComplete) {
+		return BUTTON_NONE; // gButtons[] is still garbage before the first scan
+	}
+	for (uint8_t i = 0; i < (sizeof(rotaryCmdConfig) / sizeof(rotaryCmdConfig[0])); i++) {
+		if (gButtons[i].currentState) {
+			continue; // not pressed
+		}
+		if (Button_GetRotaryAction(i, true) != CMD_NOTHING || Button_GetRotaryAction(i, false) != CMD_NOTHING) {
+			return i;
+		}
+	}
+	return BUTTON_NONE;
+}
+
+void Button_MarkModifierUsed(uint8_t buttonIndex) {
+	if (buttonIndex < (sizeof(gButtons) / sizeof(gButtons[0]))) {
+		gButtons[buttonIndex].usedAsModifier = true;
 	}
 }
 

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -404,6 +404,15 @@ uint8_t Button_GetRotaryAction(uint8_t buttonIndex, bool clockwise) {
 		: gPrefsSettings.getUChar(cfg.prefsKeyCcw, cfg.defaultCcw);
 }
 
+// Compile-time default (settings.h / the override), ignoring any NVS override. Used by the
+// web-UI's "reset to factory settings".
+uint8_t Button_GetRotaryActionDefault(uint8_t buttonIndex, bool clockwise) {
+	if (buttonIndex >= (sizeof(rotaryCmdConfig) / sizeof(rotaryCmdConfig[0]))) {
+		return CMD_NOTHING;
+	}
+	return clockwise ? rotaryCmdConfig[buttonIndex].defaultCw : rotaryCmdConfig[buttonIndex].defaultCcw;
+}
+
 // currentState (not isPressed) is the live level: false means physically down right now. isPressed is a
 // consumable latch that the long-press handler clears while the finger is still on the button, so it is
 // useless as a "still held" signal.

--- a/src/Button.h
+++ b/src/Button.h
@@ -1,10 +1,11 @@
 #pragma once
 
 typedef struct {
-	bool lastState	  : 1;
-	bool currentState : 1;
-	bool isPressed	  : 1;
-	bool isReleased	  : 1;
+	bool lastState		: 1;
+	bool currentState	: 1;
+	bool isPressed		: 1;
+	bool isReleased		: 1;
+	bool usedAsModifier : 1; // A rotary gesture was performed while this button was held: swallow its normal short/long action
 	unsigned long lastPressedTimestamp;
 	unsigned long lastReleasedTimestamp;
 	unsigned long firstPressedTimestamp;
@@ -12,6 +13,14 @@ typedef struct {
 
 extern uint8_t gShutdownButton;
 extern bool gButtonInitComplete;
+
+constexpr uint8_t BUTTON_NONE = 0xFFu;
+
+// "Hold a button, turn the rotary encoder" gestures. Button_GetHeldModifier() returns the index of a
+// button that is physically down right now AND has a rotary action configured, or BUTTON_NONE.
+uint8_t Button_GetHeldModifier(void);
+uint8_t Button_GetRotaryAction(uint8_t buttonIndex, bool clockwise);
+void Button_MarkModifierUsed(uint8_t buttonIndex);
 
 void Button_Init(void);
 void Button_Cyclic(void);

--- a/src/Button.h
+++ b/src/Button.h
@@ -20,6 +20,7 @@ constexpr uint8_t BUTTON_NONE = 0xFFu;
 // button that is physically down right now AND has a rotary action configured, or BUTTON_NONE.
 uint8_t Button_GetHeldModifier(void);
 uint8_t Button_GetRotaryAction(uint8_t buttonIndex, bool clockwise);
+uint8_t Button_GetRotaryActionDefault(uint8_t buttonIndex, bool clockwise);
 void Button_MarkModifierUsed(uint8_t buttonIndex);
 
 void Button_Init(void);

--- a/src/Cmd.cpp
+++ b/src/Cmd.cpp
@@ -14,6 +14,8 @@
 #include "System.h"
 #include "Wlan.h"
 
+#include <algorithm>
+
 static void Cmd_HandleSleepAction(bool enable, const char *enLogMsg, const char *enMqttMsg) {
 	Led_SetNightmode(enable);
 	if (enable) {
@@ -369,12 +371,25 @@ void Cmd_Action(const uint16_t mod) {
 		}
 
 		case CMD_SEEK_FORWARDS: {
-			gPlayProperties.seekmode = SEEK_FORWARDS;
+			// Accumulate rather than set a flag: the flag was a single overwrite-able enum consumed once per
+			// audio-loop iteration, so N detents of a fast rotary spin collapsed into a single jump.
+			AudioPlayer_AddSeekOffset(jumpOffset);
 			break;
 		}
 
 		case CMD_SEEK_BACKWARDS: {
-			gPlayProperties.seekmode = SEEK_BACKWARDS;
+			AudioPlayer_AddSeekOffset(-static_cast<int16_t>(jumpOffset));
+			break;
+		}
+
+		case CMD_BRIGHTNESS_UP:
+		case CMD_BRIGHTNESS_DOWN: {
+			// Led_SetBrightness() takes a uint8_t and does not bounds-check, so clamping is the caller's job:
+			// brightness 2 minus a step would otherwise wrap to ~255 and blast a dark room at full power.
+			const int16_t step = (mod == CMD_BRIGHTNESS_UP) ? LED_BRIGHTNESS_STEP : -static_cast<int16_t>(LED_BRIGHTNESS_STEP);
+			const int16_t target = static_cast<int16_t>(Led_GetBrightness()) + step;
+			Led_SetBrightness(static_cast<uint8_t>(std::clamp<int16_t>(target, LED_BRIGHTNESS_MIN, 255)));
+			Log_Printf(LOGLEVEL_INFO, "LED-brightness: %u", Led_GetBrightness());
 			break;
 		}
 

--- a/src/Led.h
+++ b/src/Led.h
@@ -60,6 +60,8 @@ struct AnimationReturnType {
 
 #ifdef NEOPIXEL_ENABLE
 	#define LED_INITIAL_BRIGHTNESS		 16u
+	#define LED_BRIGHTNESS_STEP			 4u // Brightness change per rotary detent (CMD_BRIGHTNESS_UP/DOWN)
+	#define LED_BRIGHTNESS_MIN			 1u // Never let a gesture turn the LEDs fully off -- that looks like a crash
 	#define LED_INITIAL_NIGHT_BRIGHTNESS 2u
 
 	#define FASTLED_ESP32_USE_CLOCKLESS_SPI 1

--- a/src/RotaryEncoder.cpp
+++ b/src/RotaryEncoder.cpp
@@ -5,11 +5,19 @@
 
 #include "AudioPlayer.h"
 #include "Bluetooth.h"
+#include "Button.h"
+#include "Cmd.h"
 #include "Log.h"
 #include "System.h"
 
 #ifdef USEROTARY_ENABLE
 	#include <ESP32Encoder.h>
+#endif
+
+// An override written before this feature existed does not define it (settings-override.h replaces
+// settings.h wholesale), so fall back rather than break those builds.
+#ifndef JUMP_OFFSET_ROTARY
+	#define JUMP_OFFSET_ROTARY 10
 #endif
 
 // Rotary encoder-configuration
@@ -51,6 +59,19 @@ void RotaryEncoder_Cyclic(void) {
 	}
 	#endif
 
+	// A button held down while turning acts as a modifier: the turn drives that button's rotary action
+	// (brightness, seek, ...) instead of the volume. getCount() is stateful across ticks -- it keeps a
+	// half-step that has not completed a detent yet -- so discard whatever has accumulated whenever the
+	// modifier changes, otherwise a gesture inherits rotation from before the button went down (and the
+	// volume inherits rotation from during the gesture).
+	static uint8_t lastModifier = BUTTON_NONE;
+	const uint8_t modifier = Button_GetHeldModifier();
+	if (modifier != lastModifier) {
+		lastModifier = modifier;
+		encoder.clearCount();
+		return;
+	}
+
 	int32_t encoderValue = encoder.getCount();
 	// Only if initial run or value has changed. And only after "full step" of rotary encoder
 	if ((encoderValue != 0) && (encoderValue % 2 == 0)) {
@@ -58,11 +79,38 @@ void RotaryEncoder_Cyclic(void) {
 		// just reset the encoder here, so we get a new delta next time
 		encoder.clearCount();
 
+		const int32_t detents = encoderValue / 2;
+
+		if (modifier != BUTTON_NONE) {
+			const uint8_t cmd = Button_GetRotaryAction(modifier, detents > 0);
+			if (cmd != CMD_NOTHING) {
+				// Tell Button.cpp to swallow this button's own short/long action -- otherwise letting go fires
+				// e.g. play/pause, and holding past intervalToLongPress fires the long action mid-gesture.
+				Button_MarkModifierUsed(modifier);
+
+				if (cmd == CMD_SEEK_FORWARDS || cmd == CMD_SEEK_BACKWARDS) {
+					// Seek is a magnitude, not a step: firing the command once per detent would jump jumpOffset
+					// (30s by default) *each time*, so a flick of the encoder scrubs minutes. Apply the smaller
+					// per-detent rotary step directly instead. Direction comes from the configured command, so
+					// a user who maps CW to backwards still gets backwards.
+					const int32_t step = gPrefsSettings.getUChar("rotSeekStep", JUMP_OFFSET_ROTARY);
+					const int32_t magnitude = abs(detents) * step;
+					AudioPlayer_AddSeekOffset(static_cast<int16_t>((cmd == CMD_SEEK_FORWARDS) ? magnitude : -magnitude));
+					return;
+				}
+
+				for (int32_t i = 0; i < abs(detents); i++) {
+					Cmd_Action(cmd);
+				}
+				return;
+			}
+		}
+
 		if ((OPMODE_NORMAL == System_GetOperationMode()) || (OPMODE_BLUETOOTH_SOURCE == System_GetOperationMode())) {
-			auto newVol = AudioPlayer_GetCurrentVolume() + (encoderValue / 2);
+			auto newVol = AudioPlayer_GetCurrentVolume() + detents;
 			AudioPlayer_SetVolume(newVol);
 		} else {
-			auto newVol = Bluetooth_GetCurrentVolume() + (encoderValue / 2);
+			auto newVol = Bluetooth_GetCurrentVolume() + detents;
 			Bluetooth_SetVolume(newVol);
 		}
 		return;

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -37,6 +37,12 @@
 #include <esp_task_wdt.h>
 #include <nvs.h>
 
+// An override written before this feature existed does not define it (settings-override.h replaces
+// settings.h wholesale), so fall back rather than break those builds.
+#ifndef JUMP_OFFSET_ROTARY
+	#define JUMP_OFFSET_ROTARY 10
+#endif
+
 typedef struct {
 	char nvsKey[cardIdStringSize];
 	char nvsEntry[512];

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -1344,6 +1344,13 @@ static void settingsToJSON(JsonObject obj, const String section) {
 		buttonsSettings["multi34"].set(BUTTON_MULTI_34);
 		buttonsSettings["multi35"].set(BUTTON_MULTI_35);
 		buttonsSettings["multi45"].set(BUTTON_MULTI_45);
+		for (uint8_t i = 0; i < 6; i++) { // "hold button + turn encoder" gestures
+			char jsonCw[10], jsonCcw[11];
+			snprintf(jsonCw, sizeof(jsonCw), "rotCw%u", i);
+			snprintf(jsonCcw, sizeof(jsonCcw), "rotCcw%u", i);
+			buttonsSettings[jsonCw].set(Button_GetRotaryActionDefault(i, true));
+			buttonsSettings[jsonCcw].set(Button_GetRotaryActionDefault(i, false));
+		}
 #ifdef USEROTARY_ENABLE
 		JsonObject rotarySettings = defaultsObj["rotary"].to<JsonObject>();
 		rotarySettings["reverse"].set(false); // REVERSE_ROTARY

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -8,6 +8,7 @@
 #include "AudioPlayer.h"
 #include "Battery.h"
 #include "Bluetooth.h"
+#include "Button.h"
 #include "Cmd.h"
 #include "Common.h"
 #include "ESPAsyncWebServer.h"
@@ -738,6 +739,9 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 		success = success && (gPrefsSettings.putUInt("maxVolumeSp", generalObj["maxVolumeSp"].as<uint8_t>()) != 0);
 		success = success && (gPrefsSettings.putUInt("maxVolumeHp", generalObj["maxVolumeHp"].as<uint8_t>()) != 0);
 		success = success && (gPrefsSettings.putUInt("mInactiviyT", generalObj["sleepInactivity"].as<uint8_t>()) != 0);
+		if (generalObj["rotSeekStep"].is<uint8_t>()) {
+			success = success && (gPrefsSettings.putUChar("rotSeekStep", generalObj["rotSeekStep"].as<uint8_t>()) != 0);
+		}
 		success = success && (gPrefsSettings.putBool("playMono", generalObj["playMono"].as<bool>()) != 0);
 		success = success && (gPrefsSettings.putBool("savePosShutdown", generalObj["savePosShutdown"].as<bool>()) != 0);
 		success = success && (gPrefsSettings.putBool("savePosRfidChge", generalObj["savePosRfidChge"].as<bool>()) != 0);
@@ -847,6 +851,19 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 		success = success && (gPrefsSettings.putUChar("btnLong3", buttonsObj["long3"].as<uint8_t>()) != 0);
 		success = success && (gPrefsSettings.putUChar("btnLong4", buttonsObj["long4"].as<uint8_t>()) != 0);
 		success = success && (gPrefsSettings.putUChar("btnLong5", buttonsObj["long5"].as<uint8_t>()) != 0);
+		for (uint8_t i = 0; i < 6; i++) { // "hold button + turn encoder" gestures
+			char keyCw[12], keyCcw[13], jsonCw[10], jsonCcw[11];
+			snprintf(keyCw, sizeof(keyCw), "btnRotCw%u", i);
+			snprintf(keyCcw, sizeof(keyCcw), "btnRotCcw%u", i);
+			snprintf(jsonCw, sizeof(jsonCw), "rotCw%u", i);
+			snprintf(jsonCcw, sizeof(jsonCcw), "rotCcw%u", i);
+			if (buttonsObj[jsonCw].is<uint8_t>()) {
+				success = success && (gPrefsSettings.putUChar(keyCw, buttonsObj[jsonCw].as<uint8_t>()) != 0);
+			}
+			if (buttonsObj[jsonCcw].is<uint8_t>()) {
+				success = success && (gPrefsSettings.putUChar(keyCcw, buttonsObj[jsonCcw].as<uint8_t>()) != 0);
+			}
+		}
 		success = success && (gPrefsSettings.putUChar("btnMulti01", buttonsObj["multi01"].as<uint8_t>()) != 0);
 		success = success && (gPrefsSettings.putUChar("btnMulti02", buttonsObj["multi02"].as<uint8_t>()) != 0);
 		success = success && (gPrefsSettings.putUChar("btnMulti03", buttonsObj["multi03"].as<uint8_t>()) != 0);
@@ -1095,6 +1112,7 @@ static void settingsToJSON(JsonObject obj, const String section) {
 		generalObj["maxVolumeSp"].set(gPrefsSettings.getUInt("maxVolumeSp", 21));
 		generalObj["maxVolumeHp"].set(gPrefsSettings.getUInt("maxVolumeHp", 21));
 		generalObj["sleepInactivity"].set(gPrefsSettings.getUInt("mInactiviyT", 10));
+		generalObj["rotSeekStep"].set(gPrefsSettings.getUChar("rotSeekStep", JUMP_OFFSET_ROTARY)); // seconds per detent when seeking via a rotary gesture
 		generalObj["playMono"].set(gPrefsSettings.getBool("playMono", false));
 		generalObj["savePosShutdown"].set(gPrefsSettings.getBool("savePosShutdown", false)); // SAVE_PLAYPOS_BEFORE_SHUTDOWN
 		generalObj["savePosRfidChge"].set(gPrefsSettings.getBool("savePosRfidChge", false)); // SAVE_PLAYPOS_WHEN_RFID_CHANGE
@@ -1178,6 +1196,15 @@ static void settingsToJSON(JsonObject obj, const String section) {
 	if ((section == "") || (section == "buttons")) {
 		// button settings
 		JsonObject buttonsObj = obj["buttons"].to<JsonObject>();
+		for (uint8_t i = 0; i < 6; i++) { // "hold button + turn encoder" gestures
+			char keyCw[12], keyCcw[13], jsonCw[10], jsonCcw[11];
+			snprintf(keyCw, sizeof(keyCw), "btnRotCw%u", i);
+			snprintf(keyCcw, sizeof(keyCcw), "btnRotCcw%u", i);
+			snprintf(jsonCw, sizeof(jsonCw), "rotCw%u", i);
+			snprintf(jsonCcw, sizeof(jsonCcw), "rotCcw%u", i);
+			buttonsObj[jsonCw].set(Button_GetRotaryAction(i, true));
+			buttonsObj[jsonCcw].set(Button_GetRotaryAction(i, false));
+		}
 		buttonsObj["short0"].set(gPrefsSettings.getUChar("btnShort0", BUTTON_0_SHORT));
 		buttonsObj["short1"].set(gPrefsSettings.getUChar("btnShort1", BUTTON_1_SHORT));
 		buttonsObj["short2"].set(gPrefsSettings.getUChar("btnShort2", BUTTON_2_SHORT));

--- a/src/settings-override.h.sample
+++ b/src/settings-override.h.sample
@@ -127,6 +127,20 @@
 	#define BUTTON_4_LONG     CMD_VOLUMEUP
 	#define BUTTON_5_LONG     CMD_VOLUMEDOWN
 
+	// Rotary gestures: hold the button, turn the encoder. CMD_NOTHING disables the button as a modifier.
+	#define BUTTON_0_ROTARY_CW   CMD_SEEK_FORWARDS   // hold NEXT + turn: seek within the track
+	#define BUTTON_0_ROTARY_CCW  CMD_SEEK_BACKWARDS
+	#define BUTTON_1_ROTARY_CW   CMD_NOTHING
+	#define BUTTON_1_ROTARY_CCW  CMD_NOTHING
+	#define BUTTON_2_ROTARY_CW   CMD_BRIGHTNESS_UP   // hold PLAY/PAUSE + turn: LED brightness
+	#define BUTTON_2_ROTARY_CCW  CMD_BRIGHTNESS_DOWN
+	#define BUTTON_3_ROTARY_CW   CMD_NOTHING         // rotary push: short=play/pause, long=sleep -- left free on purpose
+	#define BUTTON_3_ROTARY_CCW  CMD_NOTHING
+	#define BUTTON_4_ROTARY_CW   CMD_NOTHING
+	#define BUTTON_4_ROTARY_CCW  CMD_NOTHING
+	#define BUTTON_5_ROTARY_CW   CMD_NOTHING
+	#define BUTTON_5_ROTARY_CCW  CMD_NOTHING
+
 	#define BUTTON_MULTI_01   CMD_NOTHING   //CMD_TOGGLE_WIFI_STATUS (disabled now to prevent children from unwanted WiFi-disable)
 	#define BUTTON_MULTI_02   CMD_ENABLE_FTP_SERVER
 	#define BUTTON_MULTI_03   CMD_NOTHING
@@ -236,6 +250,10 @@
 
 	// Seekmode-configuration
 	constexpr uint8_t jumpOffset = 30;                            // Offset in seconds to jump for commands CMD_SEEK_FORWARDS / CMD_SEEK_BACKWARDS
+	#define JUMP_OFFSET_ROTARY 10                                 // Offset in seconds per encoder-detent when seeking via a rotary gesture. A button press is a
+	                                                              // deliberate act and can afford jumpOffset; a flick of the encoder is many detents at once, so
+	                                                              // reusing jumpOffset there scrubs minutes at a time. Overridable at runtime via NVS "rotSeekStep".
+	                                                              // A macro (not constexpr) so Button/RotaryEncoder can #ifndef-default it for older overrides.
 
 	// (optional) Topics for MQTT
 	#ifdef MQTT_ENABLE

--- a/src/settings.h
+++ b/src/settings.h
@@ -126,6 +126,21 @@
 	#define BUTTON_4_LONG     CMD_VOLUMEUP
 	#define BUTTON_5_LONG     CMD_VOLUMEDOWN
 
+	// Rotary gestures: hold the button, turn the encoder. CMD_NOTHING disables the button as a modifier.
+	// A modifier button keeps its normal short/long action when it is pressed *without* turning the encoder.
+	#define BUTTON_0_ROTARY_CW   CMD_SEEK_FORWARDS   // hold NEXT + turn: seek within the track
+	#define BUTTON_0_ROTARY_CCW  CMD_SEEK_BACKWARDS
+	#define BUTTON_1_ROTARY_CW   CMD_NOTHING
+	#define BUTTON_1_ROTARY_CCW  CMD_NOTHING
+	#define BUTTON_2_ROTARY_CW   CMD_BRIGHTNESS_UP   // hold PLAY/PAUSE + turn: LED brightness
+	#define BUTTON_2_ROTARY_CCW  CMD_BRIGHTNESS_DOWN
+	#define BUTTON_3_ROTARY_CW   CMD_NOTHING         // rotary push: short=play/pause, long=sleep -- left free on purpose
+	#define BUTTON_3_ROTARY_CCW  CMD_NOTHING
+	#define BUTTON_4_ROTARY_CW   CMD_NOTHING
+	#define BUTTON_4_ROTARY_CCW  CMD_NOTHING
+	#define BUTTON_5_ROTARY_CW   CMD_NOTHING
+	#define BUTTON_5_ROTARY_CCW  CMD_NOTHING
+
 	#define BUTTON_MULTI_01   CMD_NOTHING   //CMD_TOGGLE_WIFI_STATUS (disabled now to prevent children from unwanted WiFi-disable)
 	#define BUTTON_MULTI_02   CMD_ENABLE_FTP_SERVER
 	#define BUTTON_MULTI_03   CMD_NOTHING
@@ -237,6 +252,10 @@
 
 	// Seekmode-configuration
 	constexpr uint8_t jumpOffset = 30;                            // Offset in seconds to jump for commands CMD_SEEK_FORWARDS / CMD_SEEK_BACKWARDS
+	#define JUMP_OFFSET_ROTARY 10                                 // Offset in seconds per encoder-detent when seeking via a rotary gesture. A button press is a
+	                                                              // deliberate act and can afford jumpOffset; a flick of the encoder is many detents at once, so
+	                                                              // reusing jumpOffset there scrubs minutes at a time. Overridable at runtime via NVS "rotSeekStep".
+	                                                              // A macro (not constexpr) so Button/RotaryEncoder can #ifndef-default it for older overrides.
 
 	// Topics for MQTT: used to build actual topics in webinterface. So normally there's no need to apply any changes here 
 	// MQTT configuration available via webinterface: https://forum.espuino.de/t/dokumentation-webinterface/2807.

--- a/src/values.h
+++ b/src/values.h
@@ -57,7 +57,9 @@
 #define CMD_ENABLE_FTP_SERVER			 150 // Enables FTP-server
 #define CMD_TELL_IP_ADDRESS				 151 // Command: ESPuino announces its IP-address via speech
 #define CMD_TELL_CURRENT_TIME			 152 // Command: ESPuino announces current time via speech
-#define CMD_TOGGLE_AMBIENT_LIGHT		 153 // Command: ESPuino announces current time via speech
+#define CMD_TOGGLE_AMBIENT_LIGHT		 153 // Command: toggles the ambient light
+#define CMD_BRIGHTNESS_UP				 154 // Command: raise LED-brightness by one step
+#define CMD_BRIGHTNESS_DOWN				 155 // Command: lower LED-brightness by one step
 
 #define CMD_PLAYPAUSE	   170 // Command: play/pause
 #define CMD_PREVTRACK	   171 // Command: previous track


### PR DESCRIPTION
## What

Adds a modifier concept to the rotary encoder: **while a button is physically
held, turning the encoder runs that button's configured rotary action instead
of changing the volume**. One action per rotation direction, per button —
configured exactly like the existing short/long press assignments:
compile-time default in `settings.h`, runtime-overridable via NVS
(`btnRotCw0..5` / `btnRotCcw0..5`), the `/settings` API, and new dropdowns in
the web UI.

Shipped defaults (both opt-in, everything else `CMD_NOTHING`):

- **hold NEXT + turn** → seek forwards/backwards within the track
- **hold PLAY/PAUSE + turn** → LED brightness up/down (new commands, see below)

The use case driving this: a kids' audiobook box. Seeking inside a
45-minute chapter and tweaking LED brightness at bedtime were both
impossible from the device itself — the encoder only ever meant volume.

## How it works / collisions solved

All three were pre-existing behaviours that only become visible once a button
can be held for a reason other than its own action:

- **Short press fires on release** → letting go of a modifier would also
  toggle play/pause. **Long press fires at `intervalToLongPress` while still
  held** → holding NEXT to seek would fire `CMD_LASTTRACK` mid-gesture and
  jump to the end of the audiobook. Both are now swallowed — but *only if the
  encoder was actually turned* (`usedAsModifier`). A plain press/hold on the
  same button still behaves normally; the long action of a gesture-mapped
  button simply resolves on release (the same deferral `CMD_SLEEPMODE`
  already used).
- **Two-button combos** match on the latched `isPressed`, so a held modifier
  was a sitting duck for an accidental combo → combos involving a
  currently-held modifier are skipped.
- **`ESP32Encoder::getCount()` keeps an incomplete half-step across ticks**,
  so a gesture could inherit rotation from before the button went down (and
  the volume could inherit rotation from during the gesture) → the count is
  cleared whenever the held modifier changes.

New commands `CMD_BRIGHTNESS_UP`/`CMD_BRIGHTNESS_DOWN` (154/155). They clamp:
`Led_SetBrightness()` takes a `uint8_t` and does not bounds-check, so stepping
down from brightness 2 would otherwise wrap to ~255 — a dark bedroom goes to
full blast.

## Web UI

New "Hold button + turn encoder" table directly below Button assignments
(General → button/encoder tab): 6 rows × two command dropdowns (turn
left/right), reusing the existing command-select machinery. Only shown when
the firmware reports a rotary encoder. Locale strings for en/de/fr.

Two adjacent gaps closed on the way:

- 154/155 are selectable in all command dropdowns (they'd be firmware-only
  otherwise).
- The factory-defaults endpoint (`/settings?section=defaults`) now reports
  the compile-time rotary defaults via `Button_GetRotaryActionDefault()` —
  without this, "reset to factory settings" blanked the new selects and the
  next save persisted `CMD_NOTHING` for all twelve.

## Supporting fixes (first two commits — standalone, worth having regardless)

- **`AudioPlayer_SetVolume()` clamps instead of rejecting**: a fast rotary
  spin near the rails (e.g. 20 → 23 with max 21) discarded the whole change
  and did nothing.
- **Relative seeks accumulate** (`seekmode` was a single overwriteable enum
  consumed once per audio-loop iteration): N rapid seek commands used to
  collapse into one jump; now an accumulating atomic, so five detents = 5×
  the seek step.

## Testing

Hardware-verified on a Lolin D32 + RC522 running a 29-track audiobook:

- hold-NEXT seek back/forward mid-chapter, incl. rapid multi-detent seeks
- hold-PLAY/PAUSE brightness up/down, incl. clamping at both rails
- plain short/long presses on the same buttons unchanged; long press on a
  gesture-mapped button resolves on release; turning cancels it
- combo suppression while a modifier is held
- web UI: dropdowns populate from NVS, save round-trips (`rotCw3` 0 → 170 →
  0 verified over `/settings`), factory-defaults restore the compile-time
  values, en/de/fr all render
- `pio run` clean on `lolin_d32_pro`; clang-format 16 clean

Full page:
<img width="1296" height="1772" alt="encoder-tab-full-en" src="https://github.com/user-attachments/assets/efaafe19-aacc-4f81-b7da-32341d80530d" />

DE:
<img width="1296" height="402" alt="rotary-gestures-de" src="https://github.com/user-attachments/assets/cbe3c593-3114-40b6-80fa-c76ef2550d7a" />

EN:
<img width="1296" height="402" alt="rotary-gestures-en" src="https://github.com/user-attachments/assets/425382f5-abcd-4276-9846-71fe6a860e8e" />
 
FR:
<img width="1296" height="402" alt="rotary-gestures-fr" src="https://github.com/user-attachments/assets/85c43f11-1eec-4028-9348-ba6564a4c295" />

Popover:
<img width="1296" height="1772" alt="rotary-gestures-en-popover" src="https://github.com/user-attachments/assets/62a3f01b-65d0-42aa-b77c-4e4ccc2e631d" />

