### PR TITLE
Rotary gestures: add CMD_SEEK_PREVIEW as a second seek variant

### DIFF
--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -101,7 +101,12 @@
 			"gestures": "Taste halten + drehen",
 			"gesturesExp": "Solange eine dieser Tasten gehalten wird, löst Drehen am Drehimpulsgeber die zugewiesene Aktion aus, statt die Lautstärke zu ändern. 'Rechts drehen' ist die Richtung, die sonst lauter stellt. Die Lang-Aktion einer solchen Taste wird erst beim Loslassen ausgelöst - und gar nicht, wenn gedreht wurde.",
 			"ccw": "links drehen",
-			"cw": "rechts drehen"
+			"cw": "rechts drehen",
+			"seekPreviewTitle": "Positionsvorschau-Einstellungen",
+			"seekPrevDelay": "Verzögerung bis zur Übernahme [ms]",
+			"seekPrevDelayExp": "Wie lange (in ms) der Drehimpulsgeber stillstehen muss, bevor eine 🎯 Positionsvorschau-Geste von selbst zur vorgeschauten Position springt. Loslassen der gehaltenen Taste übernimmt die Position immer sofort, unabhängig von dieser Verzögerung. 0-3000, Standard 2000.",
+			"seekPrevSweep": "Anzahl Rasterungen für 0 bis 100 %",
+			"seekPrevSweepExp": "Wie viele Encoder-Rasterungen das Positionsvorschau-Ziel von 0% auf 100% (blaue LED) des Titels bewegen. Niedriger = grober/schnelleres Positionieren, höher = feinere Kontrolle. Standard 40."
 		}
 	},
 	"wifi": {
@@ -312,6 +317,7 @@
 					"183": "🔄 Neustart",
 					"184": "📁 Springe zum nächsten Ordner",
 					"185": "📁 Springe zum vorherigen Ordner",
+					"186": "🎯 Positionsvorschau (drehen zum Positionieren, wird bei Loslassen/Stillstand übernommen)",
 					"199": "📊 Taskauslastung anzeigen (Konsole)",
 					"241": "🏷 Spiele virtuelle RFID-Karte 01",
 					"242": "🏷 Spiele virtuelle RFID-Karte 02",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -101,7 +101,12 @@
 			"gestures": "Hold button + turn encoder",
 			"gesturesExp": "While one of these buttons is held down, turning the encoder triggers the assigned action instead of changing the volume. 'Turn right' is the direction that raises the volume. The long-press action of such a button fires when it is released - and not at all if the encoder was turned.",
 			"ccw": "turn left",
-			"cw": "turn right"
+			"cw": "turn right",
+			"seekPreviewTitle": "Seek preview settings",
+			"seekPrevDelay": "Auto-commit delay",
+			"seekPrevDelayExp": "How long (in ms) the encoder must stay idle before a 🎯 seek-preview gesture jumps to the previewed position on its own. Releasing the held button always commits immediately, regardless of this delay. 0-3000, default 2000.",
+			"seekPrevSweep": "Turns for full sweep",
+			"seekPrevSweepExp": "How many encoder detents move the seek-preview target from 0% to 100% (blue LED) of the track. Lower = coarser/faster scrubbing, higher = finer control. Default 40."
 		}
 	},
 	"wifi": {
@@ -312,6 +317,7 @@
 					"183": "🔄 Restart",
 					"184": "📁 Jump to next folder",
 					"185": "📁 Jump to previous folder",
+					"186": "🎯 Seek preview (turn to scrub, commits on release/idle)",
 					"199": "📊 Display task load (console)",
 					"241": "🏷 Play virtual RFID-card 01",
 					"242": "🏷 Play virtual RFID-card 02",

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -101,7 +101,12 @@
 			"gestures": "Bouton maintenu + rotation",
 			"gesturesExp": "Tant qu'un de ces boutons est maintenu, tourner le codeur rotatif déclenche l'action attribuée au lieu de changer le volume. « Tourner à droite » est le sens qui augmente le volume. L'appui long d'un tel bouton ne se déclenche qu'au relâchement - et pas du tout si le codeur a été tourné.",
 			"ccw": "tourner à gauche",
-			"cw": "tourner à droite"
+			"cw": "tourner à droite",
+			"seekPreviewTitle": "Réglages de l'aperçu de recherche",
+			"seekPrevDelay": "Délai avant validation",
+			"seekPrevDelayExp": "Durée (en ms) pendant laquelle le codeur doit rester immobile avant qu'un geste d'aperçu de recherche (voir commande 186) ne saute de lui-même à la position prévisualisée. Relâcher le bouton maintenu valide toujours immédiatement, indépendamment de ce délai. 0-3000, par défaut 2000.",
+			"seekPrevSweep": "Crans pour un balayage complet",
+			"seekPrevSweepExp": "Nombre de crans du codeur nécessaires pour déplacer la cible de l'aperçu de recherche de 0% à 100% du morceau. Plus bas = défilement plus grossier/rapide, plus haut = contrôle plus fin. Par défaut 40."
 		}
 	},
 	"wifi": {
@@ -312,6 +317,7 @@
 					"183": "🔄 Redémarrer",
 					"184": "📁 Passer au dossier suivant",
 					"185": "📁 Passer au dossier précédent",
+					"186": "🎯 Aperçu de recherche (tourner pour naviguer, valide au relâchement/immobilité)",
 					"199": "📊 Affichage de la charge de travail (console)",
 					"241": "🏷 Lire la carte RFID virtuelle 01",
 					"242": "🏷 Lire la carte RFID virtuelle 02",

--- a/html/management.html
+++ b/html/management.html
@@ -1590,6 +1590,35 @@
 									</table>
 								</div>
 							</fieldset>
+							<fieldset>
+								<legend class="w-auto" data-i18n="settingsex.rotary.seekPreviewTitle"></legend>
+								<div class="row mb-2 align-items-center">
+									<div class="col-sm-4 d-flex align-items-center gap-2">
+										<label for="seekPrevDelay" class="col-form-label"
+											data-i18n="settingsex.rotary.seekPrevDelay"></label>
+										<a href="#" class="link-secondary" data-bs-toggle="popover"
+											data-i18n="[data-bs-content]settingsex.rotary.seekPrevDelayExp" tabindex="0">
+											<i class="fas fa-circle-question"></i></a>
+									</div>
+									<div class="col-sm-8">
+										<input type="number" class="form-control" id="seekPrevDelay" name="seekPrevDelay"
+											min="0" max="3000" step="100">
+									</div>
+								</div>
+								<div class="row mb-2 align-items-center">
+									<div class="col-sm-4 d-flex align-items-center gap-2">
+										<label for="seekPrevSweep" class="col-form-label"
+											data-i18n="settingsex.rotary.seekPrevSweep"></label>
+										<a href="#" class="link-secondary" data-bs-toggle="popover"
+											data-i18n="[data-bs-content]settingsex.rotary.seekPrevSweepExp" tabindex="0">
+											<i class="fas fa-circle-question"></i></a>
+									</div>
+									<div class="col-sm-8">
+										<input type="number" class="form-control" id="seekPrevSweep" name="seekPrevSweep"
+											min="4" max="250" step="1">
+									</div>
+								</div>
+							</fieldset>
 							<hr>
 						</div>
 						<fieldset>
@@ -3404,6 +3433,8 @@
 				document.getElementById("rotaryConfig").style.display = null;
 				document.getElementById("rotaryGesturesConfig").style.display = null;
 				$('#rotaryReverse').prop('checked', rotarySettings.reverse);
+				$('#seekPrevDelay').val(rotarySettings.seekPrevDelay);
+				$('#seekPrevSweep').val(rotarySettings.seekPrevSweep);
 			}
 			// buttons
 			let buttonSettings = settings.buttons;
