### PR TITLE
Web-UI: fix mobile form layout

### DIFF
--- a/html/management.html
+++ b/html/management.html
@@ -122,6 +122,78 @@
 			padding: 1rem 1.25rem;
 		}
 
+		/* File upload controls must be allowed to shrink inside flex layouts.
+		   On phones, stack file selector and submit button so they never overflow the card. */
+		.file-upload-row {
+			display: flex;
+			gap: 0.5rem;
+			min-width: 0;
+		}
+
+		.file-upload-row > input[type="file"] {
+			flex: 1 1 0;
+			min-width: 0;
+			max-width: 100%;
+		}
+
+		.file-upload-row > button {
+			flex: 0 0 auto;
+		}
+
+		@media (max-width: 575.98px) {
+			.file-upload-row {
+				flex-direction: column;
+			}
+
+			.file-upload-row > input[type="file"],
+			.file-upload-row > button {
+				width: 100%;
+			}
+
+			/* Keep the long auto-save description readable on phones.
+			   The interval control moves to a second row instead of forcing
+			   label, number, unit and help icon into one over-wide flex row. */
+			.save-play-pos-interval-row {
+				display: grid !important;
+				grid-template-columns: auto auto auto minmax(0, 1fr);
+				align-items: center;
+				column-gap: 0.5rem;
+				row-gap: 0.35rem;
+				min-width: 0;
+			}
+
+			.save-play-pos-interval-row > #savePlayPosIntervalEnabled {
+				grid-column: 1;
+				grid-row: 1;
+				align-self: start;
+				margin-top: 0.3rem;
+			}
+
+			.save-play-pos-interval-row > label[for="savePlayPosIntervalEnabled"] {
+				grid-column: 2 / -1;
+				grid-row: 1;
+				min-width: 0;
+			}
+
+			.save-play-pos-interval-row > #savePlayPosInterval {
+				grid-column: 2;
+				grid-row: 2;
+				width: 4.25em !important;
+				max-width: 4.25em;
+			}
+
+			.save-play-pos-interval-row > label[for="savePlayPosInterval"] {
+				grid-column: 3;
+				grid-row: 2;
+			}
+
+			.save-play-pos-interval-row > a {
+				grid-column: 4;
+				grid-row: 2;
+				justify-self: start;
+			}
+		}
+
 		.slider-step-row > .slider-container,
 		.slider-step-row > .hue-slider,
 		.slider-step-row > .sat-slider {
@@ -1458,7 +1530,7 @@
 									data-i18n="[data-bs-content]general.options.savePlayPosRfidChangeExp"
 									tabindex="0"><i class="fas fa-circle-question"></i></a>
 							</div>
-							<div class="d-flex gap-2 align-items-center">
+							<div class="d-flex gap-2 align-items-center save-play-pos-interval-row">
 								<input type="checkbox" id="savePlayPosIntervalEnabled"
 									name="savePlayPosIntervalEnabled" value="false">
 								<label for="savePlayPosIntervalEnabled"
@@ -2345,7 +2417,7 @@
 							onsubmit="uploadNVSRFID('nvsUpload'); return false">
 							<div class="mb-3">
 								<label for="nvsUpload" data-i18n="tools.nvs.import.desc"></label><br><br>
-								<div class="d-flex gap-2">
+								<div class="file-upload-row">
 									<input type="file" class="form-control-file btn btn-primary" id="nvsUpload"
 										name="nvsUpload" accept=".txt">
 									<button type="submit" class="btn btn-primary" data-i18n="tools.nvs.import.button"></button>
@@ -2374,7 +2446,7 @@
 				<form id="firmwareUploadForm" method="POST" enctype="multipart/form-data" action="/update">
 					<div class="mb-3">
 						<label for="firmwareUpload" data-i18n="tools.fwupdate.desc"></label><br><br>
-						<div class="d-flex gap-2">
+						<div class="file-upload-row">
 							<input type="file" class="form-control-file btn btn-primary" id="firmwareUpload"
 								name="firmwareUpload" accept=".bin">
 							<button type="submit" class="btn btn-primary" data-i18n="tools.fwupdate.button"></button>


### PR DESCRIPTION
## Summary

Fixes layout issues in the management web UI on narrow/mobile screens.

Some form controls were wider than the available viewport, causing horizontal
overflow on mobile devices.

## Changes

- stack file selector and submit button on small screens for RFID/NVS backup import
- apply the same responsive layout to firmware upload
- allow file inputs to shrink correctly inside flex containers
- move the audiobook auto-save interval control to a second row on small screens
- keep the interval input compact on mobile while retaining the existing desktop layout
- improve the display of the RFID assignment list on mobile browsers

## Testing

Tested on Android with Chrome and Firefox, and on a desktop browser.

Verified:
- RFID/NVS backup import no longer overflows horizontally
- firmware upload no longer overflows horizontally
- audiobook auto-save interval is displayed correctly on narrow screens
- RFID assignment list is now displayed correctly on Android
- desktop layout remains unchanged

## Known limitation

On Firefox for Android, the RFID assignment dialog/list itself is now displayed
correctly, but the `OK` button may still be difficult to reach in portrait mode.
It can be reached by switching the device to landscape mode.

This appears to be specific to Firefox on Android rather than an issue with the
responsive layout changes in this PR.

## Pictures 

**before** 
<img width="709" height="1536" alt="image" src="https://github.com/user-attachments/assets/84b886ab-e8e4-4de8-9492-eebaf9461faa" />
<img width="709" height="1536" alt="image" src="https://github.com/user-attachments/assets/df5f7701-11c9-4f54-8f43-4539621f674c" />

**after**
<img width="709" height="1536" alt="image" src="https://github.com/user-attachments/assets/8842179f-f9ab-43d1-be5a-cedebfab5ae1" />
<img width="709" height="1536" alt="image" src="https://github.com/user-attachments/assets/5b2cb5d0-ac9e-4531-b897-87b65531c491" />
<img width="709" height="1536" alt="image" src="https://github.com/user-attachments/assets/e073b333-ba20-40f0-b43f-079cfb6e18f7" />




