### PR TITLE
Add reader-specific RFID settings (e.g. SLIC2 password)

### DIFF
--- a/html/locales/de.json
+++ b/html/locales/de.json
@@ -497,13 +497,16 @@
 				"description": "Wähle den Typ des RFID-Readers. Auto-detect wird versuchen, den Reader automatisch zu erkennen."
 			},
 			"pn5180Lpcd": "PN5180 LPCD aktivieren",
-			"pn5180LpcdExp": "Aktiviert Low Power Card Detection für PN5180 RFID-Reader. Nur möglich, wenn Lötbrücken richtig gesetzt sind.",
+			"pn5180LpcdExp": "Aktiviert Low Power Card Detection für PN5180 RFID-Reader. Dafür muss die PN5180-Firmware mindestens Version 4.0 sein und die erforderlichen Lötbrücken müssen korrekt gesetzt sein. Mehr Infos <a href='https://forum.espuino.de/t/was-ist-lpcd-und-wie-funktioniert-es/1664' target='_blank'>hier</a>.",
 			"mfrc522Gain": "MFRC522 Gain",
 			"mfrc522GainExp": "Stellt die Empfindlichkeit des MFRC522 RFID-Readers ein. Mögliche Werte sind 0 (niedrigste Empfindlichkeit) bis 7 (höchste Empfindlichkeit). Standard ist 7.",
 			"mfrc522ScanInterval": "MFRC522 Scan-Intervall",
 			"mfrc522ScanIntervalExp": "Zeit in Millisekunden zwischen zwei Abfragen des MFRC522 RFID-Readers. Ein Neustart ist nötig, damit eine Änderung wirksam wird. Standard ist 100ms.",
 			"pn5180Debounce": "PN5180 Debounce",
-			"pn5180DebounceExp": "Zeit in Millisekunden, die eine Karte ununterbrochen nicht erkannt werden muss, bevor sie als entfernt gilt. Verhindert, dass kurze Leseaussetzer (z.B. bei größerem Abstand zwischen Karte und Leser) fälschlich als Kartenentfernung gewertet werden. Ein Neustart ist nötig, damit eine Änderung wirksam wird. Standard ist 500ms."
+			"pn5180DebounceExp": "Zeit in Millisekunden, die eine Karte ununterbrochen nicht erkannt werden muss, bevor sie als entfernt gilt. Verhindert, dass kurze Leseaussetzer (z.B. bei größerem Abstand zwischen Karte und Leser) fälschlich als Kartenentfernung gewertet werden. Ein Neustart ist nötig, damit eine Änderung wirksam wird. Standard ist 500ms.",
+			"slixPrivacyPassword": "ICODE-SLIX2 Privacy-Passwort",
+			"slixPrivacyPasswordExp": "Vier-Byte-Passwort zum Deaktivieren des Privacy-Modus geschützter ICODE-SLIX2-Tags. Es sind ausschließlich Hexadezimalwerte von 00 bis FF zulässig.",
+			"pn5180Firmware": "Ausgelesene PN5180 Firmware"
 		},
 		"options": {
 			"title": "Optionen",

--- a/html/locales/en.json
+++ b/html/locales/en.json
@@ -497,13 +497,16 @@
 				"description": "Select the type of RFID reader connected to your ESPuino. Auto-detect will try to determine the connected reader type automatically."
 			},
 			"pn5180Lpcd": "Enable PN5180 LPCD",
-			"pn5180LpcdExp": "Enable Low Power Card Detection for PN5180 RFID reader. Only possible if solder-pins are set correctly.",
+			"pn5180LpcdExp": "Enables Low Power Card Detection for the PN5180 RFID reader. PN5180 firmware version 4.0 or newer is required, and the required solder bridges must be configured correctly. More information <a href='https://forum.espuino.de/t/was-ist-lpcd-und-wie-funktioniert-es/1664' target='_blank'>here</a>.",
 			"mfrc522Gain": "MFRC522 Gain",
 			"mfrc522GainExp": "Sets the sensitivity of the MFRC522 RFID reader. Possible values are 0 (lowest sensitivity) to 7 (highest sensitivity). Default is 7.",
 			"mfrc522ScanInterval": "MFRC522 scan interval",
 			"mfrc522ScanIntervalExp": "Time in milliseconds between two polls of the MFRC522 RFID reader. A restart is required for a change to take effect. Default is 100ms.",
 			"pn5180Debounce": "PN5180 debounce",
