### PR TITLE
Web-UI: report settings that block saving instead of failing silently

### DIFF
--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -19,7 +19,8 @@
 		"success": "Aktion erfolgreich ausgeführt.",
 		"dropout": "Langsamer Stream, Aussetzer möglich.",
 		"saved": "Einstellungen gespeichert.",
-		"ledCountRestart": "Die Anzahl der LEDs wurde geändert. Der ESPuino startet neu, um das zu übernehmen."
+		"ledCountRestart": "Die Anzahl der LEDs wurde geändert. Der ESPuino startet neu, um das zu übernehmen.",
+		"settingsInvalid": "Speichern nicht möglich: Bitte zuerst diese Einstellungen korrigieren ({{fields}})."
 	},
 	"status": {
 		"connected": "Verbindung zum ESPuino: OK",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -19,7 +19,8 @@
 		"success": "Action performed successfully.",
 		"dropout": "slow stream, dropouts are possible.",
 		"saved": "Settings saved.",
-		"ledCountRestart": "The number of LEDs was changed. ESPuino will restart to apply it."
+		"ledCountRestart": "The number of LEDs was changed. ESPuino will restart to apply it.",
+		"settingsInvalid": "Cannot save: please correct these settings first ({{fields}})."
 	},
 	"status": {
 		"connected": "Connection to ESPuino: OK",

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -19,7 +19,8 @@
 		"success": "Action effectuée avec succès.",
 		"dropout": "flux lent, des interruptions sont possibles.",
 		"saved": "Paramètres enregistrés.",
-		"ledCountRestart": "Le nombre de LEDs a été modifié. L'ESPuino va redémarrer pour appliquer ce changement."
+		"ledCountRestart": "Le nombre de LEDs a été modifié. L'ESPuino va redémarrer pour appliquer ce changement.",
+		"settingsInvalid": "Enregistrement impossible : veuillez d'abord corriger ces réglages ({{fields}})."
 	},
 	"status": {
 		"connected": "Connexion à l'ESPuino : OK",

--- a/html/management.html
+++ b/html/management.html
@@ -1892,7 +1892,7 @@
 						</div>
 						<div class="tab-pane fade" id="general-led" role="tabpanel">
 					<div class="col-md-12 mb-4" id="neopixelConfig" data-visible="false">
-						<fieldset>
+						<fieldset disabled>
 							<legend class="w-auto" data-i18n="general.neopixel.title"></legend>
 							<div class="settings-group-card">
 							<div class="row mb-2 align-items-center">
@@ -2169,7 +2169,7 @@
 						</fieldset>
 					</div>
 					<div class="col-md-12 mb-4" id="batteryConfig" data-visible="false">
-						<fieldset>
+						<fieldset disabled>
 							<legend data-i18n="general.battery.title">Batterie</legend>
 							<div class="settings-group-card">
 							<div class="row mb-2 align-items-center">
@@ -2278,7 +2278,7 @@
 									data-i18n="[data-bs-content]general.battery.shutdownOnCriticalExp" tabindex="0"><i
 										class="fas fa-circle-question"></i></a>
 							</div>
-							<div id="criticalVoltageSection" class="row mb-2 align-items-center" data-visible="false">
+							<fieldset id="criticalVoltageSection" class="row mb-2 align-items-center" data-visible="false" disabled>
 								<div class="col-sm-4 d-flex align-items-center gap-2">
 									<label for="criticalVoltage" class="col-form-label"
 										data-i18n="general.battery.criticalShutoff"></label>
@@ -2302,7 +2302,7 @@
 										</div>
 									</div>
 								</div>
-							</div>
+							</fieldset>
 							</div>
 						</fieldset>
 					</div>
@@ -2535,7 +2535,8 @@
 		   instead: name the offending settings, then open the tab holding the first one so
 		   it can actually be seen and corrected. */
 		function validateSettingsForm(form) {
-			const invalid = Array.from(form.querySelectorAll(':invalid'));
+			const invalid = Array.from(form.elements)
+				.filter((control) => control.willValidate && !control.validity.valid);
 			if (invalid.length === 0) {
 				return true;
 			}
@@ -2567,6 +2568,14 @@
 				invalid[0].reportValidity();
 			}, 250);
 			return false;
