### PR TITLE
Led: use FastLED FLEX_IO for ESP32 and ESP32-S3

### DIFF
--- a/patchFastLedI2s.py
+++ b/patchFastLedI2s.py
@@ -1,0 +1,194 @@
+from pathlib import Path
+
+globals()["Import"]("env")
+env = globals()["env"]
+
+
+def replace_exact(path, old, new):
+    text = path.read_text(encoding="utf-8")
+    if new in text:
+        return
+    if text.count(old) != 1:
+        raise RuntimeError(
+            f"FastLED I2S patch no longer matches {path}; update the pinned patch before building"
+        )
+    path.write_text(text.replace(old, new), encoding="utf-8")
+
+
+fastled = Path(env.subst("$PROJECT_LIBDEPS_DIR")) / env.subst("$PIOENV") / "FastLED"
+engine = fastled / "src/platforms/esp/32/drivers/i2s/channel_engine_i2s_esp32dev.cpp.hpp"
+peripheral = fastled / "src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp"
+
+if not engine.is_file() or not peripheral.is_file():
+    raise RuntimeError(f"Pinned FastLED dependency is missing from {fastled}")
+
+replace_exact(
+    engine,
+    "namespace fl {\n\n",
+    "namespace fl {\n\n"
+    "// Keep the one-shot I2S FIFO fed with low samples throughout the WS2812\n"
+    "// reset interval.\n"
+    "constexpr size_t kWs2812ResetTailBytes =\n"
+    "    (TIMING_WS2812_800KHZ::RESET * 6400000ULL / 1000000ULL) * sizeof(u16);\n\n",
+)
+
+replace_exact(
+    engine,
+    """    // Size the scratch buffer: max per-lane byte count across all
+    // in-flight channels. Three regions (see packScratchBuffer):
+    //   [0, 2W)        — 32-bit DMA samples (4 bytes per pulse), the
+    //                    region actually handed to transmit()
+    //   [2W, 3W)       — raw wave8 pulse pairs (2 bytes per pulse)
+    //   [3W, 3W + 16b) — 16-lane-strided transpose input
+    // where W = wave8I2s1EncodedFrameSize(bytes_per_lane).
+""",
+    """    // Size the scratch buffer for the 16-bit parallel DMA stream plus reset
+    // preamble/tail and the lane-strided transpose input.
+""",
+)
+
+replace_exact(
+    engine,
+    """    const size_t wave8_size = wave8I2s1EncodedFrameSize(bytes_per_lane);
+    const size_t output_size = wave8I2s1Encoded32FrameSize(bytes_per_lane);
+    const size_t input_size = 16 * bytes_per_lane;
+    const size_t required = output_size + wave8_size + input_size;
+""",
+    """    const size_t wave8_size = wave8I2s1EncodedFrameSize(bytes_per_lane);
+    const size_t input_size = 16 * bytes_per_lane;
+    const size_t required = wave8_size + 2 * kWs2812ResetTailBytes + input_size;
+""",
+)
+
+replace_exact(
+    engine,
+    """    // Two stages (FastLED#3569 root-cause fix):
+    //   1. `encodeChannelWave8_i2s1` — shared 16-wide transpose kernel,
+    //      2 bytes per pulse period, written to the middle region.
+    //   2. `wave8I2s1ExpandTo32Samples` — rewrite each pulse pair into
+    //      one 32-bit sample with lanes at bits 8..23, because I2S1 in
+    //      `tx_bits_mod = 32` LCD mode clocks one u32 per pixel clock
+    //      and presents sample bit (n + 8) on DATA_OUT(n).
+""",
+    """    // The shared transpose kernel already produces one 16-bit parallel word
+    // per pulse period. Feed those words directly to I2S LCD mode.
+""",
+)
+
+replace_exact(
+    engine,
+    """    const size_t input_size = 16 * bytes_per_lane;
+    const size_t wave8_size = wave8I2s1EncodedFrameSize(bytes_per_lane);
+    const size_t output_size = wave8I2s1Encoded32FrameSize(bytes_per_lane);
+    if (mScratchSize < output_size + wave8_size + input_size) {
+        // Belt-and-suspenders: defense against a stale scratch buffer
+        // surviving a show() that used a much smaller frame.
+        return 0;
+    }
+    fl::u8* const output = mScratchBuffer;                             // 32-bit DMA samples
+    fl::u8* const wave8_tmp = mScratchBuffer + output_size;           // raw pulse pairs
+    fl::u8* const input = mScratchBuffer + output_size + wave8_size;  // lane-strided input
+""",
+    """    const size_t input_size = 16 * bytes_per_lane;
+    const size_t wave8_size = wave8I2s1EncodedFrameSize(bytes_per_lane);
+    if (mScratchSize < wave8_size + 2 * kWs2812ResetTailBytes + input_size) {
+        // Belt-and-suspenders: defense against a stale scratch buffer
+        // surviving a show() that used a much smaller frame.
+        return 0;
+    }
+    fl::u8* const output = mScratchBuffer + kWs2812ResetTailBytes;
+    fl::u8* const input = output + wave8_size + kWs2812ResetTailBytes;
+""",
+)
+
+replace_exact(
+    engine,
+    """    if (!encodeChannelWave8_i2s1(
+            fl::span<const fl::u8>(input, input_size),
+            bytes_per_lane, num_lanes, mWave8ByteLut,
+            fl::span<fl::u8>(wave8_tmp, wave8_size))) {
+        return 0;
+    }
+    if (!wave8I2s1ExpandTo32Samples(
+            fl::span<const fl::u8>(wave8_tmp, wave8_size),
+            fl::span<fl::u8>(output, output_size))) {
+        return 0;
+    }
+    return output_size;
+""",
+    """    if (!encodeChannelWave8_i2s1(
+            fl::span<const fl::u8>(input, input_size),
+            bytes_per_lane, num_lanes, mWave8ByteLut,
+            fl::span<fl::u8>(output, wave8_size))) {
+        return 0;
+    }
+
+    fl::memset(mScratchBuffer, 0, kWs2812ResetTailBytes);
+    fl::memset(output + wave8_size, 0, kWs2812ResetTailBytes);
+    return wave8_size + 2 * kWs2812ResetTailBytes;
+""",
+)
+
+replace_exact(
+    peripheral,
+    """    // Sample-rate configuration — `tx_bits_mod = 32` (Yves's proven
+    // value): one 32-bit sample per pixel clock, with DATA_OUT(n)
+    // presenting sample bit n+8. The engine feeds this format via
+    // `wave8I2s1ExpandTo32Samples()` (one u32 per pulse, lanes at bits
+    // 8..23) — see FastLED#3569 for the full mapping derivation.
+    i2s->sample_rate_conf.val = 0;
+    i2s->sample_rate_conf.tx_bits_mod = 32;
+""",
+    """    // One 16-bit parallel sample per pixel clock, matching FastLED's proven
+    // classic-ESP32 I2S-SPI peripheral configuration.
+    i2s->sample_rate_conf.val = 0;
+    i2s->sample_rate_conf.tx_bits_mod = 16;
+""",
+)
+
+replace_exact(
+    peripheral,
+    """    // FIFO in DMA-serviced mode — Yves baseline (32-bit single-channel)
+    // restored after `= 1` triggered spurious DMA interrupts.
+    i2s->fifo_conf.val = 0;
+    i2s->fifo_conf.tx_fifo_mod_force_en = 1;
+    i2s->fifo_conf.tx_fifo_mod = 3;
+""",
+    """    // 16-bit single-channel FIFO in DMA-serviced mode.
+    i2s->fifo_conf.val = 0;
+    i2s->fifo_conf.tx_fifo_mod_force_en = 1;
+    i2s->fifo_conf.tx_fifo_mod = 1;
+""",
+)
+
+replace_exact(
+    peripheral,
+    """    // I2S0 quirk (FastLED#3576 Phase 1 bench): in the same 32-bit mono
+    // LCD config, I2S0 presents the emitted half-word on DATA_OUT8..23
+    // (one byte higher than I2S1's DATA_OUT0..15) — lane n therefore
+    // routes signal OUT(8+n) on port 0 and OUT(n) on port 1.
+    const int base_signal = (i2s_device == 0)
+        ? static_cast<int>(I2S0O_DATA_OUT0_IDX) + 8
+        : static_cast<int>(I2S1O_DATA_OUT0_IDX);
+""",
+    """    // In 16-bit LCD mode the parallel sample appears on DATA_OUT8..23.
+    const int base_signal = ((i2s_device == 0)
+        ? static_cast<int>(I2S0O_DATA_OUT0_IDX)
+        : static_cast<int>(I2S1O_DATA_OUT0_IDX)) + 8;
+""",
+)
+
+replace_exact(
+    peripheral,
+    """    if (int_state & I2S_OUT_EOF_INT_ST_M) {
+        self->finishTransmitFromIsr();
+""",
+    """    if (int_state & I2S_OUT_EOF_INT_ST_M) {
+        // The reset-low tail has drained into the FIFO; stop before underrun
+        // can replay stale samples as another WS2812 frame.
+        i2s->conf.tx_start = 0;
+        self->finishTransmitFromIsr();
+""",
+)
+
+print("Applied classic ESP32 FastLED I2S 16-bit transport fix")

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,7 @@ monitor_filters = esp32_exception_decoder ; you can use ESP Decoder from VSC-Ext
 ;upload_speed = 115200
 extra_scripts =
     pre:install_dependencies.py