-			"pn5180DebounceExp": "Time in milliseconds a card must go undetected before it's considered removed. Prevents brief read dropouts (e.g. with a larger gap between card and reader) from being mistaken for card removal. A restart is required for a change to take effect. Default is 500ms."
+			"pn5180DebounceExp": "Time in milliseconds a card must go undetected before it's considered removed. Prevents brief read dropouts (e.g. with a larger gap between card and reader) from being mistaken for card removal. A restart is required for a change to take effect. Default is 500ms.",
+			"slixPrivacyPassword": "ICODE-SLIX2 privacy password",
+			"slixPrivacyPasswordExp": "Four-byte password used to disable privacy mode on protected ICODE-SLIX2 tags. Only hexadecimal values from 00 to FF are accepted.",
+			"pn5180Firmware": "PN5180 firmware readout"
 		},
 		"options": {
 			"title": "Options",

--- a/html/locales/fr.json
+++ b/html/locales/fr.json
@@ -497,13 +497,16 @@
 				"description": "Sélectionnez le type de lecteur RFID connecté à votre ESPuino. La détection automatique tentera de déterminer le type de lecteur connecté automatiquement."
 			},
 			"pn5180Lpcd": "Activer PN5180 LPCD",
-			"pn5180LpcdExp": "Active la détection de carte à faible puissance pour le lecteur RFID PN5180. Uniquement possible si les broches de soudure sont correctement configurées.",
+			"pn5180LpcdExp": "Active la détection de carte à faible puissance pour le lecteur RFID PN5180. Le firmware du PN5180 doit être en version 4.0 ou plus récente et les ponts de soudure nécessaires doivent être configurés correctement. Plus d’informations <a href='https://forum.espuino.de/t/was-ist-lpcd-und-wie-funktioniert-es/1664' target='_blank'>ici</a>.",
 			"mfrc522Gain": "MFRC522 Gain",
 			"mfrc522GainExp": "Définit la sensibilité du lecteur RFID MFRC522. Les valeurs possibles sont de 0 (sensibilité la plus faible) à 7 (sensibilité la plus élevée). La valeur par défaut est 7.",
 			"mfrc522ScanInterval": "Intervalle de scan MFRC522",
 			"mfrc522ScanIntervalExp": "Durée en millisecondes entre deux interrogations du lecteur RFID MFRC522. Un redémarrage est nécessaire pour qu'une modification prenne effet. La valeur par défaut est 100ms.",
 			"pn5180Debounce": "Anti-rebond PN5180",