@@ -3891,7 +3922,9 @@
 					multi45: Number(document.getElementById("cmdselect_multi_45").value),
 				},
 				"rotary": {
-					reverse: $('#rotaryReverse').prop('checked')
+					reverse: $('#rotaryReverse').prop('checked'),
+					seekPrevDelay: Number($('#seekPrevDelay').val()),
+					seekPrevSweep: Number($('#seekPrevSweep').val())
 				}
 			};
 			// fill LED control colors
@@ -4616,7 +4649,14 @@
 			}
 
 			/* fill settingsex button commands */
-			document.querySelectorAll('[id*=cmdselect_]').forEach(e => replaceCommandSelect(e, cmdElem));
+			document.querySelectorAll('[id*=cmdselect_]:not([id*=cmdselect_rotcw_]):not([id*=cmdselect_rotccw_])').forEach(e => replaceCommandSelect(e, cmdElem));
+
+			/* Rotary CW/CCW selects additionally get CMD_SEEK_PREVIEW (186): a plain short/long/multi-button
+			   press has no "turning" to drive it, so it's meaningless there and left out of the shared cmds
+			   list above -- only the "hold + turn" gesture selects offer it. */
+			const cmdElemRotary = cmdElem.cloneNode(true);
+			addOption(cmdElemRotary, 186);
+			document.querySelectorAll('[id*=cmdselect_rotcw_], [id*=cmdselect_rotccw_]').forEach(e => replaceCommandSelect(e, cmdElemRotary));
 
 			/* The <select /> that houses all commands for the modification selectors */
 			const modElem = document.createElement('select');

