### PR TITLE
Apply max volume settings without restart

### DIFF
--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -621,6 +621,22 @@ void AudioPlayer_SetMaxVolumeSpeaker(uint8_t value) {
 	AudioPlayer_MaxVolumeSpeaker = value;
 }
 
+void AudioPlayer_ApplyMaxVolumes(uint8_t speaker, uint8_t headphone) {
+	AudioPlayer_MaxVolumeSpeaker = speaker;
+
+#ifdef HEADPHONE_ADJUST_ENABLE
+	AudioPlayer_MaxVolumeHeadphone = headphone;
+	AudioPlayer_MaxVolume = AudioPlayer_IsHeadphoneModeActive() ? AudioPlayer_MaxVolumeHeadphone : AudioPlayer_MaxVolumeSpeaker;
+#else
+	(void) headphone;
+	AudioPlayer_MaxVolume = AudioPlayer_MaxVolumeSpeaker;
+#endif
+
+	if (AudioPlayer_CurrentVolume > AudioPlayer_MaxVolume) {
+		AudioPlayer_SetVolume(AudioPlayer_MaxVolume);
+	}
+}
+
 uint8_t AudioPlayer_GetMinVolume(void) {
 	return AudioPlayer_MinVolume;
 }

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -97,6 +97,7 @@ uint8_t AudioPlayer_GetMaxVolume(void);
 void AudioPlayer_SetMaxVolume(uint8_t value);
 uint8_t AudioPlayer_GetMaxVolumeSpeaker(void);
 void AudioPlayer_SetMaxVolumeSpeaker(uint8_t value);
+void AudioPlayer_ApplyMaxVolumes(uint8_t speaker, uint8_t headphone);
 uint8_t AudioPlayer_GetMinVolume(void);
 void AudioPlayer_SetMinVolume(uint8_t value);
 uint8_t AudioPlayer_GetInitVolume(void);

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -746,14 +746,16 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 		// so reject it before writing anything. The HTML input already constrains this, but a direct
 		// REST/websocket POST could bypass that.
 		const uint8_t minVolume = generalObj["minVolume"].as<uint8_t>();
-		if (minVolume >= generalObj["maxVolumeSp"].as<uint8_t>() || minVolume >= generalObj["maxVolumeHp"].as<uint8_t>()) {
+		const uint8_t maxVolumeSp = generalObj["maxVolumeSp"].as<uint8_t>();
+		const uint8_t maxVolumeHp = generalObj["maxVolumeHp"].as<uint8_t>();
+		if (minVolume >= maxVolumeSp || minVolume >= maxVolumeHp) {
 			Log_Println(webSaveSettingsVolumeMinMaxError, LOGLEVEL_ERROR);
 			return WebsocketCodeType::Error;
 		}
 		bool success = (gPrefsSettings.putUInt("initVolume", generalObj["initVolume"].as<uint8_t>()) != 0);
 		success = success && (gPrefsSettings.putUInt("minVolume", minVolume) != 0);
-		success = success && (gPrefsSettings.putUInt("maxVolumeSp", generalObj["maxVolumeSp"].as<uint8_t>()) != 0);
-		success = success && (gPrefsSettings.putUInt("maxVolumeHp", generalObj["maxVolumeHp"].as<uint8_t>()) != 0);
+		success = success && (gPrefsSettings.putUInt("maxVolumeSp", maxVolumeSp) != 0);
+		success = success && (gPrefsSettings.putUInt("maxVolumeHp", maxVolumeHp) != 0);
 		success = success && (gPrefsSettings.putUInt("mInactiviyT", generalObj["sleepInactivity"].as<uint8_t>()) != 0);
 		if (generalObj["rotSeekStep"].is<uint8_t>()) {
 			success = success && (gPrefsSettings.putUChar("rotSeekStep", generalObj["rotSeekStep"].as<uint8_t>()) != 0);
@@ -783,6 +785,10 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 			Log_Printf(LOGLEVEL_ERROR, webSaveSettingsError, "general");
 			return WebsocketCodeType::Error;
 		}
+
+		// Apply the new maximum-volume limits immediately; no reboot is required.
+		AudioPlayer_ApplyMaxVolumes(maxVolumeSp, maxVolumeHp);
+
 		gPlayProperties.newPlayMono = generalObj["playMono"].as<bool>();
 		gPlayProperties.SavePlayPosRfidChange = generalObj["savePosRfidChge"].as<bool>();
 		gPlayProperties.pauseOnMinVolume = generalObj["pauseOnMinVol"].as<bool>();


### PR DESCRIPTION
This change applies the configured speaker and headphone maximum volume immediately after saving the settings.

### Why?

Yesterday I asked my little son to turn the music down.

That worked great — for about two minutes. 😄
Shortly afterwards, he was back at maximum volume.

So I decided to show him that I had the upper hand and reduced the maximum volume through the web interface.

Well... nothing happened.

The setting was saved correctly, but the new maximum volume only became effective after the next restart. At that point, my supposedly clever parental intervention wasn't quite as impressive anymore.

And that's why this PR exists. 🙂

### What changed?

Previously, changes to `maxVolumeSp` and `maxVolumeHp` were stored in NVS but only became active after a restart.

With this change, the runtime maximum volume is updated immediately after the settings have been successfully saved.

If the current volume exceeds the newly configured maximum, it is reduced immediately.

The existing speaker/headphone mode handling remains intact, and the change avoids re-running the amplifier setup.