-			"pn5180DebounceExp": "Durée en millisecondes pendant laquelle une carte doit rester non détectée avant d'être considérée comme retirée. Évite que de brèves pertes de lecture (par ex. avec un écart plus important entre la carte et le lecteur) soient interprétées à tort comme un retrait de carte. Un redémarrage est nécessaire pour qu'une modification prenne effet. La valeur par défaut est 500ms."
+			"pn5180DebounceExp": "Durée en millisecondes pendant laquelle une carte doit rester non détectée avant d'être considérée comme retirée. Évite que de brèves pertes de lecture (par ex. avec un écart plus important entre la carte et le lecteur) soient interprétées à tort comme un retrait de carte. Un redémarrage est nécessaire pour qu'une modification prenne effet. La valeur par défaut est 500ms.",
+			"slixPrivacyPassword": "Mot de passe de confidentialité ICODE-SLIX2",
+			"slixPrivacyPasswordExp": "Mot de passe de quatre octets utilisé pour désactiver le mode confidentialité des tags ICODE-SLIX2 protégés. Seules les valeurs hexadécimales de 00 à FF sont acceptées.",
+			"pn5180Firmware": "Firmware PN5180 lue"
 		},
 		"options": {
 			"title": "Options",

--- a/html/management.html
+++ b/html/management.html
@@ -1683,68 +1683,101 @@
 						<fieldset>
 							<legend class="w-auto" data-i18n="general.rfid.title"></legend><br>
 							<div class="settings-group-card">
-							<div class="d-flex gap-2">
-								<input type="checkbox" id="pn5180Lpcd" name="pn5180Lpcd" value="false">
-								<label for="pn5180Lpcd" data-i18n="general.rfid.pn5180Lpcd"></label>
-								<a href="#" class="link-secondary" data-bs-toggle="popover"
-									data-i18n="[data-bs-content]general.rfid.pn5180LpcdExp" tabindex="0"><i
-										class="fas fa-circle-question"></i></a>
-							</div>
-							<div class="row mb-2 align-items-center">
-								<label for="rfidReaderType" class="col-sm-4 col-form-label"
-									data-i18n="general.rfid.readerType.title"></label>
-								<div class="col-sm-8">
-									<select class="form-control form-select" id="rfidReaderType" name="rfidReaderType">
-										<option value="0" data-i18n="general.rfid.readerType.auto">Auto-detect</option>
-										<option value="1" data-i18n="general.rfid.readerType.mfrc522_spi">MFRC522 (SPI)</option>
-										<option value="2" data-i18n="general.rfid.readerType.mfrc522_i2c">MFRC522 (I2C)</option>
-										<option value="3" data-i18n="general.rfid.readerType.pn5180">PN5180</option>
-									</select>
-								</div>
-								<div class="col-sm-8 offset-sm-4">
-									<small class="form-text text-muted" data-i18n="general.rfid.readerType.description"></small>
+								<div class="row mb-2 align-items-center">
+									<label for="rfidReaderType" class="col-sm-4 col-form-label"
+										data-i18n="general.rfid.readerType.title"></label>
+									<div class="col-sm-8">
+										<select class="form-control form-select" id="rfidReaderType" name="rfidReaderType">
+											<option value="0" data-i18n="general.rfid.readerType.auto">Auto-detect</option>
+											<option value="1" data-i18n="general.rfid.readerType.mfrc522_spi">MFRC522 (SPI)</option>
+											<option value="2" data-i18n="general.rfid.readerType.mfrc522_i2c">MFRC522 (I2C)</option>
+											<option value="3" data-i18n="general.rfid.readerType.pn5180">PN5180</option>
+										</select>
+									</div>
+									<div class="col-sm-8 offset-sm-4">
+										<small class="form-text text-muted" data-i18n="general.rfid.readerType.description"></small>
+									</div>
 								</div>
 							</div>
-							<div class="row mb-2 align-items-center">
-								<div class="col-sm-4 d-flex align-items-center gap-2">
-									<label for="mfrc522Gain" class="col-form-label"
-										data-i18n="general.rfid.mfrc522Gain"></label>
-									<a href="#" class="link-secondary" data-bs-toggle="popover"
-										data-i18n="[data-bs-content]general.rfid.mfrc522GainExp" tabindex="0">
-										<i class="fas fa-circle-question"></i></a>
+
+							<div class="settings-group-card mt-3" id="mfrc522Settings" style="display:none">
+								<h5 class="mb-3">MFRC522</h5>
+								<div class="row mb-2 align-items-center">
+									<div class="col-sm-4 d-flex align-items-center gap-2">
+										<label for="mfrc522Gain" class="col-form-label"
+											data-i18n="general.rfid.mfrc522Gain"></label>
+										<a href="#" class="link-secondary" data-bs-toggle="popover"
+											data-i18n="[data-bs-content]general.rfid.mfrc522GainExp" tabindex="0">
+											<i class="fas fa-circle-question"></i></a>
+									</div>
+									<div class="col-sm-8">
+										<input type="number" class="form-control" id="mfrc522Gain" name="mfrc522Gain" min="0" max="7">
+									</div>
 								</div>
-								<div class="col-sm-8">
-									<input type="number" class="form-control" id="mfrc522Gain" name="mfrc522Gain"
-										min="0" max="7">
-								</div>
-							</div>
-							<div class="row mb-2 align-items-center">
-								<div class="col-sm-4 d-flex align-items-center gap-2">
-									<label for="mfrc522ScanInterval" class="col-form-label"
-										data-i18n="general.rfid.mfrc522ScanInterval"></label>
-									<a href="#" class="link-secondary" data-bs-toggle="popover"
-										data-i18n="[data-bs-content]general.rfid.mfrc522ScanIntervalExp" tabindex="0">
-										<i class="fas fa-circle-question"></i></a>
-								</div>
-								<div class="col-sm-8">
-									<input type="number" class="form-control" id="mfrc522ScanInterval"
-										name="mfrc522ScanInterval" min="20" max="2000" step="10">
-								</div>
-							</div>
-							<div class="row mb-2 align-items-center">
-								<div class="col-sm-4 d-flex align-items-center gap-2">
-									<label for="pn5180Debounce" class="col-form-label"
-										data-i18n="general.rfid.pn5180Debounce"></label>
-									<a href="#" class="link-secondary" data-bs-toggle="popover"
-										data-i18n="[data-bs-content]general.rfid.pn5180DebounceExp" tabindex="0">
-										<i class="fas fa-circle-question"></i></a>
-								</div>
-								<div class="col-sm-8">
-									<input type="number" class="form-control" id="pn5180Debounce" name="pn5180Debounce"
-										min="0" max="2000" step="10">
+								<div class="row mb-2 align-items-center">
+									<div class="col-sm-4 d-flex align-items-center gap-2">
+										<label for="mfrc522ScanInterval" class="col-form-label"
+											data-i18n="general.rfid.mfrc522ScanInterval"></label>
+										<a href="#" class="link-secondary" data-bs-toggle="popover"
+											data-i18n="[data-bs-content]general.rfid.mfrc522ScanIntervalExp" tabindex="0">
+											<i class="fas fa-circle-question"></i></a>
+									</div>
+									<div class="col-sm-8">
+										<input type="number" class="form-control" id="mfrc522ScanInterval"
+											name="mfrc522ScanInterval" min="20" max="2000" step="10">
+									</div>
 								</div>
 							</div>
-						</div>
+
+							<div class="settings-group-card mt-3" id="pn5180Settings" style="display:none">
+								<h5 class="mb-3">PN5180</h5>
+								<div class="row mb-2 align-items-center">
+									<div class="col-sm-4 col-form-label" data-i18n="general.rfid.pn5180Firmware"></div>
+									<div class="col-sm-8">
+										<div class="form-control-plaintext" id="pn5180FirmwareValue">—</div>
+									</div>
+								</div>
+								<div class="row mb-2 align-items-center">
+									<div class="col-sm-4 d-flex align-items-center gap-2">
+										<label for="pn5180Lpcd" class="col-form-label" data-i18n="general.rfid.pn5180Lpcd"></label>
+										<a href="#" class="link-secondary" data-bs-toggle="popover"
+											data-i18n="[data-bs-content]general.rfid.pn5180LpcdExp" tabindex="0"><i
+												class="fas fa-circle-question"></i></a>
+									</div>
+									<div class="col-sm-8">
+										<input type="checkbox" id="pn5180Lpcd" name="pn5180Lpcd" value="false">
+									</div>
+								</div>
+								<div class="row mb-2 align-items-center">
+									<div class="col-sm-4 d-flex align-items-center gap-2">
+										<label for="pn5180Debounce" class="col-form-label"
+											data-i18n="general.rfid.pn5180Debounce"></label>
+										<a href="#" class="link-secondary" data-bs-toggle="popover"
+											data-i18n="[data-bs-content]general.rfid.pn5180DebounceExp" tabindex="0">
+											<i class="fas fa-circle-question"></i></a>
+									</div>
+									<div class="col-sm-8">
+										<input type="number" class="form-control" id="pn5180Debounce" name="pn5180Debounce"
+											min="0" max="2000" step="10">
+									</div>
+								</div>
+								<div class="row mb-2 align-items-start">
+									<div class="col-sm-4 d-flex align-items-center gap-2">
+										<label for="slixPrivacyPassword0" class="col-form-label" data-i18n="general.rfid.slixPrivacyPassword"></label>
+										<a href="#" class="link-secondary" data-bs-toggle="popover"
+											data-i18n="[data-bs-content]general.rfid.slixPrivacyPasswordExp" tabindex="0">
+											<i class="fas fa-circle-question"></i></a>
+									</div>
+									<div class="col-sm-8">
+										<div class="row g-2">
+											<div class="col-3"><input type="text" class="form-control slix-password-byte text-uppercase" id="slixPrivacyPassword0" maxlength="2" pattern="[0-9A-Fa-f]{2}" autocomplete="off" spellcheck="false"></div>
+											<div class="col-3"><input type="text" class="form-control slix-password-byte text-uppercase" id="slixPrivacyPassword1" maxlength="2" pattern="[0-9A-Fa-f]{2}" autocomplete="off" spellcheck="false"></div>
+											<div class="col-3"><input type="text" class="form-control slix-password-byte text-uppercase" id="slixPrivacyPassword2" maxlength="2" pattern="[0-9A-Fa-f]{2}" autocomplete="off" spellcheck="false"></div>
+											<div class="col-3"><input type="text" class="form-control slix-password-byte text-uppercase" id="slixPrivacyPassword3" maxlength="2" pattern="[0-9A-Fa-f]{2}" autocomplete="off" spellcheck="false"></div>
+										</div>
+									</div>
+								</div>
+							</div>
 						</fieldset>
 					</div>
 					<div>
@@ -2569,6 +2602,10 @@
 			$($(e.target).attr('href')).find('[data-provide="slider"]').each(function () {
 				$(this).bootstrapSlider('relayout');
 			});
+			if ($(e.target).attr('id') === 'general-rfidreader-tab') {
+				// Refresh only the RAM-cached PN5180 firmware value. This request never touches SPI.
+				updatePn5180FirmwareInfo();
+			}
 		});
 		if (host == "") { // Not running on the device -> use the remote host
 			host = remoteHost;
@@ -4077,6 +4114,59 @@
 			});
 		}
 