+    pre:patchFastLedI2s.py
     pre:gitVersion.py
     pre:platformInfo.py
     pre:updateSdkConfig.py
@@ -35,7 +36,7 @@ lib_deps =
 	https://github.com/Joe91/ESP32-audioI2S.git#3c2a6b804afcb796fdefc755570ac28f6198d5e5 ;v3.4.7h
 	https://github.com/madhephaestus/ESP32Encoder.git#7501cb47ec702c43de3c64df56d0b10930b9bc70 ; v0.12.0
 	https://github.com/Joe91/ESP-FTP-Server-Lib.git#517a2c90876659bfd6692d1f464784a05296e8d8 ; v1.0.1
-	https://github.com/FastLED/FastLED.git#20667c3a6413ed46a828f78ec95fb57e58d753f8 ; v3.10.3
+	https://github.com/FastLED/FastLED.git#448f6ee2e77fa22b856acc2794bca6c6811c905b ; post-3.10.5 FLEX_IO snapshot (2026-08-13)
 	https://github.com/ESP32Async/ESPAsyncWebServer.git#d6aa7daf0823a41966b1841826cff015237d6e42 ; v3.11.1
 	https://github.com/bblanchon/ArduinoJson.git#77771d3c07668e01d8f52acb03910c1110bb373f ; v7.4.3
 	https://github.com/pschatzmann/arduino-audio-tools.git#b4b32dc849233e1c51424221951c9f5c576671e5 ; v1.2.4

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -152,6 +152,34 @@ bool Led_LoadSettings(LedSettings &settings) {
 }
 #endif
 