+		}
+
+		function setSettingsSectionActive(section, active) {
+			section.setAttribute('data-visible', active);
+			const fieldset = section.matches('fieldset') ? section : section.querySelector('fieldset');
+			if (fieldset) {
+				fieldset.disabled = !active;
+			}
 		}
 
 		i18next.use(i18nextHttpBackend).init({
@@ -3913,7 +3922,7 @@
 			// led
 			let ledSettings = settings.led;
 			if (ledSettings) {
-				document.getElementById('neopixelConfig').setAttribute('data-visible', true);
+				setSettingsSectionActive(document.getElementById('neopixelConfig'), true);
 				$('#initBrightness').bootstrapSlider('setValue', ledSettings.initBrightness);
 				$('#nightBrightness').bootstrapSlider('setValue', ledSettings.nightBrightness);
 				$('#atmoBrightness').bootstrapSlider('setValue', ledSettings.atmoBrightness);
@@ -3993,12 +4002,12 @@
 			// battery
 			let batSettings = settings.battery;
 			if (batSettings) {
-				document.getElementById('batteryConfig').setAttribute('data-visible', true);
+				setSettingsSectionActive(document.getElementById('batteryConfig'), true);
 				$('#warningLowVoltage').bootstrapSlider('setValue', batSettings.warnLowVoltage);
 				$('#voltageIndicatorLow').bootstrapSlider('setValue', batSettings.indicatorLow);
 				$('#voltageIndicatorHigh').bootstrapSlider('setValue', batSettings.indicatorHi);
 				$('#shutdownOnCritical').prop('checked', batSettings.shutdownOnCritical);
-				document.getElementById('criticalVoltageSection').setAttribute('data-visible', batSettings.shutdownOnCritical);
+				setSettingsSectionActive(document.getElementById('criticalVoltageSection'), batSettings.shutdownOnCritical);
 				$('#criticalVoltage').bootstrapSlider('setValue', batSettings.criticalVoltage);
 				$('#voltageCheckInterval').bootstrapSlider('setValue', batSettings.voltageCheckInterval);
 			}
@@ -5065,7 +5074,7 @@
 			   bootstrap-slider mismeasures its width while display:none, so relayout it now that it's visible. */
 			$('#shutdownOnCritical').on('change', function () {
 				const checked = $(this).prop('checked');
-				document.getElementById('criticalVoltageSection').setAttribute('data-visible', checked);
+				setSettingsSectionActive(document.getElementById('criticalVoltageSection'), checked);
 				if (checked) {
 					$('#criticalVoltage').bootstrapSlider('relayout');
 				}

--- a/html/management.html
+++ b/html/management.html
@@ -1315,7 +1315,8 @@
 			<div class="tab-pane main-tab-pane fade mb-4" id="nav-general" role="tabpanel"
 				aria-labelledby="nav-general-tab">
 				<div class="container" id="generalConfig">
-					<form action="#generalConfig" method="POST" onsubmit="genSettings('generalConfig'); return false">
+					<form action="#generalConfig" method="POST" novalidate
+						onsubmit="if (validateSettingsForm(this)) { genSettings('generalConfig'); } return false">
 					<div class="nav nav-tabs" id="GeneralSubTab" role="tablist">
 						<a class="nav-item nav-link active" id="general-playback-tab" data-bs-toggle="tab"
 							href="#general-playback" role="tab"><i class="fas fa-volume-up"></i><span
@@ -2525,6 +2526,48 @@
 			error: msg => toaster.toast(msg, 'text-bg-danger')
 		}
 
+
+		/* The settings form spans several tab-panes, and a browser refuses to report a
+		   validation error on a control it cannot focus -- which includes everything in a
+		   hidden pane. Native validation therefore blocks the submit *silently*: the Save
+		   button looks dead and the only clue is "An invalid form control ... is not
+		   focusable" in the console. So the form carries `novalidate` and we check it here
+		   instead: name the offending settings, then open the tab holding the first one so
+		   it can actually be seen and corrected. */
+		function validateSettingsForm(form) {
+			const invalid = Array.from(form.querySelectorAll(':invalid'));
+			if (invalid.length === 0) {
+				return true;
+			}
+
+			const describe = (el) => {
+				const label = el.id ? form.querySelector('label[for="' + CSS.escape(el.id) + '"]') : null;
+				const text = label ? label.textContent.trim() : '';
+				return text || el.name || el.id;
+			};
+			const fields = invalid.map(describe).filter((name, i, all) => name && all.indexOf(name) === i);
+
+			/* Reveal the first offender: show every tab-pane ancestor, outermost first, so
+			   both the main tab and its sub-tab end up active. */
+			const panes = [];
+			for (let pane = invalid[0].closest('.tab-pane'); pane; pane = pane.parentElement ? pane.parentElement.closest('.tab-pane') : null) {
+				panes.unshift(pane);
+			}
+			panes.forEach((pane) => {
+				const link = document.querySelector('[href="#' + pane.id + '"], [data-bs-target="#' + pane.id + '"]');
+				if (link) {
+					bootstrap.Tab.getOrCreateInstance(link).show();
+				}
+			});
+
+			toaster.error(i18next.t("toast.settingsInvalid", { fields: fields.join(', ') }));
+			/* after the tab transition, so the control is visible and focusable */
+			setTimeout(() => {
+				invalid[0].focus();
+				invalid[0].reportValidity();
+			}, 250);
+			return false;
+		}
 
 		i18next.use(i18nextHttpBackend).init({
 			backend: {

--- a/test/webpage/package.json
+++ b/test/webpage/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test validation.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/test/webpage/validation.test.js
+++ b/test/webpage/validation.test.js
@@ -1,0 +1,186 @@
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const { readFile } = require("node:fs/promises");
+const http = require("node:http");
+const path = require("node:path");
+const test = require("node:test");
+
+const htmlRoot = path.resolve(__dirname, "../../html");
+const mimeTypes = {
+  ".css": "text/css",
+  ".gif": "image/gif",
+  ".html": "text/html",
+  ".ico": "image/x-icon",
+  ".js": "text/javascript",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".woff2": "font/woff2",
+};
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+  });
+}
+
+async function waitForDevTools(chrome) {
+  return new Promise((resolve, reject) => {
+    let stderr = "";
+    const timeout = setTimeout(() => reject(new Error(`Chrome did not start:\n${stderr}`)), 10000);
+
+    chrome.stderr.setEncoding("utf8");
+    chrome.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      const match = stderr.match(/DevTools listening on (ws:\/\/\S+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve(match[1]);
+      }
+    });
+    chrome.once("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`Chrome exited before DevTools was ready (${code}):\n${stderr}`));
+    });
+  });
+}
+
+async function waitForPageDevTools(browserUrl) {
+  const { hostname, port } = new URL(browserUrl);
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const targets = await fetch(`http://${hostname}:${port}/json/list`).then((response) => response.json());
+    const page = targets.find((target) => target.type === "page" && target.url.includes("management.html"));
+    if (page) return page.webSocketDebuggerUrl;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("Chrome did not expose the management page target");
+}
+
+function connectDevTools(url) {
+  const socket = new WebSocket(url);
+  const pending = new Map();
+  let nextId = 0;
+
+  const opened = new Promise((resolve, reject) => {
+    socket.addEventListener("open", resolve, { once: true });
+    socket.addEventListener("error", reject, { once: true });
+  });
+  socket.addEventListener("message", ({ data }) => {
+    const message = JSON.parse(data);
+    if (!message.id || !pending.has(message.id)) return;
+    const { resolve, reject } = pending.get(message.id);
+    pending.delete(message.id);
+    if (message.error) reject(new Error(message.error.message));
+    else resolve(message.result);
+  });
+
+  return {
+    async send(method, params = {}) {
+      await opened;
+      const id = ++nextId;
+      const response = new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+      socket.send(JSON.stringify({ id, method, params }));
+      return response;
+    },
+    close() {
+      socket.close();
+    },
+  };
+}
+
+async function evaluate(client, expression) {
+  const { result, exceptionDetails } = await client.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (exceptionDetails) throw new Error(exceptionDetails.text);
+  return result.value;
+}
+
+test("settings validation reveals hidden tabs and ignores inactive sections", async (t) => {
+  const server = http.createServer(async (request, response) => {
+    try {
+      const pathname = new URL(request.url, "http://localhost").pathname;
+      const relativePath = pathname === "/" ? "management.html" : pathname.slice(1);
+      const filePath = path.resolve(htmlRoot, relativePath);
+      if (!filePath.startsWith(`${htmlRoot}${path.sep}`)) throw new Error("Invalid path");
+      const content = await readFile(filePath);
+      response.writeHead(200, { "Content-Type": mimeTypes[path.extname(filePath)] || "application/octet-stream" });
+      response.end(content);
+    } catch {
+      response.writeHead(404);
+      response.end();
+    }
+  });
+  const port = await listen(server);
+  t.after(() => server.close());
+
+  const chrome = spawn("google-chrome", [
+    "--headless=new",
+    "--no-sandbox",
+    "--disable-gpu",
+    "--remote-debugging-port=0",
+    `http://127.0.0.1:${port}/management.html`,
+  ], { stdio: ["ignore", "ignore", "pipe"] });
+  t.after(() => chrome.kill("SIGKILL"));
+
+  const client = connectDevTools(await waitForPageDevTools(await waitForDevTools(chrome)));
+  t.after(() => client.close());
+  await client.send("Runtime.enable");
+
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (await evaluate(client, "typeof validateSettingsForm === 'function'")) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  const result = await evaluate(client, `(async () => {
+    const form = document.querySelector('#generalConfig form');
+    Array.from(form.elements).forEach((control) => {
+      if (control.willValidate) control.disabled = true;
+    });
+
+    const testControl = document.createElement('input');
+    testControl.id = 'validationTestControl';
+    testControl.name = 'validationTestControl';
+    testControl.required = true;
+    document.getElementById('general-power').append(testControl);
+    const fieldset = document.createElement('fieldset');
+    testControl.replaceWith(fieldset);
+    fieldset.append(testControl);
+    const fieldsetMatchedInvalid = fieldset.matches(':invalid');
+    const accepted = validateSettingsForm(form);
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    const tabResult = {
+      accepted,
+      fieldsetMatchedInvalid,
+      focusedId: document.activeElement.id,
+      powerTabActive: document.getElementById('general-power').classList.contains('active'),
+      mainTabActive: document.getElementById('nav-general').classList.contains('active'),
+    };
+
+    const battery = document.getElementById('batteryConfig');
+    const criticalSection = document.getElementById('criticalVoltageSection');
+    const criticalVoltage = document.getElementById('criticalVoltage');
+    const initiallyExcluded = !criticalVoltage.willValidate;
+    setSettingsSectionActive(battery, true);
+    const excludedWhileFeatureOff = !criticalVoltage.willValidate;
+    setSettingsSectionActive(criticalSection, true);
+    const includedWhenFeatureOn = criticalVoltage.willValidate;
+
+    return { tabResult, initiallyExcluded, excludedWhileFeatureOff, includedWhenFeatureOn };
+  })()`);
+
+  assert.deepEqual(result.tabResult, {
+    accepted: false,
+    fieldsetMatchedInvalid: true,
+    focusedId: "validationTestControl",
+    powerTabActive: true,
+    mainTabActive: true,
+  });
+  assert.equal(result.initiallyExcluded, true);
+  assert.equal(result.excludedWhileFeatureOff, true);
+  assert.equal(result.includedWhenFeatureOn, true);
+});


### PR DESCRIPTION
The general settings form spans several tab-panes, and a browser will not report a validation error on a control it cannot focus -- which includes anything in a hidden pane. Native validation therefore blocked the submit silently: Save did nothing, no message appeared, and the only clue was "An invalid form control with name='...' is not focusable" in the browser console. A single out-of-range value on a tab the user was not looking at made the whole settings page unsaveable with no way to find out why.

The form now carries novalidate and is checked in JS on submit: the offending settings are named in an error toast, and the tab holding the first one is opened (main tab and sub-tab both) so it can be seen, focused and corrected.

This affected me after upgrading firmware, and having some values not set.

<img width="526" height="196" alt="image" src="https://github.com/user-attachments/assets/bc651d39-798b-4f7e-a9cd-7a0751645c61" />

