### PR TITLE
fix audiobook resume-seek for CBR MP3s without a Xing/Info header

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -88,6 +88,7 @@ BaseType_t trackQStatus = pdFAIL;
 uint8_t trackCommand = NO_ACTION;
 bool audioReturnCode;
 uint32_t AudioPlayer_LastPlaytimeStatsTimestamp = 0u;
+static uint32_t AudioPlayer_resumeSeekPendingSecs = 0; // deferred resume-seek target (seconds); 0 = none pending (declared early: used by the audio_info evt_bitrate callback above AudioPlayer_Loop)
 Playlist *newPlayList = nullptr;
 bool newPlayListAvailable = false;
 
@@ -166,6 +167,22 @@ void Audio_InfoCallback(Audio::msg_t m) {
 		}
 		case Audio::evt_bitrate: {
 			Log_Printf(LOGLEVEL_INFO, "bitrate:      %s", m.msg);
+			// Deferred audiobook resume-seek. connecttoFS(fileStartTime) only seeks files whose
+			// Xing/VBR header sets m_nominal_bitrate; headerless CBR audiobooks are never seeked and
+			// restart from 0. This event fires once the measured average bitrate has *stabilised*, so
+			// setAudioPlayTime() now lands accurately and the lib re-syncs the reported play-time to
+			// match (seeking earlier, before the bitrate settles, both mis-positions and desyncs the
+			// clock). Guards: only when a resume is pending, the target is within the file, and we are
+			// not already there (a VBR file the lib already positioned at connect).
+			if (AudioPlayer_resumeSeekPendingSecs > 0 && audio != nullptr) {
+				const uint32_t target = AudioPlayer_resumeSeekPendingSecs;
+				AudioPlayer_resumeSeekPendingSecs = 0; // one-shot regardless of outcome
+				if (target < audio->getAudioFileDuration() && target > audio->getAudioCurrentTime() + 3) {
+					if (audio->setAudioPlayTime(target)) {
+						Log_Printf(LOGLEVEL_NOTICE, "Resume: deferred seek to position %u", target);
+					}
+				}
+			}
 			break;
 		}
 		case Audio::evt_icyurl: {
@@ -1014,8 +1031,14 @@ void AudioPlayer_Loop() {
 				return;
 			} else {
 				int32_t fileStartTime = -1;
+				AudioPlayer_resumeSeekPendingSecs = 0; // default: no deferred seek for this track
 				if (gPlayProperties.startAtFilePos > 0) {
 					fileStartTime = gPlayProperties.startAtFilePos;
+					// Also arm a deferred seek: ESP32-audioI2S only honors this connecttoFS() start
+					// position for files whose Xing/VBR header sets m_nominal_bitrate. Headerless CBR
+					// audiobooks never get seeked here and restart from 0, so we re-seek ourselves once
+					// the measured bitrate is known (see AudioPlayer_Loop). Harmless for VBR (skipped).
+					AudioPlayer_resumeSeekPendingSecs = gPlayProperties.startAtFilePos;
 					Log_Printf(LOGLEVEL_NOTICE, trackStartatPos, gPlayProperties.startAtFilePos);
 					gPlayProperties.startAtFilePos = 0;
 				}


### PR DESCRIPTION
### Problem
Audiobooks restart from the start of the file after any reload (reboot, or
swapping to another card and back). Split books hide it; a long single-file
chapter loses the whole chapter. A warm same-card re-tap only hits the
pause/resume toggle path (no reload), so it *looks* like resume works — which
masks the bug.

The position is saved and passed back correctly — `Starting track at position N`
logs on every resume. The **seek** is what's dropped, inside the audio lib.

### Root cause (ESP32-audioI2S)
`connecttoFS(path, fileStartTime)` only seeks when a *nominal* bitrate is known:

```cpp
if (m_fileStartTime > 0 && m_nominal_bitrate) { setAudioPlayTime(m_fileStartTime); m_fileStartTime = -1; }
```

`m_nominal_bitrate` is set **only when a Xing/Info header is parsed**. An MP3
encoded **CBR without a Xing/Info header** never sets it → the seek block never
runs → playback starts from 0. Whether a file carries that header depends on the
encoder, so this bites some libraries and not others. Trace confirms: no
`Duration (s):` line, and the bitrate reported is the measured average
(`m_avr_bitrate`), not the nominal one.

### Fix
`setAudioPlayTime(sec)` works off `getBitRate()` (the measured average), which
these files do provide. Arm a deferred seek at track start and run it from the
`evt_bitrate` callback — i.e. once the average bitrate has **stabilised**. Timing
is load-bearing: the seek's byte↔time round-trip only cancels when the bitrate is
stable, so seeking on the first duration reading both mis-positions the file and
desyncs the reported clock. Guarded so it never seeks past EOF (would `stopSong()`
→ skip the track) and skips VBR files the lib already positioned. Cost: ~2-3 s
from the start before the jump.

### Tested (Lolin D32)
- Power-cycle mid-chapter → resumes at the saved spot; reported time in sync
  (`seek 780` → paused `786` = 780 + 6 s). 
- Rapid card swaps across chapter boundaries → no chapter skips.

### Note
The underlying lib bug is known and closed not-planned upstream (schreibfaul1 #803, #748/#1228)