--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -24,7 +24,9 @@
 #include "main.h"
 #include "strnatcmp.h"
 
+#include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <esp_task_wdt.h>
 #include <freertos/task.h>
 #include <random>
@@ -37,6 +39,63 @@ static std::atomic<int16_t> AudioPlayer_PendingSeekSeconds {0};
 
 void AudioPlayer_AddSeekOffset(const int16_t seconds) {
 	AudioPlayer_PendingSeekSeconds.fetch_add(seconds, std::memory_order_relaxed);
+}
+
+// Seek-preview (rotary gesture, CMD_SEEK_PREVIEW): turning moves a not-yet-committed target position
+// instead of jumping immediately; committed via the existing SEEK_POS_PERCENT path once the encoder is
+// idle for a configurable delay, or immediately on release (see RotaryEncoder.cpp). currentRelPos must
+// never be touched before the commit -- it also drives the LED progress ring, and writing the preview
+// target into it early would make played-back position look like it already jumped.
+static std::atomic<bool> AudioPlayer_SeekPreviewActive {false};
+static std::atomic<uint8_t> AudioPlayer_SeekPreviewTargetPercent {0};
+static double AudioPlayer_SeekPreviewTargetExact = 0.0; // full precision; only ever touched by the loop() task
+static uint32_t AudioPlayer_SeekPreviewLastInputMs = 0; // only ever touched by the loop() task
+// Cached once per gesture (in Start()), not re-read from NVS on every AudioPlayer_Loop() iteration/detent:
+// the idle-commit check below runs on every single loop() cycle for as long as a gesture is held, and a
+// NVS getUShort/getUChar still costs a mutex lock + key lookup each time even though it's RAM-cached.
+static uint16_t AudioPlayer_SeekPreviewDelayMsCached = 2000;
+static uint8_t AudioPlayer_SeekPreviewSweepCached = 40;
+
+void AudioPlayer_SeekPreviewStart(void) {
+	if (gPlayProperties.audioFileDuration == 0) {
+		return; // no meaningful target for webstreams / unknown-length content
+	}
+	AudioPlayer_SeekPreviewDelayMsCached = gPrefsSettings.getUShort("seekPrevDelay", 2000);
+	AudioPlayer_SeekPreviewSweepCached = gPrefsSettings.getUChar("seekPrevSweep", 40);
+	AudioPlayer_SeekPreviewTargetExact = gPlayProperties.currentRelPos; // start from where playback is, not 0
+	AudioPlayer_SeekPreviewTargetPercent.store(static_cast<uint8_t>(std::lround(AudioPlayer_SeekPreviewTargetExact)), std::memory_order_relaxed);
+	AudioPlayer_SeekPreviewLastInputMs = millis();
+	AudioPlayer_SeekPreviewActive.store(true, std::memory_order_relaxed);
+}
+
+void AudioPlayer_SeekPreviewAdjust(const int32_t detents) {
+	if (!AudioPlayer_SeekPreviewActive.load(std::memory_order_relaxed)) {
+		return;
+	}
+	AudioPlayer_SeekPreviewTargetExact = std::clamp(AudioPlayer_SeekPreviewTargetExact + (detents * 100.0 / AudioPlayer_SeekPreviewSweepCached), 0.0, 100.0);
+	AudioPlayer_SeekPreviewTargetPercent.store(static_cast<uint8_t>(std::lround(AudioPlayer_SeekPreviewTargetExact)), std::memory_order_relaxed);
+	AudioPlayer_SeekPreviewLastInputMs = millis();
+}
+
+void AudioPlayer_SeekPreviewCommit(void) {
+	if (!AudioPlayer_SeekPreviewActive.load(std::memory_order_relaxed)) {
+		return;
+	}
+	gPlayProperties.currentRelPos = AudioPlayer_SeekPreviewTargetPercent.load(std::memory_order_relaxed);
+	gPlayProperties.seekmode = SEEK_POS_PERCENT;
+	AudioPlayer_SeekPreviewActive.store(false, std::memory_order_relaxed);
+}
+
+void AudioPlayer_SeekPreviewCancel(void) {
+	AudioPlayer_SeekPreviewActive.store(false, std::memory_order_relaxed);
+}
+
+bool AudioPlayer_IsSeekPreviewActive(void) {
+	return AudioPlayer_SeekPreviewActive.load(std::memory_order_relaxed);
+}
+
+uint8_t AudioPlayer_GetSeekPreviewTargetPercent(void) {
+	return AudioPlayer_SeekPreviewTargetPercent.load(std::memory_order_relaxed);
 }
 
 // Playlist