+#ifdef NEOPIXEL_ENABLE
+	#ifdef LED_USE_FASTLED_FLEX_IO
+static fl::ChannelPtr ledChannel;
+	#endif
+
+static void Led_InitStrip(CRGB *leds, uint16_t count) {
+	#ifdef LED_USE_FASTLED_FLEX_IO
+	using ConfiguredChipset = CHIPSET<LED_PIN, COLOR_ORDER>;
+	static_assert(fl::is_same<ConfiguredChipset, WS2812B<LED_PIN, COLOR_ORDER>>::value,
+		"FastLED FLEX_IO needs an explicit timing mapping for the configured CHIPSET");
+
+	fl::ChannelOptions options;
+	options.mCorrection = TypicalSMD5050;
+	options.mDitherMode = DISABLE_DITHER;
+	options.mBus = fl::Bus::FLEX_IO;
+	options.mBusWhich = 0;
+	fl::ChannelConfigOf<fl::ClocklessChipset> config(
+		fl::makeClockless<fl::TIMING_WS2812_800KHZ>(LED_PIN),
+		fl::span<CRGB>(leds, count), COLOR_ORDER, options);
+	FastLED.setExclusiveDriver<fl::Bus::FLEX_IO, 0>();
+	ledChannel = fl::Channel::create(config);
+	FastLED.add(ledChannel);
+	#else
+	FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, count).setCorrection(TypicalSMD5050);
+	#endif
+}
+#endif
+
 void Led_Init(void) {
 #ifdef NEOPIXEL_ENABLE
 
@@ -403,7 +431,7 @@ static void Led_Task(void *parameter) {
 	leds = new CRGB[numIndicatorLeds + numControlLeds];
 	indicator = new CRGBSet(leds, numIndicatorLeds);
 	// initialize FastLED
-	FastLED.addLeds<CHIPSET, LED_PIN, COLOR_ORDER>(leds, numIndicatorLeds + numControlLeds).setCorrection(TypicalSMD5050);
+	Led_InitStrip(leds, numIndicatorLeds + numControlLeds);
 	FastLED.setBrightness(gLedSettings.Led_Brightness);
 	FastLED.setDither(DISABLE_DITHER);
 	FastLED.setMaxRefreshRate(200); // limit LED refresh rate to 200Hz (less likely to cause flickering)

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -182,6 +182,11 @@ static void Led_InitStrip(CRGB *leds, uint16_t count) {
 
 void Led_Init(void) {
 #ifdef NEOPIXEL_ENABLE
+	#if defined(CONFIG_IDF_TARGET_ESP32S3)
+	constexpr uint32_t ledTaskStackSize = 6144;
+	#else
+	constexpr uint32_t ledTaskStackSize = 3072;
+	#endif
 
 	if (Led_TaskHandle) {
 		// if led task is already running notify to reload settings
@@ -196,7 +201,7 @@ void Led_Init(void) {
 	xTaskCreatePinnedToCore(
 		Led_Task, /* Function to implement the task */
 		"Led_Task", /* Name of the task */
-		3072, /* Stack size in words */ // 20251015: increased to 3072 because saving of "allgemeine Einstellungen" let to restarts because of stack overflows
+		ledTaskStackSize, /* Stack size in bytes */
 		NULL, /* Task input parameter */
 		1, /* Priority of the task */
 		&Led_TaskHandle, /* Task handle. */

--- a/src/Led.h
+++ b/src/Led.h
@@ -69,9 +69,18 @@ struct AnimationReturnType {
 	#define LED_INITIAL_BRIGHTNESS		 16u
 	#define LED_INITIAL_NIGHT_BRIGHTNESS 2u
 
-	#define FASTLED_ESP32_USE_CLOCKLESS_SPI 1
-
+	#pragma push_macro("BUSY")
+	#undef BUSY
 	#include <FastLED.h>
+
+	#if defined(CONFIG_IDF_TARGET_ESP32)
+		#include <platforms/esp/32/drivers/i2s_spi/bus_traits.h>
+		#define LED_USE_FASTLED_FLEX_IO 1
+	#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+		#include <platforms/esp/32/drivers/lcd_spi/bus_traits.h>
+		#define LED_USE_FASTLED_FLEX_IO 1
+	#endif
+	#pragma pop_macro("BUSY")
 
 struct LedSettings {
 	uint8_t numIndicatorLeds = 24;

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -352,7 +352,7 @@ static void handleWiFiScanRequest(AsyncWebServerRequest *request) {
 			json += ",\"channel\":" + String(WiFi.channel(i));
 			json += ",\"secure\":" + String(WiFi.encryptionType(i));
 			json += ",\"quality\":" + String(quality); // WiFi strength in percent
-			json += ",\"wico\":\"w" + String(int(round(map(quality, 0, 100, 1, 4)))) + "\""; // WiFi strength icon ("w1"-"w4")
+			json += ",\"wico\":\"w" + String(int(std::round(map(quality, 0, 100, 1, 4)))) + "\""; // WiFi strength icon ("w1"-"w4")
 			json += ",\"pico\":\"" + String((WIFI_AUTH_OPEN == WiFi.encryptionType(i)) ? "" : "pw") + "\""; // auth icon ("p1" for secured)
 			json += "}";
 		}


### PR DESCRIPTION
## Summary

Replace the forced FastLED clockless-SPI LED backend with FastLED's explicit
FLEX_IO channel API.

The selected hardware backend depends on the ESP32 target:

- Classic ESP32 uses I2S1 with DMA.
- ESP32-S3 uses LCD_CAM with GDMA.
- Other targets retain the existing `FastLED.addLeds()` path.

FastLED is pinned to a specific post-3.10.5 revision containing the required
FLEX_IO support.

## Why

ESPuino currently forces `FASTLED_ESP32_USE_CLOCKLESS_SPI` for NeoPixel output.

That backend competes for an SPI peripheral. On configurations where the SPI
host is already used by the SD card, initializing or refreshing the LED strip
can time out and cause boot failures or resets.

Falling back to RMT is not a reliable solution on the current Arduino 3.x /
ESP-IDF 5.x stack:

- The legacy RMT driver conflicts with the new IDF RMT driver.
- The RMT5 path can fail during channel allocation or transmission setup,
  particularly on ESP32-S3.

FastLED's FLEX_IO API allows us to select peripherals intended for parallel
output without consuming the SD card's SPI host:

- I2S1 on classic ESP32
- LCD_CAM/GDMA on ESP32-S3

This also keeps LED output separate from ESPuino's normal audio path, which
uses I2S0.

## Approach

`Led_InitStrip()` now creates a FastLED clockless channel explicitly:

- `Bus::FLEX_IO`, instance 0
- WS2812 800 kHz timing
- Existing color order, correction, dithering, brightness, and animation
  behavior remain unchanged

The target-specific FastLED bus traits are enabled only for:

- `CONFIG_IDF_TARGET_ESP32`
- `CONFIG_IDF_TARGET_ESP32S3`

Unsupported targets continue using the existing `FastLED.addLeds()` call.

A compile-time assertion currently limits the FLEX_IO path to the configured
WS2812B chipset. This fails clearly rather than silently emitting incorrect
timing if a custom build selects another chipset.

## Classic ESP32 FastLED correction

The pinned FastLED revision's classic ESP32 I2S implementation required a
small transport correction found during hardware testing.

The PlatformIO pre-build hook applies an exact, fail-closed patch that:

- feeds native 16-bit parallel DMA samples
- configures `tx_bits_mod = 16`
- uses the 16-bit single-channel FIFO mode
- routes lanes through `DATA_OUT8..23`
- adds reset-low data before and after the WS2812 frame
- stops transmission at DMA EOF to prevent stale FIFO data from being replayed

The hook is idempotent and tied to the pinned FastLED source. If that source
changes and the expected code no longer matches, the build fails instead of
silently applying a partial patch.

## ESP32-S3 task stack

FastLED's LCD_CAM initialization uses more stack than the previous LED backend.
The existing 3072-byte LED task stack overflowed during the first
`FastLED.show()`, causing a boot loop before Wi-Fi startup.

The ESP32-S3 LED task therefore uses a 6144-byte stack. Classic ESP32 retains
the existing 3072-byte allocation.

## Compatibility

For standard classic ESP32/WROVER ESPuino configurations:

- LED output uses I2S1.
- Audio continues using I2S0.
- SPI SD continues using HSPI.
- SD_MMC configurations are independent of both.

Therefore this should work for WROVER users whether they use SPI SD, SD_MMC,
or no SD SPI bus at all.

A custom configuration that already reserves I2S1 for another peripheral may
conflict and would need separate consideration.

## Validation

Hardware:

- Classic ESP32/D32 with a 12-pixel WS2812 ring
  - verified correct colors and independent pixel output
  - verified the previous duplicated/corrupted pixel behavior is fixed
- ESP32-S3 N16R8 with a WS2812 ring on GPIO 21
  - verified LCD_CAM/GDMA backend initialization
  - verified stable startup without stack overflow
  - verified SD, Wi-Fi, HTTP, audio, and RFID startup

Builds:

- `pio run -e lolin_d32_pro`
- `pio run -e lolin_d32_pro_sdmmc_pe`
- local ESP32-S3 DevKitC N16R8 environment

The resulting maps confirm:

- classic ESP32 links `ChannelEngineI2sEsp32Dev`
- ESP32-S3 links `ChannelDriverLcdClockless`
- neither target links the previous NeoPixelBus experiment