### PR TITLE
Fix: Run timer and expander ISRs in IRAM on Arduino-ESP32 v3

### DIFF
--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -52,17 +52,13 @@ uint8_t gShutdownButton = 99; // Helper used for Neopixel: stores button-number 
 uint16_t gLongPressTime = 0;
 
 #ifdef PORT_EXPANDER_ENABLE
-extern bool Port_AllowReadFromPortExpander;
+extern volatile bool Port_AllowReadFromPortExpander;
 #endif
 
 static std::atomic<SemaphoreHandle_t> Button_TimerSemaphore;
 
 hw_timer_t *Button_Timer = NULL;
-#if (defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR < 3))
 static void IRAM_ATTR onTimer();
-#else
-static void onTimer();
-#endif
 static void Button_DoButtonActions(void);
 
 void Button_Init() {
@@ -451,10 +447,6 @@ void Button_DoButtonActions(void) {
 	}
 }
 
-#if (defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR < 3))
 void IRAM_ATTR onTimer() {
-#else
-void onTimer() {
-#endif
 	xSemaphoreGiveFromISR(Button_TimerSemaphore, NULL);
 }

--- a/src/Port.cpp
+++ b/src/Port.cpp
@@ -29,7 +29,7 @@ void Port_Test(void);
 	#if (PE_INTERRUPT_PIN >= 0 && PE_INTERRUPT_PIN <= MAX_GPIO)
 		#define PE_INTERRUPT_PIN_ENABLE
 void IRAM_ATTR PORT_ExpanderISR(void);
-bool Port_AllowReadFromPortExpander = false;
+volatile bool Port_AllowReadFromPortExpander = false;
 	#endif
 #endif
 
@@ -399,11 +399,7 @@ void Port_Test(void) {
 }
 
 	#ifdef PE_INTERRUPT_PIN_ENABLE
-		#if (defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR < 3))
 void IRAM_ATTR PORT_ExpanderISR(void) {
-		#else
-void PORT_ExpanderISR(void) {
-		#endif
 	// check if the interrupt pin is actually low and only if it is
 	// trigger the handler (there are a lot of false calls to this ISR
 	// where the interrupt pin isn't low...)


### PR DESCRIPTION
Both onTimer (100 Hz timer) and PORT_ExpanderISR (GPIO interrupt attached via attachInterrupt) were compiled without IRAM_ATTR on Arduino-ESP32 v3 via a version-conditional. If either ISR fires while the flash cache is disabled (e.g. during an NVS/flash write) it would execute from flash and crash; PORT_ExpanderISR is the higher risk since it can fire at any time. Place both unconditionally in IRAM and simplify onTimer's forward declaration to match.

Port_AllowReadFromPortExpander is written in PORT_ExpanderISR and read in the main task, so mark it volatile; align the (unused) extern in Button.cpp with the new type.