### PR TITLE
Fix: NUL-termination when copying track path from NVS

### DIFF
--- a/src/RfidCommon.cpp
+++ b/src/RfidCommon.cpp
@@ -50,7 +50,8 @@ void Rfid_PreferenceLookupHandler(void) {
 		token = strtok((char *) s.c_str(), stringDelimiter);
 		while (token != NULL) { // Try to extract data from string after lookup
 			if (i == 1) {
-				strncpy(_file, token, sizeof(_file) / sizeof(_file[0]));
+				strncpy(_file, token, sizeof(_file) - 1);
+				_file[sizeof(_file) - 1] = '\0';
 			} else if (i == 2) {
 				_lastPlayPos = strtoul(token, NULL, 10);
 			} else if (i == 3) {


### PR DESCRIPTION
`_file` (char[255]) was copied using `strncpy(_file, token, sizeof(_file) / sizeof(_file[0]))`, which resolves to 255 = the full buffer size. strncpy does not NUL-terminate the destination when the source is at least as long as the given length, so a track path of ≥255 chars read from NVS left `_file` unterminated, risking an out-of-bounds read when passed to AudioPlayer_SetPlaylist().

Related to PR #223.

The same unsafe pattern still exists at AudioPlayer.cpp:784 for gPlayProperties.playRfidTag. Lower risk there since the source is a fixed-length RFID tag ID rather than a user-supplied path/URL.