+		function normalizeSlixPasswordByte(value) {
+			const clean = String(value == null ? '' : value).toUpperCase().replace(/[^0-9A-F]/g, '').slice(0, 2);
+			return ('00' + clean).slice(-2);
+		}
+
+		function setSlixPrivacyPassword(value) {
+			let password = String(value == null ? '' : value).toUpperCase().replace(/[^0-9A-F]/g, '');
+			while (password.length < 8) password += '0';
+			password = password.slice(0, 8);
+			for (let i = 0; i < 4; i++) {
+				$('#slixPrivacyPassword' + i).val(password.slice(i * 2, i * 2 + 2));
+			}
+		}
+
+		function getSlixPrivacyPassword() {
+			let password = '';
+			for (let i = 0; i < 4; i++) {
+				const input = $('#slixPrivacyPassword' + i);
+				const value = normalizeSlixPasswordByte(input.val());
+				input.val(value);
+				password += value;
+			}
+			return password;
+		}
+
+		async function updatePn5180FirmwareInfo() {
+			const firmwareValue = $('#pn5180FirmwareValue');
+			try {
+				const response = await fetch("http://" + host + "/settings?section=rfidstatus");
+				if (!response.ok) throw new Error(response.statusText);
+				const data = await response.json();
+				const firmware = data.rfidStatus && data.rfidStatus.pn5180Firmware;
+				firmwareValue.text(firmware || '—');
+			} catch (err) {
+				firmwareValue.text('—');
+			}
+		}
+
+		function updateRfidReaderSettings() {
+			const readerType = Number($('#rfidReaderType').val());
+			const isAutoDetect = readerType === 0;
+			const isMfrc522 = readerType === 1 || readerType === 2;
+			const isPn5180 = readerType === 3;
+
+			$('#mfrc522Settings').toggle(isAutoDetect || isMfrc522);
+			$('#pn5180Settings').toggle(isAutoDetect || isPn5180);
+
+			// LPCD only applies to PN5180.
+			if (isMfrc522) {
+				$('#pn5180Lpcd').prop('checked', false);
+			}
+		}
+
 		async function fillSettings(settings) {
 			if (!settings) {
 				return false;
@@ -4111,10 +4201,11 @@
 				$('#volumeCurve').prop('checked', genSettings.volumeCurve > 0);
 				$('#rfidReaderType').val(genSettings.rfidReaderType);
 				$('#pn5180Lpcd').prop('checked', genSettings.pn5180Lpcd);
-				$('#pn5180Lpcd').prop('disabled', genSettings.rfidReaderType == 1 || genSettings.rfidReaderType == 2);
 				$('#mfrc522Gain').val(genSettings.mfrc522Gain);
 				$('#mfrc522ScanInterval').val(genSettings.mfrc522ScanInterval);
 				$('#pn5180Debounce').val(genSettings.pn5180Debounce);
+				setSlixPrivacyPassword(genSettings.slixPrivacyPassword);
+				updateRfidReaderSettings();
 			}
 			// current values
 			let currSettings = settings.current;
@@ -4599,7 +4690,8 @@
 					pn5180Lpcd: $('#pn5180Lpcd').prop('checked'),
 					mfrc522Gain: Number($('#mfrc522Gain').val()),
 					mfrc522ScanInterval: Number($('#mfrc522ScanInterval').val()),
-					pn5180Debounce: Number($('#pn5180Debounce').val())
+					pn5180Debounce: Number($('#pn5180Debounce').val()),
+					slixPrivacyPassword: getSlixPrivacyPassword()
 				},
 				"led": {
 					initBrightness: Number($('#initBrightness').val()),
@@ -5320,14 +5412,14 @@
 				}
 			});
 