@@ -1094,6 +1153,7 @@ void AudioPlayer_Loop() {
 			// firing at once; the 0 baseline just means the first checkpoint always writes.
 			AudioPlayer_lastCheckpointTimestamp = millis();
 			AudioPlayer_lastCheckpointPos = 0;
+			AudioPlayer_SeekPreviewCancel(); // a preview from the previous track must never commit onto this one
 			if (gPlayProperties.currentTrackNumber) {
 				Led_Indicate(LedIndicatorType::PlaylistProgress);
 			}
@@ -1119,6 +1179,15 @@ void AudioPlayer_Loop() {
 	if (seekOffset != 0) {
 		if (audio->setTimeOffset(seekOffset)) {
 			Log_Printf(LOGLEVEL_NOTICE, (seekOffset > 0) ? secondsJumpForward : secondsJumpBackward, abs(seekOffset));
+		}
+	}
+
+	// Seek-preview (CMD_SEEK_PREVIEW rotary gesture): commit once the encoder has been idle for the
+	// configured delay. A release-triggered commit happens directly from RotaryEncoder.cpp instead of
+	// waiting for this -- this is only the "held but stopped turning" case.
+	if (AudioPlayer_SeekPreviewActive.load(std::memory_order_relaxed)) {
+		if (millis() - AudioPlayer_SeekPreviewLastInputMs >= AudioPlayer_SeekPreviewDelayMsCached) {
+			AudioPlayer_SeekPreviewCommit();
 		}
 	}
 

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -74,6 +74,14 @@ void AudioPlayer_SetPlaylist(const char *_itemToPlay, const uint32_t _lastPlayPo
 void AudioPlayer_SetTrackControl(const uint8_t trackCommand);
 // Queue a relative seek. Accumulates, so one call per rotary detent scrubs proportionally.
 void AudioPlayer_AddSeekOffset(const int16_t seconds);
+// Seek-preview (CMD_SEEK_PREVIEW rotary gesture): moves a not-yet-committed target position instead of
+// jumping immediately; commits via the existing SEEK_POS_PERCENT path (see RotaryEncoder.cpp).
+void AudioPlayer_SeekPreviewStart(void);
+void AudioPlayer_SeekPreviewAdjust(const int32_t detents);
+void AudioPlayer_SeekPreviewCommit(void);
+void AudioPlayer_SeekPreviewCancel(void);
+bool AudioPlayer_IsSeekPreviewActive(void);
+uint8_t AudioPlayer_GetSeekPreviewTargetPercent(void);
 // Arm the "don't accept same RFID twice"-lock to be released on the next idle-state. Called when a tag is
 // accepted, independent of whether playback actually starts, so a tag whose first track fails immediately
 // (e.g. a webstream without WiFi) does not stay locked forever.

--- a/src/Cmd.cpp
+++ b/src/Cmd.cpp
@@ -382,6 +382,15 @@ void Cmd_Action(const uint16_t mod) {
 			break;
 		}
 
+		case CMD_SEEK_PREVIEW: {
+			// Rotary-gesture-only: RotaryEncoder.cpp intercepts this command directly (it needs the raw,
+			// bidirectional detent delta to move a preview target, not a single fire-and-forget action) and
+			// never dispatches it here. This case only exists so an unexpected direct dispatch (e.g. a
+			// misconfigured short/long-press assignment) is a silent no-op instead of falling into "unknown
+			// command" below.
+			break;
+		}
+
 		case CMD_BRIGHTNESS_UP:
 		case CMD_BRIGHTNESS_DOWN: {
 			// Led_SetBrightness() takes a uint8_t and does not bounds-check, so clamping is the caller's job:
@@ -394,6 +403,7 @@ void Cmd_Action(const uint16_t mod) {
 		}
 
 		case CMD_STOP: {
+			AudioPlayer_SeekPreviewCancel(); // don't let a stopped track's leftover preview commit onto whatever plays next
 			AudioPlayer_SetTrackControl(STOP);
 			break;
 		}

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -1039,12 +1039,28 @@ AnimationReturnType Animation_Progress(const bool startNewAnimation, CRGBSet &le
 	int32_t animationDelay = 0;
 	// static values
 	static double lastPos = 0.0f;
+	static bool lastPreviewActive = false;
+	static uint8_t lastPreviewTarget = 0;
 
-	if (gPlayProperties.currentRelPos != lastPos || startNewAnimation) {
+	// CMD_SEEK_PREVIEW rotary gesture (RotaryEncoder.cpp/AudioPlayer.cpp): while active, the ring shows
+	// a not-yet-committed target instead of the actual (unchanged) playback position -- read via these
+	// accessors rather than gPlayProperties.currentRelPos, which must not reflect the preview before commit.
+	const bool previewActive = AudioPlayer_IsSeekPreviewActive();
+	const uint8_t previewTarget = AudioPlayer_GetSeekPreviewTargetPercent();
+
+	if (gPlayProperties.currentRelPos != lastPos || previewActive != lastPreviewActive || (previewActive && (previewTarget != lastPreviewTarget)) || startNewAnimation) {
 		lastPos = gPlayProperties.currentRelPos;
+		lastPreviewActive = previewActive;
+		lastPreviewTarget = previewTarget;
 		leds = CRGB::Black;
 		if (gLedSettings.numIndicatorLeds == 1) {
-			leds[0].setHue((uint8_t) (85 - ((double) 90 / 100) * gPlayProperties.currentRelPos));
+			if (previewActive) {
+				// A single LED can't show ring-position and cursor separately -- solid blue is an
+				// unambiguous "preview active" signal, at the cost of not showing the target itself.
+				leds[0] = CRGB::Blue;
+			} else {
+				leds[0].setHue((uint8_t) (85 - ((double) 90 / 100) * gPlayProperties.currentRelPos));
+			}
 		} else {
 			const uint32_t ledValue = std::clamp<uint32_t>(map(gPlayProperties.currentRelPos, 0, 98, 0, leds.size() * gLedSettings.dimmableStates), 0, leds.size() * gLedSettings.dimmableStates);
 			const uint8_t fullLeds = ledValue / gLedSettings.dimmableStates;
@@ -1052,6 +1068,8 @@ AnimationReturnType Animation_Progress(const bool startNewAnimation, CRGBSet &le
 			for (uint8_t led = 0; led < fullLeds; led++) {
 				if (System_AreControlsLocked()) {
 					leds[Led_Address(led)] = CRGB::Red;
+				} else if (previewActive) {
+					leds[Led_Address(led)] = CRGB::Yellow;
 				} else if (!gPlayProperties.pausePlay) { // Hue-rainbow
 					leds[Led_Address(led)].setHue((uint8_t) (((float) gLedSettings.progressHueEnd - (float) gLedSettings.progressHueStart) / (leds.size() - 1) * led + gLedSettings.progressHueStart));
 				}
@@ -1059,10 +1077,19 @@ AnimationReturnType Animation_Progress(const bool startNewAnimation, CRGBSet &le
 			if (lastLed > 0) {
 				if (System_AreControlsLocked()) {
 					leds[Led_Address(fullLeds)] = CRGB::Red;
+				} else if (previewActive) {
+					leds[Led_Address(fullLeds)] = CRGB::Yellow;
 				} else {
 					leds[Led_Address(fullLeds)].setHue((uint8_t) (((float) gLedSettings.progressHueEnd - (float) gLedSettings.progressHueStart) / (leds.size() - 1) * fullLeds + gLedSettings.progressHueStart));
 				}
 				leds[Led_Address(fullLeds)] = Led_DimColor(leds[Led_Address(fullLeds)], lastLed);
+			}
+			if (previewActive) {
+				// Cursor is drawn last so it overrides whatever the ring fill just put at that position.
+				const uint32_t cursorValue = std::clamp<uint32_t>(map(previewTarget, 0, 100, 0, leds.size() * gLedSettings.dimmableStates), 0, leds.size() * gLedSettings.dimmableStates);
+				const uint8_t cursorLed = std::min<uint8_t>(cursorValue / gLedSettings.dimmableStates, leds.size() - 1);
+				const uint8_t cursorSub = cursorValue % gLedSettings.dimmableStates;
+				leds[Led_Address(cursorLed)] = (cursorSub > 0) ? Led_DimColor(CRGB::Blue, cursorSub) : CRGB::Blue;
 			}
 		}
 		animationDelay = 10;

--- a/src/RotaryEncoder.cpp
+++ b/src/RotaryEncoder.cpp
@@ -52,8 +52,18 @@ void RotaryEncoder_Init(void) {
 // Handles volume directed by rotary encoder
 void RotaryEncoder_Cyclic(void) {
 #ifdef USEROTARY_ENABLE
+	// Tracks whether the currently-held modifier (if any) was resolved to CMD_SEEK_PREVIEW, i.e. whether
+	// this hold-gesture is a seek-preview session rather than the generic per-detent-command dispatch below.
+	static bool previewGestureActive = false;
+	static uint8_t lastModifier = BUTTON_NONE;
+
 	#ifdef INCLUDE_ROTARY_IN_CONTROLS_LOCK
 	if (System_AreControlsLocked()) {
+		if (previewGestureActive) {
+			AudioPlayer_SeekPreviewCommit(); // don't leave a preview hanging if controls get locked mid-gesture
+			previewGestureActive = false;
+			lastModifier = BUTTON_NONE;
+		}
 		encoder.clearCount();
 		return;
 	}
@@ -64,11 +74,26 @@ void RotaryEncoder_Cyclic(void) {
 	// half-step that has not completed a detent yet -- so discard whatever has accumulated whenever the
 	// modifier changes, otherwise a gesture inherits rotation from before the button went down (and the
 	// volume inherits rotation from during the gesture).
-	static uint8_t lastModifier = BUTTON_NONE;
 	const uint8_t modifier = Button_GetHeldModifier();
 	if (modifier != lastModifier) {
+		if (previewGestureActive) {
+			// Release (or switch to a different modifier) commits immediately -- don't make the user wait
+			// out the idle-delay just because they let go of the button.
+			AudioPlayer_SeekPreviewCommit();
+			previewGestureActive = false;
+		}
 		lastModifier = modifier;
 		encoder.clearCount();
+		if (modifier != BUTTON_NONE) {
+			// Either direction mapping to CMD_SEEK_PREVIEW makes the whole hold a preview session -- a
+			// preview is inherently bidirectional, so a button with only one direction assigned to it
+			// still previews both ways (the other direction falls back from volume to preview too, since
+			// there is no other sensible meaning for "turn while holding this preview-mapped button").
+			previewGestureActive = (Button_GetRotaryAction(modifier, true) == CMD_SEEK_PREVIEW) || (Button_GetRotaryAction(modifier, false) == CMD_SEEK_PREVIEW);
+			if (previewGestureActive) {
+				AudioPlayer_SeekPreviewStart();
+			}
+		}
 		return;
 	}
 
@@ -82,6 +107,13 @@ void RotaryEncoder_Cyclic(void) {
 		const int32_t detents = encoderValue / 2;
 
 		if (modifier != BUTTON_NONE) {
+			if (previewGestureActive) {
+				// Swallow the held button's own short/long action, same as the generic gesture path below.
+				Button_MarkModifierUsed(modifier);
+				AudioPlayer_SeekPreviewAdjust(detents);
+				return;
+			}
+
 			const uint8_t cmd = Button_GetRotaryAction(modifier, detents > 0);
 			if (cmd != CMD_NOTHING) {
 				// Tell Button.cpp to swallow this button's own short/long action -- otherwise letting go fires

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -903,6 +903,14 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 			Log_Printf(LOGLEVEL_ERROR, webSaveSettingsError, "rotary");
 			return WebsocketCodeType::Error;
 		}
+		// CMD_SEEK_PREVIEW tuning: guarded (not hard-erroring like "reverse" above) so an older cached
+		// web-UI page that doesn't send these yet can't blank an already-saved value.
+		if (doc["rotary"]["seekPrevDelay"].is<uint16_t>()) {
+			gPrefsSettings.putUShort("seekPrevDelay", doc["rotary"]["seekPrevDelay"].as<uint16_t>());
+		}
+		if (doc["rotary"]["seekPrevSweep"].is<uint8_t>()) {
+			gPrefsSettings.putUChar("seekPrevSweep", doc["rotary"]["seekPrevSweep"].as<uint8_t>());
+		}
 		RotaryEncoder_Init();
 	}
 	if (doc["battery"].is<JsonObject>()) {
@@ -1250,6 +1258,8 @@ static void settingsToJSON(JsonObject obj, const String section) {
 		// Rotary encoder
 		JsonObject rotaryObj = obj["rotary"].to<JsonObject>();
 		rotaryObj["reverse"].set(gPrefsSettings.getBool("rotaryReverse", false));
+		rotaryObj["seekPrevDelay"].set(gPrefsSettings.getUShort("seekPrevDelay", 2000)); // ms idle before a CMD_SEEK_PREVIEW gesture auto-commits
+		rotaryObj["seekPrevSweep"].set(gPrefsSettings.getUChar("seekPrevSweep", 40)); // encoder detents for a full 0->100% sweep
 	}
 	// playlist
 	if ((section == "") || (section == "playlist")) {
@@ -1368,6 +1378,8 @@ static void settingsToJSON(JsonObject obj, const String section) {
 #ifdef USEROTARY_ENABLE
 		JsonObject rotarySettings = defaultsObj["rotary"].to<JsonObject>();
 		rotarySettings["reverse"].set(false); // REVERSE_ROTARY
+		rotarySettings["seekPrevDelay"].set(2000);
+		rotarySettings["seekPrevSweep"].set(40);
 #endif
 		JsonObject playlistSettings = defaultsObj["playlist"].to<JsonObject>();
 		playlistSettings["sortMode"].set(EnumUtils::underlying_value(AUDIOPLAYER_PLAYLIST_SORT_MODE_DEFAULT));

--- a/src/values.h
+++ b/src/values.h
@@ -77,6 +77,7 @@
 #define CMD_RESTARTSYSTEM  183 // Command: restart System
 #define CMD_NEXTFOLDER	   184 // Command: jump forwards to next folder (only applicable for recursive playmodes)
 #define CMD_PREVFOLDER	   185 // Command: jump forwards to previous folder (only applicable for recursive playmodes)
+#define CMD_SEEK_PREVIEW   186 // Command: rotary-gesture-only. Turning previews a target position (LED cursor); commits on release/idle instead of jumping immediately
 
 #define CMD_VIRTUAL_RFID_CARD_01 241 // Command: Virtual RFID-Card 900000000001
 #define CMD_VIRTUAL_RFID_CARD_02 242 // Command: Virtual RFID-Card 900000000002


### PR DESCRIPTION
"Hold button + turn encoder" now offers a second seek behavior alongside the existing immediate-jump CMD_SEEK_FORWARDS/BACKWARDS: turning previews a target position (yellow ring + blue LED cursor) instead of jumping right away, committing once the encoder is idle for a configurable delay or immediately on release. Selectable independently per button/direction via the existing rotary-gesture dropdowns - no separate global toggle.

Two new NVS-backed settings (seekPrevDelay ms, seekPrevSweep detents for a full 0-100% sweep) are wired into the Web-UI, unlike the older rotSeekStep setting which never got a UI or factory-defaults entry.