-			/* PN5180 LPCD only applies to the PN5180 reader - disable it (and clear it) for MFRC522. */
-			$('#rfidReaderType').on('change', function () {
-				const pn5180Lpcd = $('#pn5180Lpcd');
-				if (this.value === '1' || this.value === '2') {
-					pn5180Lpcd.prop('checked', false).prop('disabled', true);
-				} else {
-					pn5180Lpcd.prop('disabled', false);
-				}
+			/* Show only the settings that belong to the selected RFID reader. */
+			$('#rfidReaderType').on('change', updateRfidReaderSettings);
+
+			/* ICODE-SLIX2 privacy password: four bytes, hexadecimal only. */
+			$('.slix-password-byte').on('input', function () {
+				this.value = String(this.value).toUpperCase().replace(/[^0-9A-F]/g, '').slice(0, 2);
+			}).on('blur', function () {
+				this.value = normalizeSlixPasswordByte(this.value);
 			});
 
 			/* Enable/disable "resumeOnSameRfid" depending on dontAcceptRfidTwice. */

--- a/src/RfidPn5180.cpp
+++ b/src/RfidPn5180.cpp
@@ -1,6 +1,8 @@
 #include <Arduino.h>
 #include "settings.h"
 
+#include "RfidPn5180.h"
+
 #include "AudioPlayer.h"
 #include "HallEffectSensor.h"
 #include "Log.h"
@@ -12,6 +14,7 @@
 
 #include <SPI.h>
 #include <Wire.h>
+#include <atomic>
 #include <driver/gpio.h>
 #include <esp_task_wdt.h>
 #include <freertos/task.h>
@@ -53,6 +56,42 @@ extern TaskHandle_t rfidTaskHandle;
 #if (defined(PORT_EXPANDER_ENABLE) && (RFID_IRQ > 99))
 extern TwoWire i2cBusTwo;
 #endif
+
+namespace {
+uint32_t PackSlixPrivacyPassword(const SlixPrivacyPassword &password) {
+	return (static_cast<uint32_t>(password[0]) << 24) | (static_cast<uint32_t>(password[1]) << 16) | (static_cast<uint32_t>(password[2]) << 8) | password[3];
+}
+
+SlixPrivacyPassword UnpackSlixPrivacyPassword(uint32_t password) {
+	return {
+		{static_cast<uint8_t>(password >> 24), static_cast<uint8_t>(password >> 16), static_cast<uint8_t>(password >> 8),
+			static_cast<uint8_t>(password)}
+	   };
+}
+
+std::atomic<uint32_t> slixPrivacyPassword {PackSlixPrivacyPassword(SLIX_PRIVACY_PASSWORD_DEFAULT)};
+
+// Stored as major << 8 | minor. This value is RAM-only and is never written to NVS.
+std::atomic<uint16_t> pn5180FirmwareVersion {0};
+} // namespace
+
+SlixPrivacyPassword RfidPn5180_GetSlixPrivacyPassword(void) {
+	return UnpackSlixPrivacyPassword(slixPrivacyPassword.load(std::memory_order_relaxed));
+}
+
+void RfidPn5180_SetSlixPrivacyPassword(const SlixPrivacyPassword &password) {
+	slixPrivacyPassword.store(PackSlixPrivacyPassword(password), std::memory_order_relaxed);
+}
+
+bool RfidPn5180_GetFirmwareVersion(uint8_t &major, uint8_t &minor) {
+	const uint16_t version = pn5180FirmwareVersion.load(std::memory_order_relaxed);
+	if (version == 0) {
+		return false;
+	}
+	major = static_cast<uint8_t>(version >> 8);
+	minor = static_cast<uint8_t>(version & 0xFF);
+	return true;
+}
 
 #if defined(RFID_READER_TYPE_RUNTIME)
 static void RfidPn5180_Task(void *parameter);
@@ -205,6 +244,11 @@ void RfidPn5180_Task(void *parameter) {
 	uint32_t lastTimeDetected14443 = 0;
 	uint32_t lastTimeDetected15693 = 0;
 	const uint16_t debounceMs = gPrefsRfid.getUShort("pn5180Debounce", 500);
+	SlixPrivacyPassword configuredSlixPrivacyPassword = SLIX_PRIVACY_PASSWORD_DEFAULT;
+	if (gPrefsRfid.getBytesLength(SLIX_PRIVACY_PASSWORD_NVS_KEY) == configuredSlixPrivacyPassword.size()) {
+		gPrefsRfid.getBytes(SLIX_PRIVACY_PASSWORD_NVS_KEY, configuredSlixPrivacyPassword.data(), configuredSlixPrivacyPassword.size());
+	}
+	RfidPn5180_SetSlixPrivacyPassword(configuredSlixPrivacyPassword);
 	byte lastValidcardId[cardIdSize] = {0}; // "same card reapplied" is decided by comparing against it
 	bool cardAppliedCurrentRun = false;
 	bool cardAppliedLastRun = false;
@@ -247,10 +291,13 @@ void RfidPn5180_Task(void *parameter) {
 			// genuinely unresponsive instead of stalling the polling loop for half a second.
 			nfc14443.commandTimeout = 100;
 			nfc15693.commandTimeout = 100;
-			// show PN5180 reader version
-			// uint8_t firmwareVersion[2];
-			// nfc14443.readEEprom(FIRMWARE_VERSION, firmwareVersion, sizeof(firmwareVersion));
-			// Log_Printf(LOGLEVEL_DEBUG, "PN5180 firmware version=%d.%d", firmwareVersion[1], firmwareVersion[0]);
+			// Read the PN5180 firmware once during normal reader initialization and keep it in RAM
+			// for the management UI. This code only runs in the PN5180 task.
+			uint8_t firmwareVersion[2] = {0, 0};
+			if (nfc14443.readEEprom(FIRMWARE_VERSION, firmwareVersion, sizeof(firmwareVersion))) {
+				pn5180FirmwareVersion.store((static_cast<uint16_t>(firmwareVersion[1]) << 8) | firmwareVersion[0], std::memory_order_relaxed);
+				Log_Printf(LOGLEVEL_DEBUG, "PN5180 firmware version=%d.%d", firmwareVersion[1], firmwareVersion[0]);
+			}
 
 			// activate RF field
 			delay(4u);
@@ -325,14 +372,10 @@ void RfidPn5180_Task(void *parameter) {
 		} else if (RFID_PN5180_NFC15693_STATE_SETUPRF == stateMachine) {
 			nfc15693.setupRF();
 		} else if (RFID_PN5180_NFC15693_STATE_DISABLEPRIVACYMODE == stateMachine) {
-			// check for ICODE-SLIX2 password protected tag
-			// put your privacy password here, e.g.:
-			// https://de.ifixit.com/Antworten/Ansehen/513422/nfc+Chips+f%C3%BCr+tonies+kaufen
-			//
-			// default factory password for ICODE-SLIX2 is {0x0F, 0x0F, 0x0F, 0x0F}
-			//
-			const uint8_t password[] = {0x0F, 0x0F, 0x0F, 0x0F};
-			ISO15693ErrorCode myrc = nfc15693.disablePrivacyMode(password);
+			// Check for an ICODE-SLIX2 password protected tag using the currently configured
+			// password. Take a snapshot so a password saved via the web UI is used immediately.
+			const SlixPrivacyPassword currentSlixPrivacyPassword = RfidPn5180_GetSlixPrivacyPassword();
+			ISO15693ErrorCode myrc = nfc15693.disablePrivacyMode(currentSlixPrivacyPassword.data());
 			if (ISO15693_EC_OK == myrc) {
 				if (showDisablePrivacyNotification) {
 					showDisablePrivacyNotification = false;

--- a/src/RfidPn5180.h
+++ b/src/RfidPn5180.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <array>
+#include <stdint.h>
+
+using SlixPrivacyPassword = std::array<uint8_t, 4>;
+
+// ICODE-SLIX2 privacy password defaults / storage key.
+// Keep these here so PN5180 runtime and web settings use the same values.
+static constexpr char SLIX_PRIVACY_PASSWORD_NVS_KEY[] = "slixPwd";
+static constexpr SlixPrivacyPassword SLIX_PRIVACY_PASSWORD_DEFAULT = {
+	{0x0F, 0x0F, 0x0F, 0x0F}
+};
+
+// Get/set the password currently used by the PN5180 task. The value is RAM-only;
+// persistence remains handled by the RFID preferences in Web.cpp.
+SlixPrivacyPassword RfidPn5180_GetSlixPrivacyPassword(void);
+void RfidPn5180_SetSlixPrivacyPassword(const SlixPrivacyPassword &password);
+
+// Returns the PN5180 firmware version cached in RAM during PN5180 initialization.
+// No hardware access is performed here; false means no version has been read yet.
+bool RfidPn5180_GetFirmwareVersion(uint8_t &major, uint8_t &minor);

--- a/src/Web.cpp
+++ b/src/Web.cpp
@@ -21,6 +21,7 @@
 #include "MemX.h"
 #include "Mqtt.h"
 #include "Rfid.h"
+#include "RfidPn5180.h"
 #include "RotaryEncoder.h"
 #include "SdCard.h"
 #include "System.h"
@@ -113,6 +114,20 @@ static void onWebsocketEvent(AsyncWebSocket *server, AsyncWebSocketClient *clien
 static void settingsToJSON(JsonObject obj, const String section);
 static WebsocketCodeType JSONToSettings(JsonObject obj);
 static void webserverStart(void);
+
+static String slixPrivacyPasswordToHex(const SlixPrivacyPassword &password) {
+	char hex[9];
+	snprintf(hex, sizeof(hex), "%02X%02X%02X%02X", password[0], password[1], password[2], password[3]);
+	return String(hex);
+}
+
+static SlixPrivacyPassword slixPrivacyPasswordFromPrefs(void) {
+	SlixPrivacyPassword password = SLIX_PRIVACY_PASSWORD_DEFAULT;
+	if (gPrefsRfid.getBytesLength(SLIX_PRIVACY_PASSWORD_NVS_KEY) == password.size()) {
+		gPrefsRfid.getBytes(SLIX_PRIVACY_PASSWORD_NVS_KEY, password.data(), password.size());
+	}
+	return password;
+}
 
 // IPAddress converters, for a description see: https://arduinojson.org/news/2021/05/04/version-6-18-0/
 void convertFromJson(JsonVariantConst src, IPAddress &dst) {
@@ -781,6 +796,45 @@ WebsocketCodeType JSONToSettings(JsonObject doc) {
 		success = success && (gPrefsRfid.putUChar("mfrc522Gain", generalObj["mfrc522Gain"].as<uint8_t>()) != 0);
 		success = success && (gPrefsRfid.putUShort("rfidScanIntv", generalObj["mfrc522ScanInterval"].as<uint16_t>()) != 0);
 		success = success && (gPrefsRfid.putUShort("pn5180Debounce", generalObj["pn5180Debounce"].as<uint16_t>()) != 0);
+
+		// Keep compatibility with older cached management pages: if the field is missing,
+		// preserve the password already stored in NVS instead of overwriting it.
+		String slixPrivacyPassword = generalObj["slixPrivacyPassword"].as<String>();
+		if (slixPrivacyPassword.length() > 0) {
+			SlixPrivacyPassword slixPassword = {};
+			bool validPassword = (slixPrivacyPassword.length() == slixPassword.size() * 2);
+			for (size_t i = 0; validPassword && i < slixPassword.size(); i++) {
+				auto hexNibble = [](char c) -> int8_t {
+					if ((c >= '0') && (c <= '9')) {
+						return c - '0';
+					}
+					if ((c >= 'A') && (c <= 'F')) {
+						return c - 'A' + 10;
+					}
+					if ((c >= 'a') && (c <= 'f')) {
+						return c - 'a' + 10;
+					}
+					return -1;
+				};
+				const int8_t high = hexNibble(slixPrivacyPassword[i * 2]);
+				const int8_t low = hexNibble(slixPrivacyPassword[i * 2 + 1]);
+				if ((high < 0) || (low < 0)) {
+					validPassword = false;
+				} else {
+					slixPassword[i] = static_cast<uint8_t>((high << 4) | low);
+				}
+			}
+			if (validPassword) {
+				const bool passwordStored = success && (gPrefsRfid.putBytes(SLIX_PRIVACY_PASSWORD_NVS_KEY, slixPassword.data(), slixPassword.size()) == slixPassword.size());
+				success = passwordStored;
+				if (passwordStored) {
+					RfidPn5180_SetSlixPrivacyPassword(slixPassword);
+				}
+			} else {
+				success = false;
+				Log_Println("Invalid ICODE-SLIX2 privacy password in web settings", LOGLEVEL_ERROR);
+			}
+		}
 		if (!success) {
 			Log_Printf(LOGLEVEL_ERROR, webSaveSettingsError, "general");
 			return WebsocketCodeType::Error;
@@ -1173,9 +1227,24 @@ static void settingsToJSON(JsonObject obj, const String section) {
 		generalObj["mfrc522Gain"].set(gPrefsRfid.getUChar("mfrc522Gain", 7)); // MFRC522_GAIN
 		generalObj["mfrc522ScanInterval"].set(gPrefsRfid.getUShort("rfidScanIntv", 100)); // RFID_SCAN_INTERVAL
 		generalObj["pn5180Debounce"].set(gPrefsRfid.getUShort("pn5180Debounce", 500)); // PN5180 debounce (ms)
+
+		const String slixPasswordHex = slixPrivacyPasswordToHex(slixPrivacyPasswordFromPrefs());
+		generalObj["slixPrivacyPassword"].set(slixPasswordHex);
 		generalObj["pauseOnMinVol"].set(gPrefsSettings.getBool("pauseOnMinVol", false)); // PAUSE_ON_MIN_VOLUME
 		generalObj["recoverVolBoot"].set(gPrefsSettings.getBool("recoverVolBoot", false)); // USE_LAST_VOLUME_AFTER_REBOOT
 		generalObj["volumeCurve"].set(gPrefsSettings.getUChar("volumeCurve", 0)); // VOLUMECURVE
+	}
+	if (section == "rfidstatus") {
+		JsonObject rfidStatusObj = obj["rfidStatus"].to<JsonObject>();
+		uint8_t firmwareMajor = 0;
+		uint8_t firmwareMinor = 0;
+		if (RfidPn5180_GetFirmwareVersion(firmwareMajor, firmwareMinor)) {
+			char firmwareVersion[8];
+			snprintf(firmwareVersion, sizeof(firmwareVersion), "%u.%u", firmwareMajor, firmwareMinor);
+			rfidStatusObj["pn5180Firmware"].set(firmwareVersion);
+		} else {
+			rfidStatusObj["pn5180Firmware"].set("");
+		}
 	}
 	if ((section == "") || (section == "equalizer")) {
 		// equalizer settings
@@ -1335,6 +1404,7 @@ static void settingsToJSON(JsonObject obj, const String section) {
 		genSettings["mfrc522Gain"].set(7u); // MFRC522_GAIN default (max gain)
 		genSettings["mfrc522ScanInterval"].set(100u); // RFID_SCAN_INTERVAL default
 		genSettings["pn5180Debounce"].set(500u); // PN5180 debounce (ms) default
+		genSettings["slixPrivacyPassword"].set(slixPrivacyPasswordToHex(SLIX_PRIVACY_PASSWORD_DEFAULT));
 		JsonObject eqSettings = defaultsObj["equalizer"].to<JsonObject>();
 		eqSettings["gainHighPass"].set(0);
 		eqSettings["gainBandPass"].set(0);


### PR DESCRIPTION
This PR improves the RFID reader settings in the management interface.

Changes:
- Group reader-specific settings by RFID reader type
- Show both reader-specific sections when Auto-detect is selected
- Add configurable ICODE-SLIX2 privacy password for PN5180
- Restrict password input to four hexadecimal bytes
- Use 0F 0F 0F 0F as the default SLIX2 privacy password
- Display the PN5180 firmware version read from the reader
- Add LPCD help text with a link to the ESPuino forum
- Keep the existing LPCD firmware requirement (>= 4.0) unchanged
- When Auto-detect is selected, both reader-specific option sections are shown


 **LPCD help text with a link to the ESPuino forum**
<img width="407" height="285" alt="LPCD Hinweis" src="https://github.com/user-attachments/assets/3ce2d5ac-b484-4b28-8db0-bd6a11e87cbd" />

**MRFC522**
<img width="1457" height="704" alt="MRFC522" src="https://github.com/user-attachments/assets/3698cea6-b44a-49ab-bf25-5a628aa9049d" />

**PN5180**
<img width="1454" height="769" alt="pn5180" src="https://github.com/user-attachments/assets/4b65594a-1aba-4204-960f-c06f24dff76a" />
